### PR TITLE
m3cc: Optimize gcc register allocator less to avoid Linux/x86 crashes.

### DIFF
--- a/m3-sys/m3cc/gcc-4.7/gcc/ira-build.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/ira-build.c
@@ -43,6 +43,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "ira-int.h"
 #include "emit-rtl.h"  /* FIXME: Can go away once crtl is moved to rtl.h.  */
 
+// cm3 cm3cg crashes on Linux/x86 host if ira is optimized.
+#pragma GCC optimize ("O1")
+
 static ira_copy_t find_allocno_copy (ira_allocno_t, ira_allocno_t, rtx,
 				     ira_loop_tree_node_t);
 

--- a/m3-sys/m3cc/gcc-4.7/gcc/ira-color.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/ira-color.c
@@ -41,6 +41,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "df.h"
 #include "ira-int.h"
 
+// cm3 cm3cg crashes on Linux/x86 host if ira is optimized.
+#pragma GCC optimize ("O1")
+
 typedef struct allocno_hard_regs *allocno_hard_regs_t;
 
 /* The structure contains information about hard registers can be

--- a/m3-sys/m3cc/gcc-4.7/gcc/ira-conflicts.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/ira-conflicts.c
@@ -41,6 +41,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "ira-int.h"
 #include "addresses.h"
 
+// cm3 cm3cg crashes on Linux/x86 host if ira is optimized.
+#pragma GCC optimize ("O1")
+
 /* This file contains code responsible for allocno conflict creation,
    allocno copy creation and allocno info accumulation on upper level
    regions.  */

--- a/m3-sys/m3cc/gcc-4.7/gcc/ira-costs.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/ira-costs.c
@@ -41,6 +41,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "params.h"
 #include "ira-int.h"
 
+// cm3 cm3cg crashes on Linux/x86 host if ira is optimized.
+#pragma GCC optimize ("O1")
+
 /* The flags is set up every time when we calculate pseudo register
    classes through function ira_set_pseudo_classes.  */
 static bool pseudo_classes_defined_p = false;

--- a/m3-sys/m3cc/gcc-4.7/gcc/ira-emit.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/ira-emit.c
@@ -91,6 +91,8 @@ along with GCC; see the file COPYING3.  If not see
 #include "df.h"
 #include "ira-int.h"
 
+// cm3 cm3cg crashes on Linux/x86 host if ira is optimized.
+#pragma GCC optimize ("O1")
 
 /* Data used to emit live range split insns and to flattening IR.  */
 ira_emit_data_t ira_allocno_emit_data;

--- a/m3-sys/m3cc/gcc-4.7/gcc/ira-lives.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/ira-lives.c
@@ -42,6 +42,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "sparseset.h"
 #include "ira-int.h"
 
+// cm3 cm3cg crashes on Linux/x86 host if ira is optimized.
+#pragma GCC optimize ("O1")
+
 /* The code in this file is similar to one in global but the code
    works on the allocno basis and creates live ranges instead of
    pseudo-register conflicts.  */

--- a/m3-sys/m3cc/gcc-4.7/gcc/ira.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/ira.c
@@ -387,6 +387,8 @@ along with GCC; see the file COPYING3.  If not see
 #include "ira-int.h"
 #include "dce.h"
 
+// cm3 cm3cg crashes on Linux/x86 host if ira is optimized.
+#pragma GCC optimize ("O1")
 
 struct target_ira default_target_ira;
 struct target_ira_int default_target_ira_int;


### PR DESCRIPTION
cm3cg crashes e.g. in caltech*/cit-util.
Ues pragma gcc optimize O1 to downgrade from O2 to workaround.
More debugging would be good.