### PR TITLE
m3core.h: Add __try/__finally macros that do nothing for non-msc.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -171,6 +171,11 @@
 #define __cdecl /* nothing */
 #endif
 
+#ifndef _MSC_VER
+#define __try /* nothing */
+#define __finally /* nothing */
+#endif
+
 #ifdef __cplusplus
 #define M3_EXTERN_C         extern "C"
 #define M3_EXTERN_C_BEGIN   extern "C" {


### PR DESCRIPTION
These might be useful in future.
I was going to use them, but then decided to limit C interaction
with traced references, lest barriers are needed. i.e. with mutexes.