### PR TITLE
Add test that fails in Grisu when using C backend.

### DIFF
--- a/m3-sys/m3tests/src/m3makefile
+++ b/m3-sys/m3tests/src/m3makefile
@@ -818,6 +818,9 @@ p_test ("p2", "p264", "mixtures of fixed and open arrays")
 % grisu-based test, loophole integers/floats, multiply longint within function parameters
 p_test ("p2", "p265", "grisu-based")
 
+% This fails in Grisu when using C backend.
+p_test ("p2", "p268", "grisuc")
+
 %------------------------------------------------------------------- rtests ---
 %  RUNTIME tests: modules containing runtime error where the generated
 %    error messages are of interest.

--- a/m3-sys/m3tests/src/p2/p268/Main.m3
+++ b/m3-sys/m3tests/src/p2/p268/Main.m3
@@ -1,0 +1,13 @@
+(* Grisu vs. C backend *)
+
+MODULE Main;
+IMPORT Fmt;
+
+PROCEDURE Test() =
+BEGIN
+  EVAL Fmt.LongReal(0.047218084335327148D0);
+END Test;
+
+BEGIN
+ Test();
+END Main.

--- a/m3-sys/m3tests/src/p2/p268/m3makefile
+++ b/m3-sys/m3tests/src/p2/p268/m3makefile
@@ -1,0 +1,2 @@
+implementation ("Main")
+include ("../../Test.common") 


### PR DESCRIPTION
Bug is not yet understood/fixed, but it works for gcc backend at least (and integrated?)
This is derived from m3-comm/sharedobjgen.