### PR TITLE
caltech-other/newuoa/m3makefile: Move library() to within if amd64_linux so it builds/ships

### DIFF
--- a/caltech-other/newuoa/src/m3makefile
+++ b/caltech-other/newuoa/src/m3makefile
@@ -21,5 +21,5 @@ Module ("NewUOAs")
 
 %implementation("Main")
 %program ("testnewuoa")
-end
 library ("newuoa")
+end


### PR DESCRIPTION
without error (does nothing) on other platforms, such as amd64_nt.