### PR TITLE
caltech: Remove duplicate SeqChar since I did this

### DIFF
--- a/caltech-parser/cit_util/src/m3makefile
+++ b/caltech-parser/cit_util/src/m3makefile
@@ -200,7 +200,6 @@ List("Bool","Boolean")
 
 Module("Cardinal")
 Sequence("Card","Cardinal")
-Sequence("Char","Char")
 
 Module("IntForRat")
 Module("BigInt")


### PR DESCRIPTION
this in libm3 too. This highlights Modula-3 generic
deficiencies vs. C++ alas.