### PR TITLE
m3core: Convert coroutine code to valid C++.

### DIFF
--- a/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.i3
+++ b/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.i3
@@ -31,7 +31,7 @@ PROCEDURE  GetCurrentCoroutine() : UNTRACED REF INTEGER;
 PROCEDURE  SetCurrentCoroutine(c : UNTRACED REF INTEGER);
 
 <*EXTERNAL ContextC__InitC*>
-PROCEDURE  InitC(); (* must call this before any of the other routines in this interface *)
+PROCEDURE  InitC(stack: ADDRESS); (* must call this before any of the other routines in this interface *)
 
 <*EXTERNAL ContextC__SetLink*>  
 PROCEDURE SetLink(tgt, src : T); (* set return link of tgt to be src *)

--- a/m3-libs/m3core/src/coroutine/UCONTEXT/CoroutineUcontext.m3
+++ b/m3-libs/m3core/src/coroutine/UCONTEXT/CoroutineUcontext.m3
@@ -481,6 +481,12 @@ PROCEDURE Cleanup(<*UNUSED*>READONLY self : WeakRef.T; ref : REFANY) =
 
 VAR DEBUG := RTParams.IsPresent("debugcoroutines");
 
+PROCEDURE Init() =
+VAR stack: INTEGER;
 BEGIN
-  ContextC.InitC()
+  ContextC.InitC(ADR(stack))
+END Init;
+
+BEGIN
+  Init()
 END CoroutineUcontext.


### PR DESCRIPTION
The function ContextC__PushContext is not convincing.
The memset is inefficient, and can be completely optimized away.
Intent is probably to do alloca(256) here.

Clean it up a little.

Try to accomodate stacks that grow up.
 i.e. HPPA, but that is not tested (I might have
 tested it long ago with the Posix threads).

include m3core.h
Use size_t instead of unsigned long; or rather, whatever m3core.h does
Fix mild printf problems %p vs. %lx.
Cast to correct pointer type instead of void*.

Do not use auto, at least under if cplusplus.
Add extern C (maybe some day remove it)