### PR TITLE
caltech-other: Cleanup.

### DIFF
--- a/caltech-other/bool/src/bool.h
+++ b/caltech-other/bool/src/bool.h
@@ -20,15 +20,23 @@
 extern "C" {
 #endif
 
-typedef unsigned long bool_var_t;
+typedef size_t bool_var_t;
+
+struct bool_t;
+struct rootlist;
+struct triple;
+
+typedef struct bool_t bool_t;
+typedef struct rootlist rootlist;
+typedef struct triple triple;
 
 /* do not rearrange order of fields! */
-typedef struct bool_t {
-  struct bool_t *l, *r;		/* left, right links */
-  struct bool_t *next;		/* next ptr, for hashtable */
+struct bool_t {
+  bool_t *l, *r;		/* left, right links */
+  bool_t *next;		/* next ptr, for hashtable */
   bool_var_t id;		/* variable, if non-leaf, value if leaf. */
   unsigned int ref:14;		/* refcount */
-} bool_t;
+};
 
 #ifdef BOOL_INTERNAL_H
 
@@ -44,7 +52,7 @@ typedef struct bool_t {
 #define ISLEAF(b)      (((b)->id & (1UL << HIBIT_OFFSET)) ? 1 : 0)
  /* True if "b" is a leaf */
 
-#define ASSIGN_LEAF(b,n) ((b)->id = ((b)->id & ~(1UL<<HIBIT_OFFSET))|(((unsigned long)n) << HIBIT_OFFSET))
+#define ASSIGN_LEAF(b,n) ((b)->id = ((b)->id & ~(1UL<<HIBIT_OFFSET))|(((size_t)n) << HIBIT_OFFSET))
  /* assign to the "leaf" bit. */
 
 #define REF(b)         ((b)->ref)
@@ -75,72 +83,72 @@ enum triple_operations_t {
 #define BOOL_MAXOP 7
 
 typedef struct {
-  unsigned long nelements;	/* number of elements in the hashtable */
-  unsigned long nbuckets;	/* number of buckets */
+  size_t nelements;	/* number of elements in the hashtable */
+  size_t nbuckets;	/* number of buckets */
   bool_t **bucket;		/* the buckets */
 } pairhash_t;
 
-struct triple {			/* triple for hashing */
+struct triple { /* triple for hashing */
   bool_t *v1, *v2, *v3;
-  struct triple *next;
+  triple *next;
 };
 
 typedef struct {
-  unsigned long nbuckets;
-  unsigned long nelements;
-  struct triple **bucket;
+  size_t nbuckets;
+  size_t nelements;
+  triple **bucket;
 } triplehash_t;			/* triple hash table */
 
 struct rootlist {
   bool_t *b;
-  struct rootlist *next;
+  rootlist *next;
 }; 
 
 typedef struct {
-  unsigned long nvar;		/* number of variables */
-  unsigned long totvar;		/* total number of variables */
+  size_t nvar;		/* number of variables */
+  size_t totvar;		/* total number of variables */
   pairhash_t **H;		/* hashtable for each variable */
   triplehash_t *TH[BOOL_MAXOP];	/* hashtable for (a,b)->c values */
   bool_t *True, *False;
-  struct rootlist *roots;	/* roots */
+  rootlist *roots;	/* roots */
 } BOOL_T;
 
 typedef struct {
   bool_var_t *v;
-  unsigned long n;
+  size_t n;
 } bool_list_t;			/* sorted list of variables */
 
-extern BOOL_T *bool_init (void);
+BOOL_T *bool_init (void);
 
-extern bool_t *bool_true (BOOL_T *);
-extern bool_t *bool_false (BOOL_T *);
-extern bool_t *bool_newvar (BOOL_T *);
-extern bool_t *bool_var (BOOL_T *, bool_var_t);
+bool_t *bool_true (BOOL_T *);
+bool_t *bool_false (BOOL_T *);
+bool_t *bool_newvar (BOOL_T *);
+bool_t *bool_var (BOOL_T *, bool_var_t);
 
-extern bool_t *bool_and (BOOL_T *, bool_t *, bool_t *);
-extern bool_t *bool_or (BOOL_T *, bool_t *, bool_t *);
-extern bool_t *bool_xor (BOOL_T *, bool_t *, bool_t *);
-extern bool_t *bool_not (BOOL_T *, bool_t *);
-extern bool_t *bool_copy  (BOOL_T *, bool_t *);
-extern bool_t *bool_implies (BOOL_T *, bool_t *, bool_t *);
+bool_t *bool_and (BOOL_T *, bool_t *, bool_t *);
+bool_t *bool_or (BOOL_T *, bool_t *, bool_t *);
+bool_t *bool_xor (BOOL_T *, bool_t *, bool_t *);
+bool_t *bool_not (BOOL_T *, bool_t *);
+bool_t *bool_copy  (BOOL_T *, bool_t *);
+bool_t *bool_implies (BOOL_T *, bool_t *, bool_t *);
 
-extern bool_t *bool_maketrue (BOOL_T *, bool_t *, bool_t *);
-extern bool_t *bool_makefalse (BOOL_T *, bool_t *, bool_t *);
+bool_t *bool_maketrue (BOOL_T *, bool_t *, bool_t *);
+bool_t *bool_makefalse (BOOL_T *, bool_t *, bool_t *);
 
-extern bool_t *bool_substitute (BOOL_T *, bool_list_t *, bool_list_t *, 
+bool_t *bool_substitute (BOOL_T *, bool_list_t *, bool_list_t *,
 				bool_t *);
-extern bool_t *bool_exists (BOOL_T *, bool_list_t *, bool_t *);
-extern bool_t *bool_exists2 (BOOL_T *, bool_list_t *, bool_t *, bool_t *);
-extern bool_list_t *bool_qlist (BOOL_T *, unsigned long, bool_var_t *);
+bool_t *bool_exists (BOOL_T *, bool_list_t *, bool_t *);
+bool_t *bool_exists2 (BOOL_T *, bool_list_t *, bool_t *, bool_t *);
+bool_list_t *bool_qlist (BOOL_T *, size_t, bool_var_t *);
 
-extern void bool_free (BOOL_T *, bool_t *);
-extern void bool_gc (BOOL_T *);
+void bool_free (BOOL_T *, bool_t *);
+void bool_gc (BOOL_T *);
 
-extern void bool_print (bool_t *);
-extern void bool_info (BOOL_T *B);
-extern int bool_getid(bool_t *b);
+void bool_print (bool_t *);
+void bool_info (BOOL_T *B);
+int bool_getid(bool_t *b);
 
-extern int bool_isleaf (bool_t *b);
+int bool_isleaf (bool_t *b);
 
 #define bool_topvar(b) ((b)->id)
 

--- a/caltech-other/bool/src/misc.c
+++ b/caltech-other/bool/src/misc.c
@@ -32,12 +32,13 @@ void fatal_error (const char *s, ...)
   exit (1);
 }
 
-
 char *Strdup (char *s)
 {
   char *t;
-  MALLOC (t, char, strlen(s)+1);
-  strcpy (t, s);
+  size_t length;
+  length = strlen(s) + 1;
+  MALLOC (t, char, length);
+  memcpy (t, s, length);
   return t;
 }
 

--- a/caltech-other/bool/src/misc.h
+++ b/caltech-other/bool/src/misc.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-extern void fatal_error (const char *s, ...);
+void fatal_error (const char *s, ...);
 
 #define MALLOC(a,b,c)  do { if(!(a=(b*)malloc(sizeof(b)*(c)))) fatal_error("malloc failed, size=%d", sizeof(b)*(c)); }while(0)
   /* allocate "c" number of elements of type "b" and assign the resulting

--- a/caltech-other/m3readline/c/src/program.c
+++ b/caltech-other/m3readline/c/src/program.c
@@ -35,7 +35,6 @@ install_int_handler(void) { signal(SIGINT, SIG_IGN); signal(SIGTTOU, SIG_IGN); s
 static void
 deinstall_int_handler(void) { signal(SIGINT, NULL); }
 
-
 /**********************************************************************/
 
 void
@@ -47,7 +46,6 @@ fatal(const char *whatfailed)
 }
 
 int debug=0;
-
 
 /**********************************************************************/
 
@@ -64,10 +62,13 @@ readline_callback(char *r_line)
   rl_callback_handler_remove();
 }
 
-typedef struct inelem {
+struct inelem;
+typedef struct inelem inelem;
+
+struct inelem {
   char *data;
-  struct inelem *next, *prev;
-} inelem;
+  inelem *next, *prev;
+};
 
 void 
 mainloop2(int fd)
@@ -203,7 +204,6 @@ mainloop2(int fd)
     }
   }
 }
-  
 
 int 
 main(int argc, const char **argv) 
@@ -235,5 +235,3 @@ main(int argc, const char **argv)
   mainloop2(s);
   exit(0);
 }
-
-

--- a/caltech-other/voronoi/src/defs.c
+++ b/caltech-other/voronoi/src/defs.c
@@ -8,25 +8,25 @@ extern "C" {
 
 int triangulate, sorted, plot, debug;
 float xmin, xmax, ymin, ymax, deltax, deltay;
-struct	Site	*sites;
+Site	*sites;
 int		nsites;
 int		siteidx;
 int		sqrt_nsites;
 int		nvertices;
-struct	Site	*bottomsite;
-struct Triple *triples;
+Site	*bottomsite;
+Triple *triples;
 int nedges;
-struct	Halfedge *ELleftend, *ELrightend;
+Halfedge *ELleftend, *ELrightend;
 int 	ELhashsize;
-struct	Halfedge **ELhash;
+Halfedge **ELhash;
 int PQhashsize;
-struct	Halfedge *PQhash;
+Halfedge *PQhash;
 int PQcount;
 int PQmin;
-struct Triple *tfl;
-struct Halfedge *hfl;
-struct Site *sfl;
-struct Edge *efl;
+Triple *tfl;
+Halfedge *hfl;
+Site *sfl;
+Edge *efl;
 
 #if __cplusplus
 } /* extern "C" */

--- a/caltech-other/voronoi/src/defs.h
+++ b/caltech-other/voronoi/src/defs.h
@@ -13,6 +13,7 @@ extern int triangulate, sorted, plot, debug;
 
 extern float xmin, xmax, ymin, ymax, deltax, deltay;
 
+/* Forward declare structs. */
 struct Edge;
 struct Halfedge;
 struct Point;
@@ -20,107 +21,114 @@ struct Site;
 struct Triple;
 struct TripleArg;
 
-struct Point	{
-float x,y;
+/* Typedef structs to plain names. */
+typedef struct Edge Edge;
+typedef struct Halfedge Halfedge;
+typedef struct Point Point;
+typedef struct Site Site;
+typedef struct Triple Triple;
+typedef struct TripleArg TripleArg;
+
+struct Point {
+    float x,y;
 };
 
 /* structure used both for sites and for vertices */
 struct Site	{
-struct	Point	coord;
+Point	coord;
 int		sitenbr;
 };
 
-
-extern struct	Site	*sites;
+extern Site	    *sites;
 extern int		nsites;
 extern int		siteidx;
 extern int		sqrt_nsites;
 extern int		nvertices;
-extern struct	Site	*bottomsite;
-
+extern Site	*bottomsite;
 
 struct TripleArg {
   int s1, s2, s3;
 };
 
 struct Triple {
-  struct TripleArg d;
-  struct Triple *next;
+  TripleArg d;
+  Triple *next;
 };
 
-extern struct Triple *triples;
-
+extern Triple *triples;
 
 struct Edge	{
 float		a,b,c;
-struct	Site 	*ep[2];
-struct	Site	*reg[2];
+Site 	*ep[2];
+Site	*reg[2];
 int		edgenbr;
 };
+
 #define le 0
 #define re 1
 extern int nedges;
 
-int has_endpoint();
-int right_of(struct Halfedge *el, struct Point *p);
-struct Site *intersect(struct Halfedge*, struct Halfedge*);
-float dist(struct Site *s, struct Site *t);
-struct Point PQ_min();
-struct Halfedge *PQextractmin();
-struct Edge *bisect(struct Site*, struct Site*);
+int has_endpoint(void);
+int right_of(Halfedge *el, Point *p);
+Site *intersect(Halfedge*, Halfedge*);
+float dist(Site *s, Site *t);
+Point PQ_min(void);
+Halfedge *PQextractmin(void);
+Edge *bisect(Site*, Site*);
 
 struct Halfedge {
-struct Halfedge	*ELleft, *ELright;
-struct Edge	*ELedge;
-char		ELpm;
-struct	Site	*vertex;
-float		ystar;
-struct	Halfedge *PQnext;
+Halfedge *ELleft;
+Halfedge *ELright;
+Edge     *ELedge;
+char      ELpm;
+Site     *vertex;
+float     ystar;
+Halfedge *PQnext;
 };
 
-extern struct	Halfedge *ELleftend, *ELrightend;
+extern Halfedge *ELleftend, *ELrightend;
 extern int 	ELhashsize;
-extern struct	Halfedge **ELhash;
-struct Halfedge *ELleft(struct Halfedge*);
-struct Halfedge *ELleftbnd(struct Point*);
-struct Halfedge *HEcreate(struct Edge *e, int pm);
-struct Halfedge *ELright(struct Halfedge*);
-struct Site *leftreg(struct Halfedge*);
-struct Site *rightreg(struct Halfedge*);
+extern Halfedge **ELhash;
+Halfedge *ELleft(Halfedge*);
+Halfedge *ELleftbnd(Point*);
+Halfedge *HEcreate(Edge *e, int pm);
+Halfedge *ELright(Halfedge*);
+Site *leftreg(Halfedge*);
+Site *rightreg(Halfedge*);
 
 extern int PQhashsize;
-extern struct	Halfedge *PQhash;
-struct	Halfedge *PQfind();
+extern Halfedge *PQhash;
+Halfedge *PQfind(void);
 extern int PQcount;
 extern int PQmin;
-int PQempty();
+int PQempty(void);
 
 char *memmalloc(size_t);
 
 /* free lists */
-extern struct Triple *tfl;
-extern struct Halfedge *hfl;
-extern struct Site *sfl;
-extern struct Edge *efl;
+extern Triple *tfl;
+extern Halfedge *hfl;
+extern Site *sfl;
+extern Edge *efl;
 
-void out_ep(struct Edge*);
-void PQdelete(struct Halfedge*);
-void PQinsert(struct Halfedge *he, struct Site *v, float offset);
-void ELinsert(struct Halfedge *lb, struct Halfedge *new_);
-void endpoint(struct Edge *e, int lr, struct Site *s);
-void ELdelete(struct Halfedge*);
-void makevertex(struct Site*);
-void ELinitialize();
-void PQinitialize();
-void voronoi(int triangulate, struct Site *(*nextsite)());
-void geominit();
-void clear_triples();
-int PQbucket(struct Halfedge*);
-void out_bisector(struct Edge*);
-void out_triple(struct Site*, struct Site*, struct Site*);
-void out_site(struct Site*);
-void clip_line(struct Edge*);
-void out_vertex(struct Site*);
+void out_ep(Edge*);
+void PQdelete(Halfedge*);
+void PQinsert(Halfedge *he, Site *v, float offset);
+void ELinsert(Halfedge *lb, Halfedge *new_);
+void endpoint(Edge *e, int lr, Site *s);
+void ELdelete(Halfedge*);
+void makevertex(Site*);
+void ELinitialize(void);
+void PQinitialize(void);
+void voronoi(int triangulate, Site *(*nextsite)(void));
+void geominit(void);
+void clear_triples(void);
+int PQbucket(Halfedge*);
+void out_bisector(Edge*);
+void out_triple(Site*, Site*, Site*);
+void out_site(Site*);
+void clip_line(Edge*);
+void out_vertex(Site*);
 
 #if __cplusplus
 } /* extern "C" */

--- a/caltech-other/voronoi/src/edgelist.c
+++ b/caltech-other/voronoi/src/edgelist.c
@@ -9,13 +9,13 @@ static int ntry, totalsearch;
 
 /*int ELhashsize;*/
 void
-ELinitialize()
+ELinitialize(void)
 {
 int i;
 	ELhashsize = 2 * sqrt_nsites;
 
 
-	ELhash = (struct Halfedge **) memmalloc ( sizeof *ELhash * ELhashsize);
+	ELhash = (Halfedge**)memmalloc(sizeof *ELhash * ELhashsize);
 	for(i=0; i<ELhashsize; i +=1) ELhash[i] = NULL;
 	ELleftend = HEcreate(NULL, 0);
 	ELrightend = HEcreate(NULL, 0);
@@ -30,17 +30,17 @@ int i;
 #define HALLOC 100
 static int hp=0;
 
-struct Halfedge *HEcreate(
-struct Edge *e,
+Halfedge *HEcreate(
+Edge *e,
 int pm)
 {
-  struct Halfedge *answer;
+  Halfedge *answer;
  
   if (!hfl || hp==HALLOC) {
-    hfl=(struct Halfedge *)memmalloc(sizeof(struct Halfedge)*HALLOC);
+    hfl = (Halfedge*)memmalloc(sizeof(Halfedge) * HALLOC);
     hp=0;
   }
-  answer=(struct Halfedge *)hfl+(hp++);
+  answer=(Halfedge *)hfl+(hp++);
 
 	answer -> ELedge = e;
 	answer -> ELpm = pm;
@@ -51,8 +51,8 @@ int pm)
 
 void
 ELinsert(
-struct	Halfedge *lb,
-struct	Halfedge *new_)
+Halfedge *lb,
+Halfedge *new_)
 {
 	new_ -> ELleft = lb;
 	new_ -> ELright = lb -> ELright;
@@ -61,9 +61,9 @@ struct	Halfedge *new_)
 }
 
 /* Get entry from hash table, pruning any deleted nodes */
-struct Halfedge *ELgethash(int b)
+Halfedge *ELgethash(int b)
 {
-struct Halfedge *he;
+Halfedge *he;
 
 	if(b<0 || b>=ELhashsize) return NULL;
 	he = ELhash[b]; 
@@ -75,10 +75,10 @@ struct Halfedge *he;
 	return NULL;
 }	
 
-struct Halfedge *ELleftbnd(struct Point *p)
+Halfedge *ELleftbnd(Point *p)
 {
 int i, bucket;
-struct Halfedge *he;
+Halfedge *he;
 
 /* Use hash table to get close to desired halfedge */
 	bucket = (p->x - xmin)/deltax * ELhashsize;
@@ -89,9 +89,9 @@ struct Halfedge *he;
 	{   for(i=1; 1 ; i += 1)
 	    {	if ((he=ELgethash(bucket-i)) != NULL) break;
 		if ((he=ELgethash(bucket+i)) != NULL) break;
-	    };
+	    }
 	totalsearch += i;
-	};
+	}
 	ntry += 1;
 /* Now search linear list of halfedges for the corect one */
 	if (he==ELleftend  || (he != ELrightend && right_of(he,p)))
@@ -105,38 +105,38 @@ struct Halfedge *he;
 	if(bucket > 0 && bucket <ELhashsize-1)
 	{
 		ELhash[bucket] = he;
-	};
+	}
 	return (he);
 }
 
 	/* This delete routine can't reclaim node, since pointers from hash
    table may be present.   */
 void
-ELdelete(struct Halfedge *he)
+ELdelete(Halfedge *he)
 {
 	(he -> ELleft) -> ELright = he -> ELright;
 	(he -> ELright) -> ELleft = he -> ELleft;
-	he -> ELedge = (struct Edge *)DELETED;
+	he -> ELedge = (Edge*)DELETED;
 }
 
-struct Halfedge *ELright(struct Halfedge *he)
+Halfedge *ELright(Halfedge *he)
 {
 	return (he -> ELright);
 }
 
-struct Halfedge *ELleft(struct Halfedge *he)
+Halfedge *ELleft(Halfedge *he)
 {
 	return (he -> ELleft);
 }
 
-struct Site *leftreg(struct Halfedge *he)
+Site *leftreg(Halfedge *he)
 {
 	if(he -> ELedge == NULL) return(bottomsite);
 	return( he -> ELpm == le ? 
 		he -> ELedge -> reg[le] : he -> ELedge -> reg[re]);
 }
 
-struct Site *rightreg(struct Halfedge *he)
+Site *rightreg(Halfedge *he)
 {
 	if(he -> ELedge == NULL) return(bottomsite);
 	return( he -> ELpm == le ? 

--- a/caltech-other/voronoi/src/geometry.c
+++ b/caltech-other/voronoi/src/geometry.c
@@ -8,9 +8,9 @@ extern "C" {
 #endif
 
 void
-geominit()
+geominit(void)
 {
-struct Edge e;
+Edge e;
 float sn;
 
 	nvertices = 0;
@@ -24,24 +24,24 @@ float sn;
 #define EALLOC 100
 static int ep=100;
 
-struct Edge *bisect(
-struct	Site *s1,
-struct	Site *s2)
+Edge *bisect(
+Site *s1,
+Site *s2)
 {
   float dx,dy,adx,ady;
-  struct Edge *newedge;
+  Edge *newedge;
   
   if (!efl || ep == EALLOC) {
-    efl=(struct Edge *)memmalloc(sizeof(struct Edge)*EALLOC);
+    efl = (Edge*)memmalloc(sizeof(Edge) * EALLOC);
     ep=0;
   }
    
-  newedge=(struct Edge *)efl+(ep++);
+  newedge=(Edge *)efl+(ep++);
 
 	newedge -> reg[0] = s1;
 	newedge -> reg[1] = s2;
-	newedge -> ep[0] = (struct Site *) NULL;
-	newedge -> ep[1] = (struct Site *) NULL;
+	newedge -> ep[0] = NULL;
+	newedge -> ep[1] = NULL;
 
 	dx = s2->coord.x - s1->coord.x;
 	dy = s2->coord.y - s1->coord.y;
@@ -51,7 +51,7 @@ struct	Site *s2)
 	if (adx>ady)
 	{	newedge -> a = 1.0; newedge -> b = dy/dx; newedge -> c /= dx;}
 	else
-	{	newedge -> b = 1.0; newedge -> a = dx/dy; newedge -> c /= dy;};
+	{	newedge -> b = 1.0; newedge -> a = dx/dy; newedge -> c /= dy;}
 
 	newedge -> edgenbr = nedges;
 	out_bisector(newedge);
@@ -62,15 +62,15 @@ struct	Site *s2)
 #define SALLOC 100
 static int sp=0;
 
-struct Site *intersect(
-struct Halfedge *el1,
-struct Halfedge *el2)
+Site *intersect(
+Halfedge *el1,
+Halfedge *el2)
 {
-struct	Edge *e1,*e2, *e;
-struct  Halfedge *el;
+Edge *e1,*e2, *e;
+ Halfedge *el;
 float d, xint, yint;
 int right_of_site;
-struct Site *v;
+Site *v;
 
 	e1 = el1 -> ELedge;
 	e2 = el2 -> ELedge;
@@ -89,16 +89,16 @@ struct Site *v;
 		e1->reg[1]->coord.x < e2->reg[1]->coord.x) )
 	{	el = el1; e = e1;}
 	else
-	{	el = el2; e = e2;};
+	{	el = el2; e = e2;}
 	right_of_site = xint >= e -> reg[1] -> coord.x;
 	if ((right_of_site && el -> ELpm == le) ||
 	   (!right_of_site && el -> ELpm == re)) return NULL;
 
 	if (!sfl || sp==SALLOC) {
-	  sfl = (struct Site *)memmalloc(sizeof(struct Site)*SALLOC);
+	  sfl = (Site*)memmalloc(sizeof(Site) * SALLOC);
 	  sp=0;
 	}
-	    v = (struct Site *)sfl+(sp++);
+	    v = (Site*)sfl+(sp++);
 	v -> coord.x = xint;
 	v -> coord.y = yint;
 	return(v);
@@ -106,11 +106,11 @@ struct Site *v;
 
 /* returns 1 if p is to right of halfedge e */
 int right_of(
-struct Halfedge *el,
-struct Point *p)
+Halfedge *el,
+Point *p)
 {
-struct Edge *e;
-struct Site *topsite;
+Edge *e;
+Site *topsite;
 int right_of_site, above, fast;
 float dxp, dyp, dxs, t1, t2, t3, yl;
 
@@ -132,13 +132,13 @@ if (e->a == 1.0)
 	{	above = p->x + p->y*e->b > e-> c;
 		if(e->b<0.0) above = !above;
 		if (!above) fast = 1;
-	};
+	}
 	if (!fast)
 	{	dxs = topsite->coord.x - (e->reg[0])->coord.x;
 		above = e->b * (dxp*dxp - dyp*dyp) <
 		        dxs*dyp*(1.0+2.0*dxp/dxs + e->b*e->b);
 		if(e->b<0.0) above = !above;
-	};
+	}
 }
 else  /*e->b==1.0 */
 {	yl = e->c - e->a*p->x;
@@ -146,24 +146,19 @@ else  /*e->b==1.0 */
 	t2 = p->x - topsite->coord.x;
 	t3 = yl - topsite->coord.y;
 	above = t1*t1 > t2*t2 + t3*t3;
-};
+}
 return (el->ELpm==le ? above : !above);
 }
 
 void
-endpoint(
-struct Edge *e,
-int	lr,
-struct Site *s)
+endpoint(Edge *e, int lr, Site *s)
 {
 e -> ep[lr] = s;
 if(e -> ep[re-lr]== NULL) return;
 out_ep(e);
 }
 
-float dist(
-struct Site *s,
-struct Site *t)
+float dist(Site *s, Site *t)
 {
 float dx,dy;
 	dx = s->coord.x - t->coord.x;
@@ -171,7 +166,7 @@ float dx,dy;
 	return(sqrt(dx*dx + dy*dy));
 }
 
-void makevertex(struct Site *v)
+void makevertex(Site *v)
 {
 v -> sitenbr = nvertices;
 nvertices += 1;

--- a/caltech-other/voronoi/src/heap.c
+++ b/caltech-other/voronoi/src/heap.c
@@ -6,12 +6,9 @@ extern "C" {
 #endif
 
 void
-PQinsert(
-struct Halfedge *he,
-struct Site *v,
-float 	offset)
+PQinsert(Halfedge *he, Site *v, float offset)
 {
-struct Halfedge *last, *next;
+Halfedge *last, *next;
 
 he -> vertex = v;
 he -> ystar = v -> coord.y + offset;
@@ -19,16 +16,16 @@ last = &PQhash[PQbucket(he)];
 while ((next = last -> PQnext) != NULL &&
       (he -> ystar  > next -> ystar  ||
       (he -> ystar == next -> ystar && v -> coord.x > next->vertex->coord.x)))
-	{	last = next;};
+	{	last = next;}
 he -> PQnext = last -> PQnext; 
 last -> PQnext = he;
 PQcount += 1;
 }
 
 void
-PQdelete(struct Halfedge *he)
+PQdelete(Halfedge *he)
 {
-struct Halfedge *last;
+Halfedge *last;
 
 if(he ->  vertex != NULL)
 {	last = &PQhash[PQbucket(he)];
@@ -36,10 +33,10 @@ if(he ->  vertex != NULL)
 	last -> PQnext = he -> PQnext;
 	PQcount -= 1;
 	he -> vertex = NULL;
-};
+}
 }
 
-int PQbucket(struct Halfedge *he)
+int PQbucket(Halfedge *he)
 {
 int bucket;
 
@@ -50,42 +47,41 @@ if (bucket < PQmin) PQmin = bucket;
 return(bucket);
 }
 
-int PQempty()
+int PQempty(void)
 {
 	return(PQcount==0);
 }
 
-struct Point PQ_min()
+Point PQ_min(void)
 {
-struct Point answer;
+Point answer;
 
-	while(PQhash[PQmin].PQnext == NULL) {PQmin += 1;};
+	while(PQhash[PQmin].PQnext == NULL) {PQmin += 1;}
 	answer.x = PQhash[PQmin].PQnext -> vertex -> coord.x;
 	answer.y = PQhash[PQmin].PQnext -> ystar;
-	return (answer);
+	return answer;
 }
 
-struct Halfedge *PQextractmin()
+Halfedge *PQextractmin(void)
 {
-struct Halfedge *curr;
+Halfedge *curr;
 
 	curr = PQhash[PQmin].PQnext;
 	PQhash[PQmin].PQnext = curr -> PQnext;
 	PQcount -= 1;
-	return(curr);
+	return curr;
 }
 
 void
-PQinitialize()
+PQinitialize(void)
 {
-int i; struct Point *s;
+int i; Point *s;
 
 	PQcount = 0;
 	PQmin = 0;
 	PQhashsize = 4 * sqrt_nsites;
 
-
-	PQhash = (struct Halfedge *) memmalloc(PQhashsize * sizeof *PQhash);
+	PQhash = (Halfedge*)memmalloc(PQhashsize * sizeof(*PQhash));
 	for(i=0; i<PQhashsize; i+=1) PQhash[i].PQnext = NULL;
 }
 

--- a/caltech-other/voronoi/src/main.c
+++ b/caltech-other/voronoi/src/main.c
@@ -19,8 +19,8 @@
 extern "C" {
 #endif
 
-struct Site *readone();
-struct Site *nextone();
+Site *readone(void);
+Site *nextone(void);
 
 #if __cplusplus
 } /* extern "C" */
@@ -32,7 +32,7 @@ int argc,
 char *argv[])
 {	
 int c;
-struct Site *(*next)();
+Site *(*next)(void);
 
 sorted = 0; triangulate = 0; plot = 0; debug = 0;
 while((c=getopt(argc,argv,"dpst")) != EOF)
@@ -45,7 +45,7 @@ while((c=getopt(argc,argv,"dpst")) != EOF)
 		  break;
 	case 'p': plot = 1;
 		  break;
-		  };
+		  }
 
 freeinit(&sfl, sizeof *sites);
 if(sorted)
@@ -55,7 +55,7 @@ if(sorted)
 else 
 {	readsites();
 	next = nextone;
-};
+}
 
 siteidx = 0;
 geominit();
@@ -75,8 +75,8 @@ int scomp(
 const void *p1,
 const void *p2)
 {
-    const struct Point *s1 = (const struct Point*)p1;
-    const struct Point *s2 = (const struct Point*)p2;
+    const Point *s1 = (const Point*)p1;
+    const Point *s2 = (const Point*)p2;
 	if(s1 -> y < s2 -> y) return(-1);
 	if(s1 -> y > s2 -> y) return(1);
 	if(s1 -> x < s2 -> x) return(-1);
@@ -85,9 +85,9 @@ const void *p2)
 }
 
 /* return a single in-storage site */
-struct Site *nextone()
+Site *nextone(void)
 {
-struct Site *s;
+Site *s;
 if(siteidx < nsites)
 {	s = &sites[siteidx];
 	siteidx += 1;
@@ -98,36 +98,36 @@ else	return NULL;
 
 /* read all sites, sort, and compute xmin, xmax, ymin, ymax */
 void
-readsites()
+readsites(void)
 {
 int i;
 
 nsites=0;
-sites = (struct Site *) memmalloc(4000*sizeof *sites);
+sites = (Site*)memmalloc(4000 * sizeof(*sites));
 while(scanf("%f %f", &sites[nsites].coord.x, &sites[nsites].coord.y)!=EOF)
 {	sites[nsites].sitenbr = nsites;
 	sites[nsites].refcnt = 0;
 	nsites += 1;
 	if (nsites % 4000 == 0) 
-		sites = (struct Site *) memrealloc(sites,(nsites+4000)*sizeof*sites);
-};
+		sites = (Site*)memrealloc(sites,(nsites+4000)*sizeof*sites);
+}
 qsort(sites, nsites, sizeof *sites, scomp);
 xmin=sites[0].coord.x; 
 xmax=sites[0].coord.x;
 for(i=1; i<nsites; i+=1)
 {	if(sites[i].coord.x < xmin) xmin = sites[i].coord.x;
 	if(sites[i].coord.x > xmax) xmax = sites[i].coord.x;
-};
+}
 ymin = sites[0].coord.y;
 ymax = sites[nsites-1].coord.y;
 }
 
 /* read one site */
-struct Site *readone()
+Site *readone(void)
 {
-struct Site *s;
+Site *s;
 
-s = (struct Site *) getfree(&sfl);
+s = (Site*)getfree(&sfl);
 s -> refcnt = 0;
 s -> sitenbr = siteidx;
 siteidx += 1;

--- a/caltech-other/voronoi/src/mod3_main.c
+++ b/caltech-other/voronoi/src/mod3_main.c
@@ -25,17 +25,17 @@
 extern "C" {
 #endif
 
-struct Site *readone();
-struct Site *nextone();
+Site *readone(void);
+Site *nextone(void);
 
 static int setup=0;
 
 void
-mod3_start()
+mod3_start(void)
 {
   setup=0;
   nsites = 0;
-  sites = (struct Site *) memmalloc(4000*sizeof *sites);
+  sites = (Site*)memmalloc(4000 * sizeof(*sites));
 
   tfl=NULL;
   hfl=NULL;
@@ -46,7 +46,7 @@ mod3_start()
 }
 
 void
-mod3_addsite(struct Point p)
+mod3_addsite(Point p)
 {
   assert(!setup);
   sites[nsites].coord = p;
@@ -56,10 +56,10 @@ mod3_addsite(struct Point p)
     /* let's just free this here, as it is such a large data structure */
 
     /* the following code is wrong anyway (two args to memmalloc) */
-    /* struct Site *newsites = (struct Site *) memmalloc(sites,(nsites+4000)*sizeof*sites); */
+    /* Site *newsites = (Site*)memmalloc(sites,(nsites+4000)*sizeof*sites); */
 
-    struct Site *newsites = (struct Site *) mymalloc((nsites+4000)*sizeof*sites);
-    bcopy(sites,newsites,nsites*sizeof*sites);
+    Site *newsites = (Site*)mymalloc((nsites+4000) * sizeof(*sites));
+    bcopy(sites, newsites, nsites * sizeof(*sites));
 
     /* don't free first time, as the first block as allocated by memmalloc */
     if (nsites!=4000) myfree(sites);
@@ -75,8 +75,8 @@ int scomp(
 const void *p1,
 const void *p2)
 {
-    const struct Point *s1 = (const struct Point*)p1;
-    const struct Point *s2 = (const struct Point*)p2;
+    const Point *s1 = (const Point*)p1;
+    const Point *s2 = (const Point*)p2;
 	if(s1 -> y < s2 -> y) return(-1);
 	if(s1 -> y > s2 -> y) return(1);
 	if(s1 -> x < s2 -> x) return(-1);
@@ -85,7 +85,7 @@ const void *p2)
 }
 
 void
-mod3_setup() 
+mod3_setup(void) 
 {
 int i;
   setup=1;
@@ -95,17 +95,17 @@ xmax=sites[0].coord.x;
 for(i=1; i<nsites; i+=1)
 {	if(sites[i].coord.x < xmin) xmin = sites[i].coord.x;
 	if(sites[i].coord.x > xmax) xmax = sites[i].coord.x;
-};
+}
 ymin = sites[0].coord.y;
 ymax = sites[nsites-1].coord.y;
 }
 
 void
-mod3_delaunay()
+mod3_delaunay(void)
 {	
 int c;
  int i;
-struct Site *(*next)();
+Site *(*next)(void);
 
  assert(setup); 
 triangulate = 1; 
@@ -121,25 +121,25 @@ voronoi(triangulate, next);
 }
 
 void
-clear_triples()
+clear_triples(void)
 {
-  struct Triple *t=triples;
+  Triple *t=triples;
   triples=NULL;
 
   while (t!=NULL) {
-    struct Triple *u=t;
+    Triple *u=t;
     t=t->next;
   }
 
 }
 
-int mod3_gettriple(struct TripleArg *t)
+int mod3_gettriple(TripleArg *t)
 {
   if (!triples) 
     return 0;
   
   {
-    struct Triple *u=triples;
+    Triple *u=triples;
     *t = triples->d;
 
     triples=u->next;
@@ -150,10 +150,10 @@ int mod3_gettriple(struct TripleArg *t)
 }
 
 void
-mod3_voronoi()
+mod3_voronoi(void)
 {	
 int c;
-struct Site *(*next)();
+Site *(*next)(void);
 
  assert(setup); 
 triangulate = 0; 
@@ -164,14 +164,13 @@ siteidx = 0;
 geominit();
 
 voronoi(triangulate, next); 
-
 }
 
 
 /* return a single in-storage site */
-struct Site *nextone()
+Site *nextone(void)
 {
-struct Site *s;
+Site *s;
 if(siteidx < nsites)
 {	s = &sites[siteidx];
 	siteidx += 1;
@@ -179,7 +178,6 @@ if(siteidx < nsites)
 }
 else	return NULL;
 }
-
 
 char *mem=NULL;
 
@@ -201,10 +199,10 @@ char *mem=NULL;
    P.S. I hate C programming!!!!
  */
 
-char *memmalloc(
-     size_t siz)
+char *memmalloc(size_t siz)
 {
-  char *res = (char*)mymalloc(siz+sizeof(char *));
+  /* TODO This reduces alignment. Better to use two pointers. */
+  char *res = (char*)mymalloc(siz + sizeof(char*));
 
   *((char **)res) = mem;
   mem=res;
@@ -213,7 +211,7 @@ char *memmalloc(
 
 /* clear it all out */
 void
-mod3_finish()
+mod3_finish(void)
 {
   char *q;
   

--- a/caltech-other/voronoi/src/mymalloc.c
+++ b/caltech-other/voronoi/src/mymalloc.c
@@ -49,15 +49,17 @@ static int mymalloc_where=0; /* for future use */
 static int mblocks=0,fblocks=0,mbytes=0,fbytes=0;
 
 /* this is a private data structure */
+struct mtabent;
+typedef struct mtabent mtabent;
 
-typedef struct mtabent {
+struct mtabent {
   void *address;
   size_t size;
   int where;
-  struct mtabent *next;
+  mtabent *next;
   char *file;
   int line;
-} mtabent;
+};
 
 static   mtabent *mallocs=NULL;
 

--- a/caltech-other/voronoi/src/output.c
+++ b/caltech-other/voronoi/src/output.c
@@ -22,7 +22,7 @@ range(){}
 static float pxmin, pxmax, pymin, pymax, cradius;
 
 void
-out_bisector(struct Edge *e)
+out_bisector(Edge *e)
 {
 if(triangulate & plot &!debug)
 	line(e->reg[0]->coord.x, e->reg[0]->coord.y, 
@@ -35,19 +35,19 @@ if(debug)
 }
 
 void
-out_ep(struct Edge *e)
+out_ep(Edge *e)
 {
 if(!triangulate & plot) 
 	clip_line(e);
 if(!triangulate & !plot)
 {	printf("e %d", e->edgenbr);
-	printf(" %d ", e->ep[le] != (struct Site *)NULL ? e->ep[le]->sitenbr : -1);
-	printf("%d\n", e->ep[re] != (struct Site *)NULL ? e->ep[re]->sitenbr : -1);
-};
+	printf(" %d ", e->ep[le] != NULL ? e->ep[le]->sitenbr : -1);
+	printf("%d\n", e->ep[re] != NULL ? e->ep[re]->sitenbr : -1);
+}
 }
 
 void
-out_vertex(struct Site *v)
+out_vertex(Site *v)
 {
 if(!triangulate & !plot &!debug)
 	printf ("v %f %f\n", v->coord.x, v->coord.y);
@@ -56,7 +56,7 @@ if(debug)
 }
 
 void
-out_site(struct Site *s)
+out_site(Site *s)
 {
 if(!triangulate & plot & !debug)
 	circle (s->coord.x, s->coord.y, cradius);
@@ -70,18 +70,15 @@ if(debug)
 static int tp=0;
 
 void
-out_triple(
-struct Site *s1,
-struct Site *s2,
-struct Site *s3)
+out_triple(Site *s1, Site *s2, Site *s3)
 {
-  struct Triple *t;
+  Triple *t;
 
-  if (!tfl || tp==TALLOC) {
-    tfl=(struct Triple *)memmalloc(sizeof(struct Triple)*TALLOC);
+  if (!tfl || tp == TALLOC) {
+    tfl = (Triple*)memmalloc(sizeof(Triple) * TALLOC);
     tp=0;
   }
-  t=(struct Triple *)tfl+(tp++);
+  t = (Triple *)tfl + (tp++);
 
   t->next=triples;
   t->d.s1 = s1->sitenbr;
@@ -89,11 +86,10 @@ struct Site *s3)
   t->d.s3 = s3->sitenbr;
 
   triples = t;
-
 }
 
 void
-plotinit()
+plotinit(void)
 {
 float dx,dy,d;
 
@@ -110,9 +106,9 @@ range(pxmin, pymin, pxmax, pymax);
 }
 
 void
-clip_line(struct Edge *e)
+clip_line(Edge *e)
 {
-struct Site *s1, *s2;
+Site *s1, *s2;
 float x1,x2,y1,y2;
 
 	if(e -> a == 1.0 && e ->b >= 0.0)
@@ -122,52 +118,52 @@ float x1,x2,y1,y2;
 	else 
 	{	s1 = e -> ep[0];
 		s2 = e -> ep[1];
-	};
+	}
 
 	if(e -> a == 1.0)
 	{
 		y1 = pymin;
-		if (s1!=(struct Site *)NULL && s1->coord.y > pymin)
+		if (s1 != NULL && s1->coord.y > pymin)
 			 y1 = s1->coord.y;
 		if(y1>pymax) return;
 		x1 = e -> c - e -> b * y1;
 		y2 = pymax;
-		if (s2!=(struct Site *)NULL && s2->coord.y < pymax) 
+		if (s2 != NULL && s2->coord.y < pymax)
 			y2 = s2->coord.y;
 		if(y2<pymin) return;
 		x2 = e -> c - e -> b * y2;
 		if ((x1> pxmax & x2>pxmax) | (x1<pxmin&x2<pxmin)) return;
 		if(x1> pxmax)
-		{	x1 = pxmax; y1 = (e -> c - x1)/e -> b;};
+		{	x1 = pxmax; y1 = (e -> c - x1)/e -> b;}
 		if(x1<pxmin)
-		{	x1 = pxmin; y1 = (e -> c - x1)/e -> b;};
+		{	x1 = pxmin; y1 = (e -> c - x1)/e -> b;}
 		if(x2>pxmax)
-		{	x2 = pxmax; y2 = (e -> c - x2)/e -> b;};
+		{	x2 = pxmax; y2 = (e -> c - x2)/e -> b;}
 		if(x2<pxmin)
-		{	x2 = pxmin; y2 = (e -> c - x2)/e -> b;};
+		{	x2 = pxmin; y2 = (e -> c - x2)/e -> b;}
 	}
 	else
 	{
 		x1 = pxmin;
-		if (s1!=(struct Site *)NULL && s1->coord.x > pxmin) 
+		if (s1 != NULL && s1->coord.x > pxmin)
 			x1 = s1->coord.x;
 		if(x1>pxmax) return;
 		y1 = e -> c - e -> a * x1;
 		x2 = pxmax;
-		if (s2!=(struct Site *)NULL && s2->coord.x < pxmax) 
+		if (s2 != NULL && s2->coord.x < pxmax)
 			x2 = s2->coord.x;
 		if(x2<pxmin) return;
 		y2 = e -> c - e -> a * x2;
 		if ((y1> pymax & y2>pymax) | (y1<pymin&y2<pymin)) return;
 		if(y1> pymax)
-		{	y1 = pymax; x1 = (e -> c - y1)/e -> a;};
+		{	y1 = pymax; x1 = (e -> c - y1)/e -> a;}
 		if(y1<pymin)
-		{	y1 = pymin; x1 = (e -> c - y1)/e -> a;};
+		{	y1 = pymin; x1 = (e -> c - y1)/e -> a;}
 		if(y2>pymax)
-		{	y2 = pymax; x2 = (e -> c - y2)/e -> a;};
+		{	y2 = pymax; x2 = (e -> c - y2)/e -> a;}
 		if(y2<pymin)
-		{	y2 = pymin; x2 = (e -> c - y2)/e -> a;};
-	};
+		{	y2 = pymin; x2 = (e -> c - y2)/e -> a;}
+	}
 	
 	line(x1,y1,x2,y2);
 }

--- a/caltech-other/voronoi/src/voronoi.c
+++ b/caltech-other/voronoi/src/voronoi.c
@@ -9,17 +9,14 @@ extern "C" {
    Performance suffers if they are wrong; better to make nsites,
    deltax, and deltay too big than too small.  (?) */
 void
-voronoi(
-int triangulate,
-struct Site *(*nextsite)())
+voronoi(int triangulate, Site *(*nextsite)(void))
 {
-struct Site *newsite, *bot, *top, *temp, *p;
-struct Site *v;
-struct Point newintstar;
+Site *newsite, *bot, *top, *temp, *p;
+Site *v;
+Point newintstar;
 int pm;
-struct Halfedge *lbnd, *rbnd, *llbnd, *rrbnd, *bisector;
-struct Edge *e;
-
+Halfedge *lbnd, *rbnd, *llbnd, *rrbnd, *bisector;
+Edge *e;
 
 PQinitialize();
 bottomsite = (*nextsite)();
@@ -31,7 +28,7 @@ while(1)
 {
 	if(!PQempty()) newintstar = PQ_min();
 
-	if (newsite != (struct Site *)NULL 
+	if (newsite != NULL
 	   && (PQempty() 
 		 || newsite -> coord.y < newintstar.y
 	 	 || (newsite->coord.y == newintstar.y 
@@ -47,13 +44,13 @@ while(1)
 		if ((p = intersect(lbnd, bisector)) != NULL)
 		{	PQdelete(lbnd);
 			PQinsert(lbnd, p, dist(p,newsite));
-		};
+		}
 		lbnd = bisector;
 		bisector = HEcreate(e, re);
 		ELinsert(lbnd, bisector);
 		if ((p = intersect(bisector, rbnd)) != NULL)
 		{	PQinsert(bisector, p, dist(p,newsite));	
-		};
+		}
 		newsite = (*nextsite)();	
 	}
 	else if (!PQempty()) 
@@ -82,18 +79,18 @@ while(1)
 		if((p = intersect(llbnd, bisector)) != NULL)
 		{	PQdelete(llbnd);
 			PQinsert(llbnd, p, dist(p,bot));
-		};
+		}
 		if ((p = intersect(bisector, rrbnd)) != NULL)
 		{	PQinsert(bisector, p, dist(p,bot));
-		};
+		}
 	}
 	else break;
-};
+}
 
 for(lbnd=ELright(ELleftend); lbnd != ELrightend; lbnd=ELright(lbnd))
 	{	e = lbnd -> ELedge;
 		out_ep(e);
-	};
+	}
 }
 
 #if __cplusplus


### PR DESCRIPTION
 - typedef struct foo foo and then refer to just foo
 - () to (void)
 - Some space and newline changes but not huge/systematic.
 - Remove extern on functions, it is redundant.
 - unsigned long to size_t for hypothetical portability
   to more environments, mainly Win64; many would argue
   for uintptr_t but same thing really.
 - Remove semicolons after close braces.