### PR TITLE
RISCV64_LINUX support.

### DIFF
--- a/m3-libs/libm3/src/os/POSIX/m3makefile
+++ b/m3-libs/libm3/src/os/POSIX/m3makefile
@@ -74,6 +74,7 @@ local readonly DefaultArch = {
     "MIPS64" : "mips64",
     "PPC": "ppc",
     "PPC64": "ppc64",
+    "RISCV64" : "riscv64",
     "SPARC" : "sparc",
     "SPARC64" : "sparc64",
     "VAX" : "vax",

--- a/m3-libs/m3core/src/runtime/POSIX/RTSignalC.c
+++ b/m3-libs/m3core/src/runtime/POSIX/RTSignalC.c
@@ -156,6 +156,8 @@ static WORD_T GetPC(void* xcontext)
 #elif defined(__s390__)
 #error untested __linux target
       context->uc_mcontext.sregs.regs.psw.addr
+#elif defined(__riscv) || defined(__riscv64)
+      context->uc_mcontext.__gregs[REG_PC]
 #else
 #error unknown __linux target
 #endif

--- a/m3-sys/cminstall/src/config-no-install/RISCV64.common
+++ b/m3-sys/cminstall/src/config-no-install/RISCV64.common
@@ -1,0 +1,6 @@
+readonly TARGET_ARCH = "RISCV64"
+readonly TARGET_ENDIAN = "LITTLE"   % { "BIG" OR "LITTLE" }
+readonly WORD_SIZE = "64BITS"       % { "32BITS" or "64BITS" }
+readonly M3_BACKEND_MODE = "C"
+
+M3_PARALLEL_BACK = 4

--- a/m3-sys/cminstall/src/config-no-install/RISCV64_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/RISCV64_LINUX
@@ -1,0 +1,8 @@
+readonly TARGET = "RISCV64_LINUX" % code generation target
+% readonly GNU_PLATFORM = "riscv64-linux" % "cpu-os" string for GNU
+
+readonly SYSTEM_CC = "g++ -g -fPIC" % C compiler
+readonly SYSTEM_ASM = "as" % Assembler
+
+include("RISCV64.common")
+include("Linux.common")

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -203,7 +203,8 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
 
     | Systems.ARM64_DARWIN,
       Systems.ARM64_LINUX,
-      Systems.ARM64_NT =>
+      Systems.ARM64_NT,
+      Systems.RISCV64_LINUX =>
                  EVAL 0;
 
     | Systems.ARM_LINUX,

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -381,7 +381,7 @@ def _GetAllTargets():
 
     for proc in ["ALPHA", "ALPHA32", "ALPHA64", "AMD64", "ARM", "ARMEL", "ARM64",
                  "IA64", "I386", "PPC", "PPC32", "PPC64", "SPARC", "SPARC32",
-                 "SPARC64", "MIPS32", "MIPS64EL", "MIPS64", "PA32", "PA64", "SH"]:
+                 "SPARC64", "MIPS32", "MIPS64EL", "MIPS64", "PA32", "PA64", "RISCV64", "SH"]:
         for os in ["AIX",  "CE", "CYGWIN", "DARWIN",  "FREEBSD", "HPUX", "INTERIX", "IRIX",
                    "LINUX", "MINGW", "NETBSD", "NT", "OPENBSD", "OSF", "SOLARIS", "VMS"]:
                    # "BEOS", "MSDOS" (DJGPP), "OS2" (EMX), "PLAN9"


### PR DESCRIPTION
System can build itself.
Using the C backend as usual.
If using qemu, you must use qemu-system, not merely qemu usermode/chroot/binfmt on top of native kernel, because of preemptive suspend. And this is much slower, alas.