### PR TITLE
m3middle: Make Aligned_procedures constant false.

### DIFF
--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -537,7 +537,7 @@ VAR (*CONST*)
   (* The C name of the routine used to capture the machine state in
        an exception handler frame. *)
 
-  Aligned_procedures: BOOLEAN;
+  CONST Aligned_procedures = FALSE;
   (* TRUE => all procedure values are aligned to at least Integer.align
      and can be safely dereferenced.  Otherwise, the code generated to
      test for nested procedures passed as parameters must be more


### PR DESCRIPTION
It was already always variable false.
There is a missed optimization here, but it is ok.