### PR TITLE
Win64: Widen some UINT32 parameters to INTEGER.

### DIFF
--- a/m3-libs/m3core/src/win32/WinBase.i3
+++ b/m3-libs/m3core/src/win32/WinBase.i3
@@ -140,9 +140,12 @@ CONST
 
   MAILSLOT_WAIT_FOREVER: INT32 = -1;
 
-(* File structures *)
-
 TYPE
+
+(* Widen some parameters to INTEGER for convenience. *)
+  UINT32_ARG = INTEGER;
+
+(* File structures *)
   POVERLAPPED = UNTRACED REF OVERLAPPED;
   LPOVERLAPPED = POVERLAPPED; (* compat *)
   OVERLAPPED = RECORD
@@ -1229,10 +1232,10 @@ PROCEDURE GetCurrentProcess (): HANDLE;
 PROCEDURE GetCurrentProcessId (): UINT32;
 
 <*EXTERNAL ExitProcess:WINAPI*>
-PROCEDURE ExitProcess (uExitCode: UINT32);
+PROCEDURE ExitProcess (uExitCode: UINT32_ARG);
 
 <*EXTERNAL TerminateProcess:WINAPI*>
-PROCEDURE TerminateProcess (hProcess: HANDLE; uExitCode: UINT32): BOOL;
+PROCEDURE TerminateProcess (hProcess: HANDLE; uExitCode: UINT32_ARG): BOOL;
 
 <*EXTERNAL GetExitCodeProcess:WINAPI*>
 PROCEDURE GetExitCodeProcess (hProcess: HANDLE; lpExitCode: PUINT32): BOOL;

--- a/m3-libs/m3core/src/win32/WinSock.i3
+++ b/m3-libs/m3core/src/win32/WinSock.i3
@@ -15,10 +15,12 @@ FROM Ctypes IMPORT char_star, char_star_star, char, int;
 FROM WinBaseTypes IMPORT UINT8, UINT16, UINT32, INT16, INT32, PINT32, SIZE_T;
 FROM Word IMPORT Or, And, Shift, Not;
 
+TYPE
+
+(* Wide some parameters to INTEGER for convenience. *)
+  UINT32_ARG = INTEGER;
 
 (* Basic system type definitions, taken from the BSD file sys/types.h. *)
-
-TYPE
   u_char  = UINT8; (* compat *)
   u_short = UINT16; (* compat *)
   u_int   = UINT32; (* compat *)
@@ -574,7 +576,7 @@ PROCEDURE connect (
     s: SOCKET; addr: struct_sockaddr_star; namelen: INT32): INT32;
 
 <* EXTERNAL ioctlsocket:PASCAL *>
-PROCEDURE ioctlsocket (s: SOCKET; cmd: UINT32; argp: UNTRACED REF UINT32): INT32;
+PROCEDURE ioctlsocket (s: SOCKET; cmd: UINT32_ARG; argp: UNTRACED REF UINT32): INT32;
 
 <* EXTERNAL getpeername:PASCAL *>
 PROCEDURE getpeername (


### PR DESCRIPTION
Win64: Widen some UINT32 parameters to UINT32_ARG = INTEGER
so that 64bit systems can pass -1 or other seemingly invalid but acceptable values.
ExitProcess because people pass -1.
TerminateProcess because it is like ExitProcess.
And ioctlsocket because it has been a problem.
Quite possibly we want to do this more.

On NT/amd64 parameters are never passed in half registers,
or half stack positions. Always 64bits per parameter.
So this is safe.

It does not work for out pointer/var parameters however.

This fixes e.g.:

```
C:\s\cm3\scripts\python>boot1.py PA32_HPUX c
== package C:\s\cm3\m3-libs\m3core ==

 +++ C:\cm3\bin\cm3.exe  -DM3_BACKEND_MODE=C   -build -override -DROOT=C:/s/cm3 -boot -no-m3ship-resolution -group-writable -keep -DM3CC_TARGET=PA32_HPUX +++
--- building in PA32_HPUXc ---

missing version stamps -> compiling LongRealRep.i3
TIntLiteral:type=INT64 i=18442240474082181120 ok1=TRUE ok2=FALSE


***
*** runtime error:
***    <*ASSERT*> failed.
***    file "..\src\M3C.m3", line 4828
***
```
which is presumably correct some C backend bug on big endian target.

Instead of the previous, printing the same, but then:
```
*** runtime error:
***    An enumeration or subrange value was out of range.
***    file "..\src\runtime\WIN32\RTOS.m3", line 16
***
```
and a long run of repeating:
```
***
*** runtime error:
***    <*ASSERT*> failed.
***    file "..\src\thread\WIN32\ThreadWin32.m3", line 798
***
```
until stack overflow.

Because it calls `ExitProcess(-1)`, which seems ok, and works on the 32bit system.