### PR TITLE
m3core: It is mildly useful to depend on error values to be non-zero.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Uconstants.c
+++ b/m3-libs/m3core/src/unix/Common/Uconstants.c
@@ -714,11 +714,10 @@ Y(SF_SNAPSHOT, 0)
 #endif
 
 #undef X
-#define X(x) EXTERN_CONST int Unetdb__##x = x;
+#define X(x) M3_STATIC_ASSERT(x); EXTERN_CONST int Unetdb__##x = x;
 X(TRY_AGAIN)
 X(NO_RECOVERY)
 X(NO_ADDRESS)
-
 
 #undef X
 #define X(x) EXTERN_CONST int Uin__##x = x;


### PR DESCRIPTION
Static assert it for a few.