### PR TITLE
libm3: Move the OSF/Ultrix RefetchError hack into C.

### DIFF
--- a/m3-libs/libm3/src/os/POSIX/SocketPosix.i3
+++ b/m3-libs/libm3/src/os/POSIX/SocketPosix.i3
@@ -1,0 +1,10 @@
+INTERFACE SocketPosix;
+
+(* Move this hack to C so ifdef is there and C backend
+ * output is platform-independent.
+ *
+ * This is an OSF/Ultrix hack so hardly worth anything.
+ *)
+<*EXTERNAL "SocketPosix__RefetchError"*> PROCEDURE RefetchError(fd: INTEGER);
+
+END SocketPosix.

--- a/m3-libs/libm3/src/os/POSIX/SocketPosix.m3
+++ b/m3-libs/libm3/src/os/POSIX/SocketPosix.m3
@@ -1,16 +1,16 @@
 (* Copyright 1996-2000, Critical Mass, Inc.  All rights reserved. *)
 (* See file COPYRIGHT-CMASS for details. *)
 
-UNSAFE MODULE SocketPosix EXPORTS Socket;
+UNSAFE MODULE SocketPosix EXPORTS Socket, SocketPosix;
 
-IMPORT Atom, AtomList, SocketPosix_IsUltrixOrOSF, File, FilePosix;
+IMPORT Atom, AtomList, File, FilePosix;
 IMPORT OSError, OSErrorPosix, SchedulerPosix, Thread;
 IMPORT Uuio, Ustat, Word;
 FROM Cerrno IMPORT GetErrno;
 FROM Unetdb IMPORT struct_hostent, struct_hostent_star, gethostbyname;
 FROM Ctypes IMPORT int, char, char_star;
 FROM Usocket IMPORT accept, AF_INET, bind, connect, getpeername, getsockname,
-                    getsockopt, listen, MSG_PEEK, recvfrom, sendto, setsockopt,
+                    listen, MSG_PEEK, recvfrom, sendto, setsockopt,
                     SO_LINGER, SO_REUSEADDR, SOCK_DGRAM, SOCK_STREAM, socket,
                     SOL_SOCKET, struct_linger, socklen_t;
 FROM Uin IMPORT IPPROTO_TCP, ntohs, htons, struct_in_addr, struct_sockaddr_in;
@@ -470,18 +470,6 @@ PROCEDURE MakeNonBlocking (fd: INTEGER)
       IOError (Unexpected);
     END;
   END MakeNonBlocking;
-
-PROCEDURE RefetchError(fd: INTEGER) =
-(* Awful hack to retrieve a meaningful error from a TCP accept
-   socket.  Only works on Ultrix and OSF.  Leaves result
-   in GetError().  *)
-  VAR optbuf: int := 0;   optlen: socklen_t := BYTESIZE(optbuf);
-  BEGIN
-    IF SocketPosix_IsUltrixOrOSF.Value THEN
-      EVAL getsockopt (fd, IPPROTO_TCP, TCP_NODELAY,
-                       ADR(optbuf), ADR(optlen));
-    END;
-  END RefetchError;
 
 PROCEDURE IOError (a: Atom.T) RAISES {OSError.E} =
   VAR ec: AtomList.T := NIL;

--- a/m3-libs/libm3/src/os/POSIX/m3makefile
+++ b/m3-libs/libm3/src/os/POSIX/m3makefile
@@ -18,7 +18,8 @@ Module("FilePosix")
 implementation("FSPosix")
 implementation("PipePosix")
 implementation("PathnamePosix")
-implementation("SocketPosix")
+module("SocketPosix")
+c_source("SocketPosixC")
 implementation("OSConfigPosix")
 
 module("ProcessPosixCommon")
@@ -92,11 +93,5 @@ end
 
 MakeInterfaceForConstant("OSConfigPosix_DefaultOSName", "\"" & DefaultOSName{TARGET_OS} & "\"")
 MakeInterfaceForConstant("OSConfigPosix_DefaultArch", "\"" & DefaultArch{TARGET_ARCH} & "\"")
-
-if equal(TARGET, "ALPHA_OSF") or equal(TARGET, "DS3100")  	 
-  MakeInterfaceForConstant("SocketPosix_IsUltrixOrOSF", "TRUE") 	 
-else 	 
-  MakeInterfaceForConstant("SocketPosix_IsUltrixOrOSF", "FALSE") 	 
-end
  
 end


### PR DESCRIPTION
libm3: Move the OSF/Ultrix RefetchError hack into ifdef'ed C, in order to converge on identical C code for all targets. (or at least cut the matrix to small). We should probably just cut support for these very old systems.