### PR TITLE
import-libs: Remove from scripts and make building it just print a warning.

### DIFF
--- a/m3-win/import-libs/src/m3makefile
+++ b/m3-win/import-libs/src/m3makefile
@@ -1,3 +1,8 @@
+write("WARNING: import-libs is of historical interest only,\n")
+write("WARNING: for use with very old CM3 and/or lacking a Windows SDK.\n")
+
+if FALSE
+
 % Jay Krell
 % jay.krell@cornell.edu
 % October 18, 2006 in Windows cmd
@@ -299,4 +304,6 @@ if not equal(M3_MODE, "clean")
     > ".M3WEB" in 
       write("")
     end
+end
+
 end

--- a/scripts/all-deps
+++ b/scripts/all-deps
@@ -1,5 +1,4 @@
 
-m3-win/import-libs import-libs: 
 m3-sys/m3cc m3cc: 
 m3-libs/m3core m3core: 
 m3-libs/libm3 libm3: m3core

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -346,7 +346,7 @@ EOF
           fi
         done
       fi
-      if [ "$b" != "import-libs" -a "$b" != "m3cc" -a "$b" != "m3gdb" ]; then
+      if [ "$b" != "m3cc" -a "$b" != "m3gdb" ]; then
         echo "<a href=\"http://www.opencm3.net/doc/help/gen_html/${b}/INDEX.html\">Browse Sources Online</a><br>"
       fi
       for section in 1 5 6 7 8; do

--- a/scripts/pkginfo.txt
+++ b/scripts/pkginfo.txt
@@ -1,4 +1,3 @@
-import-libs base core front unicode min gui comm caltech-parser caltech-other
 m3core base core front unicode min
 libm3 base core front unicode min
 windowsResources core

--- a/scripts/win/upgrade.cmd
+++ b/scripts/win/upgrade.cmd
@@ -8,7 +8,6 @@
 @if defined CM3 set CM3=
 
 @set p_runtime=^
- import-libs ^
  m3core ^
  libm3
 
@@ -28,7 +27,7 @@ call %~dp0do-cm3-core realclean || exit /b 1
 @echo on
 
 @call :header building just new compiler with old compiler (old compiler cannot necessarily build new runtime)
-call %~dp0do-pkg buildship import-libs %p_compiler% || exit /b 1
+call %~dp0do-pkg buildship %p_compiler% || exit /b 1
 @echo on
 
 @call :header installing new compiler


### PR DESCRIPTION
It could be fully deleted.