### PR TITLE
AMD64_NT: Switch from libcmt.lib to C runtime .dll by default.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_NT
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_NT
@@ -4,7 +4,4 @@ readonly WORD_SIZE = "64BITS"       % { "32BITS" or "64BITS" }
 
 M3_BACKEND_MODE = "C"
 
-% temporary workaround, some problem with our exception handling
-USE_MSVCRT = FALSE
-
 include("NT.common")


### PR DESCRIPTION
We should remove libcmt.lib support by now, since it was
just an ancient aberrant toolset that lacked C runtime .dll,
and some bug workaround here, that I never debugged, just
tried it again and it worked.