### PR TITLE
caltech: More C++ fixes.

### DIFF
--- a/caltech-other/voronoi/src/defs.h
+++ b/caltech-other/voronoi/src/defs.h
@@ -11,9 +11,14 @@ extern "C" {
 
 extern int triangulate, sorted, plot, debug;
 
-
 extern float xmin, xmax, ymin, ymax, deltax, deltay;
 
+struct Edge;
+struct Halfedge;
+struct Point;
+struct Site;
+struct Triple;
+struct TripleArg;
 
 struct Point	{
 float x,y;


### PR DESCRIPTION
Forward declare structs so that function declarations do not introduce private structs.