### PR TITLE
m3-comm: Move TCPHack from Modula-3 to ifdefed C.

### DIFF
--- a/m3-comm/tcp/src/POSIX/TCPHack.m3
+++ b/m3-comm/tcp/src/POSIX/TCPHack.m3
@@ -2,6 +2,8 @@
 (* Distributed only by permission. *)
 (* Created on Sat Jan 11 15:49:00 PST 1992 by wobber *)
 
+(* This has been moved to TCPHackC.c.
+
 UNSAFE MODULE TCPHack;
 
 IMPORT Uin, Usocket;
@@ -18,3 +20,5 @@ PROCEDURE RefetchError(fd: INTEGER): BOOLEAN =
 
 BEGIN
 END TCPHack.
+
+*)

--- a/m3-comm/tcp/src/POSIX/TCPHackC.c
+++ b/m3-comm/tcp/src/POSIX/TCPHackC.c
@@ -1,0 +1,57 @@
+/* Copyright 1994 Digital Equipment Corporation.
+/* Distributed only by permission. */
+/* Created on Sat Jan 11 15:49:00 PST 1992 by wobber */
+
+// TODO Just delete this old code? All the copies?
+// git grep RefetchError
+
+#include "m3core.h"
+#ifndef _WIN32
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#else
+#include <winsock2.h>
+#include <stdlib.h>
+#endif
+
+#define TRUE 1
+#define FALSE 0
+
+/* https://github.com/natefoo/predef/wiki/OperatingSystems */
+#if defined(ULTRIX)     || \
+    defined(ultrix)     || \
+    defined(__ultrix)   || \
+    defined(__ultrix__) || \
+    defined(__osf__)    || \
+    defined(__osf)
+static const char refetchError = TRUE;
+#else
+static const char refetchError;
+#endif
+
+#define RefetchError TCPHack__RefetchError
+
+int
+__cdecl
+RefetchError(INTEGER fd);
+
+int
+__cdecl
+RefetchError(INTEGER fd)
+{
+    if (refetchError)
+    {
+        int optbuf = 0;
+        socklen_t optlen = sizeof(optbuf);
+
+        return getsockopt((int)fd, IPPROTO_TCP, TCP_NODELAY, &optbuf, &optlen) >= 0;
+    }
+    else
+    {
+        return FALSE;
+    }
+}

--- a/m3-comm/tcp/src/POSIX/TCPHackNull.m3
+++ b/m3-comm/tcp/src/POSIX/TCPHackNull.m3
@@ -2,6 +2,8 @@
 (* Distributed only by permission. *)
 (* Created on Sat Jan 11 15:49:00 PST 1992 by wobber *)
 
+(* This has been moved to TCPHackC.c.
+
 UNSAFE MODULE TCPHackNull EXPORTS TCPHack;
 
 PROCEDURE RefetchError(<*UNUSED*> fd: INTEGER): BOOLEAN =
@@ -11,3 +13,5 @@ PROCEDURE RefetchError(<*UNUSED*> fd: INTEGER): BOOLEAN =
 
 BEGIN
 END TCPHackNull.
+
+*)

--- a/m3-comm/tcp/src/POSIX/m3makefile
+++ b/m3-comm/tcp/src/POSIX/m3makefile
@@ -12,9 +12,4 @@ implementation("TCP")
 implementation("TCPExtras")
 implementation("TCPPeer")
 interface("TCPHack")
-
-if equal (TARGET, "ALPHA_OSF") or equal(TARGET, "DS3100")
-   implementation("TCPHack")
-else
-   implementation("TCPHackNull")
-end
+c_source("TCPHackC")

--- a/m3-libs/libm3/src/os/POSIX/SocketPosixC.c
+++ b/m3-libs/libm3/src/os/POSIX/SocketPosixC.c
@@ -1,6 +1,9 @@
 /* Copyright 1996-2000, Critical Mass, Inc.  All rights reserved. */
 /* See file COPYRIGHT-CMASS for details. */
 
+// TODO Just delete this old code? All the copies?
+// git grep RefetchError
+
 #include "m3core.h"
 #ifndef _WIN32
 #include <sys/types.h>
@@ -24,9 +27,9 @@
     defined(__ultrix__) || \
     defined(__osf__)    || \
     defined(__osf)
-static char refetchError = TRUE;
+static const char refetchError = TRUE;
 #else
-static char refetchError = FALSE;
+static const char refetchError;
 #endif
 
 #define RefetchError SocketPosix__RefetchError
@@ -613,7 +616,9 @@ static void MakeNonBlocking(int fd)
 
 #endif
 
-void RefetchError(INTEGER fd)
+void
+__cdecl
+RefetchError(INTEGER fd)
 {
   if (refetchError)
   {


### PR DESCRIPTION
This is OSF/1 and Ultrix specific code, that can/should probably just be deleted.
(If you want to run MIPS or Alpha, try another OS.)