### PR TITLE
C backend setjmp work:

### DIFF
--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -130,6 +130,7 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
        Target-variation is to be reduced and is not any target-specific optimization here.
     *)
 
+    (* TODO aligned_procedures is long obsolete; remove *)
     Aligned_procedures := FALSE; (* Use the safe default for all targets. *)
 
     (* add the system-specific customization *)
@@ -180,9 +181,11 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
         Setjmp := "decc$setjmp";
     END;
 
-    IF System IN SET OF Systems{Systems.AMD64_NT} THEN
+    IF System IN SET OF Systems{Systems.AMD64_NT, Systems.ARM64_NT} THEN
          Setjmp := "setjmp";
     END;
+
+    (* TODO jumpbuf_size is long obsolete; remove *)
 
     CASE System OF
 


### PR DESCRIPTION
 - Avoid include setjmp.h unless call seen to setjmp, or
   less likely, longjmp. This should be a little faster.
 - Handle the VMS setjmp name.
 - Cast first parameter to setjmp tp *(jmpbuf*) to fix C++ compilation.
 - setjmp instead of _setjmp on nascent ARM64_NT
 - some comments

This enables the AMD64_LINUX system to be build using the C backend, compiled as C++.
The real problem being passing char* to setjmp.