### PR TITLE
Fix AMD64_NT exception handling.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -1930,7 +1930,13 @@ CONST Prefix = ARRAY OF TEXT {
 "#include <stddef.h>", (* try to remove this, it is slow -- need size_t *)
 "#endif",
 
-(* "#include <setjmp.h>", TODO do not always #include *)
+(* setjmp and maybe jmp_buf, longjmp must be properly declared.
+For example Visual C++ has an intrinsic setjmp with a
+compiler-produced second parameter that is only passed
+if you include setjmp.h, and without it, longjmp crashes.
+In future, only include in files that need it, or replace
+exception handling with optimized C++ *)
+"#include <setjmp.h>",
 
 "/* http://c.knowcoding.com/view/23699-portable-alloca.html */",
 "/* Find a good version of alloca. */",


### PR DESCRIPTION
There are special things in the setjmp (and longjmp?) declaration,
best duplicated by actually including setjmp.h.

A later change will only include setjmp.h in files that
call setjmp, or longjmp, or maybe that declare local jmp_buf.
i.e. to not slow down compilation as much.