### PR TITLE
Include expressions in assertion failures.

### DIFF
--- a/m3-libs/libm3/src/sequence/m3makefile
+++ b/m3-libs/libm3/src/sequence/m3makefile
@@ -16,6 +16,7 @@ Generic_implementation("Sequence")
 template ("sequence")
 
 Sequence ("Atom", "Atom")
+Sequence ("Char", "Char")
 Sequence ("Int",  "Integer")
 Sequence ("Ref",  "Refany")
 Sequence ("Text", "Text")

--- a/m3-sys/m3front/src/misc/Scanner.i3
+++ b/m3-sys/m3front/src/misc/Scanner.i3
@@ -45,4 +45,8 @@ PROCEDURE Pop ();
 PROCEDURE Initialize ();
 PROCEDURE Reset ();
 
+(* Support for retrieving actual text. *)
+PROCEDURE EnableTextCapture();
+PROCEDURE DisableTextCapture(VAR text: REF ARRAY OF CHAR; VAR size: INTEGER);
+
 END Scanner.

--- a/m3-sys/m3tests/src/m3makefile
+++ b/m3-sys/m3tests/src/m3makefile
@@ -838,6 +838,7 @@ r_test ("r0", "r001", "unhandled exception")
 r_test ("r0", "r002", "stack overflow in the main thread")
 r_test ("r0", "r003", "b3tests/b002 - improper size for an open array parameter")
 r_test ("r0", "r004", "negative size for an open array")
+r_test ("r0", "r005", "assertion failure messages include expression")
 
 %------------------------------------------------------------------- etests ---
 % ERROR tests: modules containing static errors where the generated

--- a/m3-sys/m3tests/src/r0/r005/Main.m3
+++ b/m3-sys/m3tests/src/r0/r005/Main.m3
@@ -1,0 +1,5 @@
+MODULE Main;
+
+BEGIN
+  <*ASSERT 1 = 22*>
+END Main.

--- a/m3-sys/m3tests/src/r0/r005/m3makefile
+++ b/m3-sys/m3tests/src/r0/r005/m3makefile
@@ -1,0 +1,6 @@
+% Copyright (C) 1994, Digital Equipment Corporation.
+% All rights reserved.
+% See the file COPYRIGHT for a full description.
+ 
+implementation ("Main")
+include ("../../Test.common") 

--- a/m3-sys/m3tests/src/r0/r005/stderr.pgm
+++ b/m3-sys/m3tests/src/r0/r005/stderr.pgm
@@ -1,0 +1,8 @@
+
+
+***
+*** runtime error:
+***    <*ASSERT*> failed: 1 = 22 
+***    file "..\Main.m3", line 4
+***
+


### PR DESCRIPTION
Previously:
```
***
*** runtime error:
***    <*ASSERT*> failed.
***    file "..\Main.m3", line 4
***
```

Now:
```
***
*** runtime error:
***    <*ASSERT*> failed: 1 = 22
***    file "..\Main.m3", line 4
***
```

This is presently on unconditionally, but some configurability
and/or moving the text out of the program, might be desirable.

(This probably also breaks bootstrapping from existing libm3. New release should be issued.)