### PR TITLE
Config: Fix Alpha VMS builds.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/VMS.common
+++ b/m3-sys/cminstall/src/config-no-install/VMS.common
@@ -1,4 +1,3 @@
-readonly TARGET_ENDIAN = "LITTLE"
 readonly TARGET_OS = "VMS"
 M3_MAIN_IN_C = TRUE
 


### PR DESCRIPTION
cd C:\s\cm3\m3-sys\cminstall\src\config-no-install

findstr TARGET_ENDIAN AL* vms*

Alpha32.common:readonly TARGET_ENDIAN = "LITTLE" % { "BIG" OR "LITTLE" }
Alpha64.common:readonly TARGET_ENDIAN = "LITTLE" % { "BIG" OR "LITTLE" }
ALPHA_OSF:readonly TARGET_ENDIAN = "LITTLE" % { "BIG" OR "LITTLE" }
VMS.common:readonly TARGET_ENDIAN = "LITTLE"

This fails because cannot write to readonly variable.
Quake should allow it, maybe, since writing the same value it already has.

But for now, just remove the last line.
Arguably it doesn't belong there, or even where it is.
Arguably it is a function of the root config, in case
of architectures like ARM, PowerPC, MIPS whose endianness varies.

Ideally we remove endian sensitivity from the system, really.