### PR TITLE
m3cc: Reduce warnings building m3cc.

### DIFF
--- a/m3-sys/m3cc/gcc-4.7/gcc/builtins.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/builtins.c
@@ -111,7 +111,6 @@ static rtx expand_builtin_frame_address (tree, tree);
 static tree stabilize_va_list_loc (location_t, tree, int);
 static rtx expand_builtin_expect (tree, rtx);
 static bool validate_arg (const_tree, enum tree_code code);
-static bool integer_valued_real_p (tree);
 static bool readonly_data_expr (tree);
 static tree fold_builtin_memory_op (location_t, tree, tree, tree, tree, bool, int);
 static tree fold_builtin_memchr (location_t, tree, tree, tree, tree);
@@ -5004,78 +5003,6 @@ builtin_mathfn_code (const_tree t)
 
   /* Variable-length argument list.  */
   return DECL_FUNCTION_CODE (fndecl);
-}
-
-/* Return true if the floating point expression T has an integer value.
-   We also allow +Inf, -Inf and NaN to be considered integer values.  */
-
-static bool
-integer_valued_real_p (tree t)
-{
-  switch (TREE_CODE (t))
-    {
-    case FLOAT_EXPR:
-      return true;
-
-    case ABS_EXPR:
-    case SAVE_EXPR:
-      return integer_valued_real_p (TREE_OPERAND (t, 0));
-
-    case COMPOUND_EXPR:
-    case MODIFY_EXPR:
-    case BIND_EXPR:
-      return integer_valued_real_p (TREE_OPERAND (t, 1));
-
-    case PLUS_EXPR:
-    case MINUS_EXPR:
-    case MULT_EXPR:
-    case MIN_EXPR:
-    case MAX_EXPR:
-      return integer_valued_real_p (TREE_OPERAND (t, 0))
-	     && integer_valued_real_p (TREE_OPERAND (t, 1));
-
-    case COND_EXPR:
-      return integer_valued_real_p (TREE_OPERAND (t, 1))
-	     && integer_valued_real_p (TREE_OPERAND (t, 2));
-
-    case REAL_CST:
-      return real_isinteger (TREE_REAL_CST_PTR (t), TYPE_MODE (TREE_TYPE (t)));
-
-    case NOP_EXPR:
-      {
-	tree type = TREE_TYPE (TREE_OPERAND (t, 0));
-	if (TREE_CODE (type) == INTEGER_TYPE)
-	  return true;
-	if (TREE_CODE (type) == REAL_TYPE)
-	  return integer_valued_real_p (TREE_OPERAND (t, 0));
-	break;
-      }
-
-    case CALL_EXPR:
-      switch (builtin_mathfn_code (t))
-	{
-	CASE_FLT_FN (BUILT_IN_CEIL):
-	CASE_FLT_FN (BUILT_IN_FLOOR):
-	CASE_FLT_FN (BUILT_IN_NEARBYINT):
-	CASE_FLT_FN (BUILT_IN_RINT):
-	CASE_FLT_FN (BUILT_IN_ROUND):
-	CASE_FLT_FN (BUILT_IN_TRUNC):
-	  return true;
-
-	CASE_FLT_FN (BUILT_IN_FMIN):
-	CASE_FLT_FN (BUILT_IN_FMAX):
-	  return integer_valued_real_p (CALL_EXPR_ARG (t, 0))
- 	    && integer_valued_real_p (CALL_EXPR_ARG (t, 1));
-
-	default:
-	  break;
-	}
-      break;
-
-    default:
-      break;
-    }
-  return false;
 }
 
 /* Return true if VAR is a VAR_DECL or a component thereof.  */

--- a/m3-sys/m3cc/gcc-4.7/gcc/configure
+++ b/m3-sys/m3cc/gcc-4.7/gcc/configure
@@ -6553,13 +6553,13 @@ CFLAGS="$save_CFLAGS"
 # Do the check with the no- prefix removed from the warning options
 # since gcc silently accepts any -Wno-* option on purpose
 if test "$GCC" = yes; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -pedantic -Wlong-long -Wvariadic-macros -Woverlength-strings" >&5
-$as_echo_n "checking whether $CC supports -pedantic -Wlong-long -Wvariadic-macros -Woverlength-strings... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wlong-long -Wvariadic-macros -Woverlength-strings" >&5
+$as_echo_n "checking whether $CC supports -Wlong-long -Wvariadic-macros -Woverlength-strings... " >&6; }
 if test "${acx_cv_prog_cc_pedantic__Wlong_long__Wvariadic_macros__Woverlength_strings+set}" = set; then :
   $as_echo_n "(cached) " >&6
 else
   save_CFLAGS="$CFLAGS"
-CFLAGS="-pedantic -Wlong-long -Wvariadic-macros -Woverlength-strings"
+CFLAGS="-Wlong-long -Wvariadic-macros -Woverlength-strings"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/m3-sys/m3cc/gcc-4.7/gcc/configure.ac
+++ b/m3-sys/m3cc/gcc-4.7/gcc/configure.ac
@@ -331,6 +331,8 @@ GCC_STDINT_TYPES
 # * C++11 narrowing conversions in { }
 # So, we only use -pedantic if we can disable those warnings.
 
+# cm3: -pedantic is patched out as it causes very many warnings e.g. for __FUNCTION__
+
 ACX_PROG_CC_WARNING_OPTS(
 	m4_quote(m4_do([-W -Wno-missing-field-initializers -Wall -Wno-narrowing -Wwrite-strings -Wcast-qual])), [loose_warn])
 ACX_PROG_CC_WARNING_OPTS(

--- a/m3-sys/m3cc/gcc-4.7/gcc/gengtype.c
+++ b/m3-sys/m3cc/gcc-4.7/gcc/gengtype.c
@@ -159,7 +159,7 @@ static outf_p *base_files;
 
 
 
-#if ENABLE_CHECKING
+#if 1 /* ENABLE_CHECKING */
 /* Utility debugging function, printing the various type counts within
    a list of types.  Called thru the DBGPRINT_COUNT_TYPE macro.  */
 void
@@ -4817,7 +4817,7 @@ main (int argc, char **argv)
 
   parse_program_options (argc, argv);
 
-#if ENABLE_CHECKING
+#if 1 /* ENABLE_CHECKING */
   if (do_debug)
     {
       time_t now = (time_t) 0;

--- a/m3-sys/m3cc/gcc-4.7/gcc/gengtype.h
+++ b/m3-sys/m3cc/gcc-4.7/gcc/gengtype.h
@@ -482,7 +482,7 @@ extern int do_dump;		/* (-d) program argument. */
    gengtype source code).  Only useful to debug gengtype itself.  */
 extern int do_debug;		/* (-D) program argument. */
 
-#if ENABLE_CHECKING
+#if 1 /* ENABLE_CHECKING */
 #define DBGPRINTF(Fmt,...) do {if (do_debug)				\
       fprintf (stderr, "%s:%d: " Fmt "\n",				\
 	       lbasename (__FILE__),__LINE__, ##__VA_ARGS__);} while (0)

--- a/m3-sys/m3cc/gcc-4.7/gcc/system.h
+++ b/m3-sys/m3cc/gcc-4.7/gcc/system.h
@@ -538,15 +538,21 @@ extern int vsnprintf(char *, size_t, const char *, va_list);
 
 /* 1 if we have C99 designated initializers.  */
 #if !defined(HAVE_DESIGNATED_INITIALIZERS)
-#define HAVE_DESIGNATED_INITIALIZERS \
-  (((GCC_VERSION >= 2007) || (__STDC_VERSION__ >= 199901L)) \
+#if (((GCC_VERSION >= 2007) || (__STDC_VERSION__ >= 199901L)) \
    && !defined(__cplusplus))
+#define HAVE_DESIGNATED_INITIALIZERS 1
+#else
+#define HAVE_DESIGNATED_INITIALIZERS 0
+#endif
 #endif
 
 #if !defined(HAVE_DESIGNATED_UNION_INITIALIZERS)
-#define HAVE_DESIGNATED_UNION_INITIALIZERS \
-  (((GCC_VERSION >= 2007) || (__STDC_VERSION__ >= 199901L)) \
+#if (((GCC_VERSION >= 2007) || (__STDC_VERSION__ >= 199901L)) \
    && (!defined(__cplusplus) || (GCC_VERSION >= 4007)))
+#define HAVE_DESIGNATED_UNION_INITIALIZERS 1
+#else
+#define HAVE_DESIGNATED_UNION_INITIALIZERS 0
+#endif
 #endif
 
 #if HAVE_SYS_STAT_H

--- a/m3-sys/m3cc/gcc-4.7/include/ansidecl.h
+++ b/m3-sys/m3cc/gcc-4.7/include/ansidecl.h
@@ -141,7 +141,13 @@ So instead we use the macro below and test it against specific values.  */
    gcc at all.  */
 #ifndef GCC_VERSION
 #define GCC_VERSION (__GNUC__ * 1000 + __GNUC_MINOR__)
-#define ENABLE_CHECKING_GCC_VERSION ((GCC_VERSION > 3003) || (!defined(__cplusplus) && (GCC_VERSION > 2007)))
+#if ((GCC_VERSION > 3003) || (!defined(__cplusplus) && (GCC_VERSION > 2007)))
+#define ENABLE_CHECKING_GCC_VERSION 1
+#else
+#define ENABLE_CHECKING_GCC_VERSION 0
+#endif
+#else
+#define ENABLE_CHECKING_GCC_VERSION 0
 #endif /* GCC_VERSION */
 
 #if defined (__STDC__) || defined(__cplusplus) || defined (_AIX) || (defined (__mips) && defined (_SYSTYPE_SVR4)) || defined(_WIN32)

--- a/m3-sys/m3cc/gcc-4.7/libcpp/configure
+++ b/m3-sys/m3cc/gcc-4.7/libcpp/configure
@@ -4782,13 +4782,13 @@ WARN_PEDANTIC=
 # Do the check with the no- prefix removed from the warning options
 # since gcc silently accepts any -Wno-* option on purpose
 if test "$GCC" = yes; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -pedantic -Wlong-long" >&5
-$as_echo_n "checking whether $CC supports -pedantic -Wlong-long... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wlong-long" >&5
+$as_echo_n "checking whether $CC supports -Wlong-long... " >&6; }
 if test "${acx_cv_prog_cc_pedantic__Wlong_long+set}" = set; then :
   $as_echo_n "(cached) " >&6
 else
   save_CFLAGS="$CFLAGS"
-CFLAGS="-pedantic -Wlong-long"
+CFLAGS="-Wlong-long"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -4811,7 +4811,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $acx_cv_prog_cc_pedantic__Wlong_long" >&5
 $as_echo "$acx_cv_prog_cc_pedantic__Wlong_long" >&6; }
 if test $acx_cv_prog_cc_pedantic__Wlong_long = yes; then :
-  WARN_PEDANTIC="$WARN_PEDANTIC${WARN_PEDANTIC:+ }-pedantic -Wno-long-long"
+  WARN_PEDANTIC="$WARN_PEDANTIC${WARN_PEDANTIC:+ }-Wno-long-long"
 fi
 
 fi

--- a/m3-sys/m3cc/gcc-4.7/libiberty/configure
+++ b/m3-sys/m3cc/gcc-4.7/libiberty/configure
@@ -3973,7 +3973,7 @@ if test "${acx_cv_prog_cc_pedantic_+set}" = set; then :
   $as_echo_n "(cached) " >&6
 else
   save_CFLAGS="$CFLAGS"
-CFLAGS="-pedantic "
+CFLAGS=" "
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -3996,7 +3996,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $acx_cv_prog_cc_pedantic_" >&5
 $as_echo "$acx_cv_prog_cc_pedantic_" >&6; }
 if test $acx_cv_prog_cc_pedantic_ = yes; then :
-  ac_libiberty_warn_cflags="$ac_libiberty_warn_cflags${ac_libiberty_warn_cflags:+ }-pedantic "
+  ac_libiberty_warn_cflags="$ac_libiberty_warn_cflags${ac_libiberty_warn_cflags:+ } "
 fi
 
 fi


### PR DESCRIPTION
m3cc: Reduce warnings building m3cc.
  - Remove -pedantic more/better/cleaner (probably same amount).
  - Convert some if undefined to if 0 or 1.
  - Remove unused static function.