### PR TITLE
m3core: Build Win32 for all targets.

### DIFF
--- a/m3-libs/m3core/src/m3makefile
+++ b/m3-libs/m3core/src/m3makefile
@@ -27,16 +27,11 @@ if equal (TARGET, "OS2")
   include_dir ("OS2")
 end
 
-if equal (OS_TYPE, "WIN32") or equal(TARGET, "NT386")
-   or ({"NT", "MINGW", "CYGWIN"} contains TARGET)
-% 2014-02-24 win32 contains hundreds of WINAPI, APIENTRY, and PASCAL calling 
-% conventions.  These all give compile errors on non-windows targets, when
-% building with the release compiler. 
-% When there is a released version of the now-head compiler, (which accepts
-% these for any target,) we could reinstate win32, though it still may not be
-% of any use on non-windows targets.  
-  include_dir ("win32")
-end
+% Declare all of the Win32 types, constants, functions for all platforms.
+% This can be useful, for example, to build mklib hosted on other platforms.
+% Mklib clones some of this as a workaround.
+% Frontend accepts the Win32 calling conventions for all targets, usually ignoring them.
+include_dir ("win32")
 
 include_dir ("unix")
 


### PR DESCRIPTION
The .i3 there can be useful, for example to build
mklib on other hosts.
This effectively undoes commit 997e499081 from year 2014.
This originally went in commit 907515e97f in year 2008.
Frontend accepts all the Win32 calling conventions,
silently ignoring them on most platforms.