### PR TITLE
config: Undo AMD64_NT parallel back.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_NT
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_NT
@@ -7,6 +7,4 @@ M3_BACKEND_MODE = "C"
 % temporary workaround, some problem with our exception handling
 USE_MSVCRT = FALSE
 
-M3_PARALLEL_BACK = 20 % AMD64 machines usually have lots of cores
-
 include("NT.common")


### PR DESCRIPTION
I and another are getting sharing violations.
Investigate at a much later time or never.
(bulk cl will help, possibly with /MP)

This reverts ce2d23fdaf6743b2bc63db15a3bd68f48664d380