### PR TITLE
m3core: Remove declaration of gai_strerror.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Unetdb.i3
+++ b/m3-libs/m3core/src/unix/Common/Unetdb.i3
@@ -76,7 +76,4 @@ PROCEDURE getnameinfo(addr : (*const*) UNTRACED REF Uin.struct_sockaddr;
                       servlen : socklen_t;
                       flags : int) : int ;
 
-<*EXTERNAL*>
-PROCEDURE gai_strerror(err : int) : char_star;
-
 END Unetdb.


### PR DESCRIPTION
It is not used.
It is not thread safe on Windows (it is a small inline
function in the headers, that can be copy/pasted and fixed).
Any future use imho should be in C, not Modula-3.
i.e. Prefer to stop rewriting /usr/include.
Also this declaration might not work on Windows.
It looks correct, but the function is inline in .h files,
so might not link.