### PR TITLE
Config: gcc/gdb -gstabs and -gstabs+ is buggy.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/ALPHA_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/ALPHA_LINUX
@@ -1,7 +1,7 @@
 readonly TARGET = "ALPHA_LINUX" % code generation target
 readonly GNU_PLATFORM = "alpha-linux" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -fPIC" % C compiler
+SYSTEM_CC = "g++ -g -fPIC" % C compiler
 readonly SYSTEM_ASM = "as" % Assembler
 
 include("Alpha64.common")

--- a/m3-sys/cminstall/src/config-no-install/ALPHA_OPENBSD
+++ b/m3-sys/cminstall/src/config-no-install/ALPHA_OPENBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "ALPHA_OPENBSD" % code generation target
 readonly GNU_PLATFORM = "alpha-openbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -fPIC" % C compiler
+SYSTEM_CC = "g++ -g -fPIC" % C compiler
 readonly SYSTEM_ASM = "as" % Assembler
 
 % Guessing similar to Darwin and HP-UX after default and -g failed.

--- a/m3-sys/cminstall/src/config-no-install/AMD64_FREEBSD
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_FREEBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "AMD64_FREEBSD"
 readonly GNU_PLATFORM = "amd64-freebsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -m64 -fPIC"
+SYSTEM_CC = "g++ -g -m64 -fPIC"
 readonly SYSTEM_ASM = "as -64"
 
 include("AMD64.common")

--- a/m3-sys/cminstall/src/config-no-install/AMD64_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_LINUX
@@ -1,8 +1,8 @@
 readonly TARGET = "AMD64_LINUX" % code generation target
 readonly GNU_PLATFORM = "amd64-linux" % "cpu-os" string for GNU
 
-SYSTEM_CC = "gcc -gstabs+ -m64 -fPIC" % C compiler
-SYSTEM_CXXC = "g++ -gstabs+ -m64 -fPIC" % C++ compiler
+SYSTEM_CC = "gcc -g -m64 -fPIC" % C compiler
+SYSTEM_CXXC = "g++ -g -m64 -fPIC" % C++ compiler
 
 readonly SYSTEM_ASM = "as --64" % Assembler
 

--- a/m3-sys/cminstall/src/config-no-install/AMD64_NETBSD
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_NETBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "AMD64_NETBSD"
 readonly GNU_PLATFORM = "amd64-netbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -m64 -fPIC"
+SYSTEM_CC = "g++ -g -m64 -fPIC"
 SYSTEM_LD = SYSTEM_CC & " -Wl,-z,now"
 readonly SYSTEM_ASM = "as -64"
 

--- a/m3-sys/cminstall/src/config-no-install/AMD64_OPENBSD
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_OPENBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "AMD64_OPENBSD"
 readonly GNU_PLATFORM = "amd64-openbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -m64 -fPIC"
+SYSTEM_CC = "g++ -g -m64 -fPIC"
 readonly SYSTEM_ASM = "as -64"
 
 include("AMD64.common")

--- a/m3-sys/cminstall/src/config-no-install/ARM_LINUX.common
+++ b/m3-sys/cminstall/src/config-no-install/ARM_LINUX.common
@@ -1,6 +1,6 @@
 readonly GNU_PLATFORM = "arm-linux-gnueabihf" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -fPIC" % C compiler
+SYSTEM_CC = "g++ -g -fPIC" % C compiler
 SYSTEM_ASM = "as" % Assembler
 % SYSTEM_CC = GNU_PLATFORM & "-" & SYSTEM_CC
 % SYSTEM_CC = GNU_PLATFORM & "-" & SYSTEM_ASM

--- a/m3-sys/cminstall/src/config-no-install/Darwin.common
+++ b/m3-sys/cminstall/src/config-no-install/Darwin.common
@@ -94,10 +94,6 @@ proc configure_c_compiler() is
   %
   % Clang assembler gives warnings for -fPIC, which appears meaningless (review for arm/arm64).
   %
-  % -gstabs+ does not work on Mac OSX.
-  %
-
-  %SYSTEM_CC = "gcc -gstabs+ -fPIC"
   %SYSTEM_CC = "gcc -g -fPIC"
   SYSTEM_CC = "g++ -g -fPIC"
   SYSTEM_CC = SYSTEM_CC & " -Wall"

--- a/m3-sys/cminstall/src/config-no-install/I386_FREEBSD.common
+++ b/m3-sys/cminstall/src/config-no-install/I386_FREEBSD.common
@@ -20,7 +20,7 @@ proc configure_c_compiler() is
   % gcc -c -m32 -x c /dev/null
   % cc1: Invalid option `32'
 
-  SYSTEM_CC = "g++ -gstabs+ -fPIC"
+  SYSTEM_CC = "g++ -g -fPIC"
   if defined("FREEBSD_LD_CC_APPEND")
     SYSTEM_CC = SYSTEM_CC & FREEBSD_LD_CC_APPEND
   end

--- a/m3-sys/cminstall/src/config-no-install/I386_LINUX.common
+++ b/m3-sys/cminstall/src/config-no-install/I386_LINUX.common
@@ -1,6 +1,6 @@
 readonly GNU_PLATFORM = "i686-linux" % "cpu-os" string for GNU
 
-SYSTEM_CC = "@g++ -gstabs+ -m32 -fPIC" % C compiler
+SYSTEM_CC = "@g++ -g -m32 -fPIC" % C compiler
 readonly SYSTEM_ASM = "@as --32" % Assembler
 
 include("I386.common")

--- a/m3-sys/cminstall/src/config-no-install/I386_NETBSD
+++ b/m3-sys/cminstall/src/config-no-install/I386_NETBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "I386_NETBSD"
 readonly GNU_PLATFORM = "i686-netbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -m32 -fPIC"
+SYSTEM_CC = "g++ -g -m32 -fPIC"
 SYSTEM_LD = SYSTEM_CC & " -Wl,-z,now"
 readonly SYSTEM_ASM = "as -32"
 

--- a/m3-sys/cminstall/src/config-no-install/I386_OPENBSD
+++ b/m3-sys/cminstall/src/config-no-install/I386_OPENBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "I386_OPENBSD"
 readonly GNU_PLATFORM = "i686-openbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -m32 -fPIC"
+SYSTEM_CC = "g++ -g -m32 -fPIC"
 readonly SYSTEM_ASM = "as -32"
 
 include("I386.common")

--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -721,7 +721,7 @@ proc compile_c_gnu(source, object, options, optimize, debug) is
     if M3_PROFILING
         args += "-pg"
     end
-    return try_exec("@g++", "-gstabs+", escape(subst_chars(args, "\\", "/")), "-c", subst_chars(source, "\\", "/"), "-o", object)
+    return try_exec("@g++", "-g", escape(subst_chars(args, "\\", "/")), "-c", subst_chars(source, "\\", "/"), "-o", object)
 end
 
 proc compile_c(source, object, options, optimize, debug) is
@@ -922,7 +922,7 @@ proc make_dll_gnu(options, objects, imported_libs, lib_file, def_file, dll_file,
 
     return try_exec(
             "@g++",
-            "-gstabs+",
+            "-g",
             %"-v",
             "-shared", % must be visible to compiler
             "-Wl,"
@@ -1274,7 +1274,7 @@ proc m3_link_gnu(prog, options, objects, imported_libs, shared, pgm_file, listin
 
     return try_exec(
             "@g++",
-            "-gstabs+",
+            "-g",
             %"-v",
             "-Wl,"
                 & WriteResponseFile(

--- a/m3-sys/cminstall/src/config-no-install/PA32_HPUX
+++ b/m3-sys/cminstall/src/config-no-install/PA32_HPUX
@@ -7,7 +7,7 @@ readonly GNU_PLATFORM = "hppa-hpux" % "cpu-os" string for GNU
 % -mpa-risc-2-0 substitutes for -m32?
 %
 m3back_m32 = "-mpa-risc-2-0"
-SYSTEM_CC = "/usr/local/32/bin/g++ -fPIC -gstabs+ -mpa-risc-2-0" % C compiler
+SYSTEM_CC = "/usr/local/32/bin/g++ -fPIC -g -mpa-risc-2-0" % C compiler
 if not defined("SYSTEM_ASM")
   readonly SYSTEM_ASM = "/usr/local/32/bin/gas" % Assembler
 end

--- a/m3-sys/cminstall/src/config-no-install/PPC32_OPENBSD
+++ b/m3-sys/cminstall/src/config-no-install/PPC32_OPENBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "PPC32_OPENBSD"
 readonly GNU_PLATFORM = "powerpc-openbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -gstabs+ -fPIC"
+SYSTEM_CC = "g++ -g -fPIC"
 readonly SYSTEM_ASM = "as"
 
 m3back_pic = "-fpic" % -fPIC does not work, though it ought to

--- a/m3-sys/cminstall/src/config-no-install/PPC_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/PPC_LINUX
@@ -1,7 +1,7 @@
 readonly TARGET = "PPC_LINUX"     % code generation target
 readonly GNU_PLATFORM = "powerpc-linuxelf" % "cpu-os" string for GNU
 
-SYSTEM_CC = "@g++ -gstabs+ -m32 -fPIC" % C compiler
+SYSTEM_CC = "@g++ -g -m32 -fPIC" % C compiler
 readonly SYSTEM_ASM = "@as" % Assembler
 
 % PIE debugging requires gdb 7.1 or newer, even for C

--- a/m3-sys/cminstall/src/config-no-install/SPARC32_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/SPARC32_LINUX
@@ -1,7 +1,7 @@
 readonly TARGET = "SPARC32_LINUX" % code generation target
 readonly GNU_PLATFORM = "sparc-linux" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -m32 -mcpu=v9 -fPIC -mno-app-regs -gstabs+" % C compiler
+SYSTEM_CC = "g++ -m32 -mcpu=v9 -fPIC -mno-app-regs -g" % C compiler
 SYSTEM_ASM = "as -Qy -s -KPIC -Av9a -32 -relax" % Assembler
 
 include("SPARC.common")

--- a/m3-sys/cminstall/src/config-no-install/SPARC64_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/SPARC64_LINUX
@@ -1,7 +1,7 @@
 readonly TARGET = "SPARC64_LINUX"
 readonly GNU_PLATFORM = "sparc64-linux" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -m64 -fPIC -mno-app-regs -gstabs+" % C compiler
+SYSTEM_CC = "g++ -m64 -fPIC -mno-app-regs -g" % C compiler
 SYSTEM_ASM = "as -Qy -s -KPIC -Av9a -64 -no-undeclared-regs -relax" % Assembler
 
 include("SPARC64.common")

--- a/m3-sys/cminstall/src/config-no-install/SPARC64_OPENBSD
+++ b/m3-sys/cminstall/src/config-no-install/SPARC64_OPENBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "SPARC64_OPENBSD"
 readonly GNU_PLATFORM = "sparc64-openbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -m64 -fPIC -mno-app-regs -gstabs+" % C compiler
+SYSTEM_CC = "g++ -m64 -fPIC -mno-app-regs -g" % C compiler
 SYSTEM_ASM = "as -Qy -s -KPIC -Av9a -64 -no-undeclared-regs -relax" % Assembler
 
 include("SPARC64.common")

--- a/m3-sys/cminstall/src/config-no-install/Solaris.common
+++ b/m3-sys/cminstall/src/config-no-install/Solaris.common
@@ -96,7 +96,7 @@ end
 
 if equal (C_COMPILER, "GNU")
     if not defined("SYSTEM_CC")
-        SYSTEM_CC = "/usr/sfw/bin/g++ -gstabs+ -fPIC -pthreads -m" & WordSize
+        SYSTEM_CC = "/usr/sfw/bin/g++ -g -fPIC -pthreads -m" & WordSize
     end
 end
 

--- a/m3-sys/cminstall/src/config/FreeBSD3
+++ b/m3-sys/cminstall/src/config/FreeBSD3
@@ -294,7 +294,7 @@ M3_BACKEND_MODE = "3"
 proc compile_c (source, object, options, optimize, debug) is
   local args = [ "-fpic", options ]
   if optimize  args += "-O"  end
-  if debug     args += "-gstabs"  end
+  if debug     args += "-g"  end
   if M3_PROFILING args += "-pg" end
   return try_exec ("@" & SYSTEM_CC, args, "-c", source)
 end

--- a/m3-sys/cminstall/src/config/HPPA
+++ b/m3-sys/cminstall/src/config/HPPA
@@ -282,7 +282,7 @@ proc compile_c (source, object, options, optimize, debug) is
   %%PIC local args = [ "+z", options ]  % +Z => -fpic for cc
   local args = [ options, "-Dalloca=malloc" ]
   if optimize  args += "-O"  end
-  if debug     args += "-gstabs"  end
+  if debug     args += "-g"  end
   return try_exec ("@" & SYSTEM_CC, args, "-c", source)
 end
 
@@ -290,7 +290,7 @@ end
 % proc compile_c (source, object, options, optimize, debug) is
 %   local args = [ "-fPIC", "-z", options ] % gcc
 %   if optimize  args += "-O"  end
-%   if debug     args += "-gstabs"  end
+%   if debug     args += "-g"  end
 %   return try_exec ("@" & SYSTEM_CC, args, "-c", source)
 % end
 
@@ -454,6 +454,6 @@ end
 %
 
 GNU_CC     = "gcc"
-GNU_CFLAGS = "-gstabs"
+GNU_CFLAGS = "-g"
 GNU_MAKE   = "/usr/local/gnu/bin/make"
 

--- a/m3-sys/cminstall/src/config/IBMR2
+++ b/m3-sys/cminstall/src/config/IBMR2
@@ -306,7 +306,7 @@ M3_BACKEND_MODE = "3"
 proc compile_c (source, object, options, optimize, debug) is
   local args = [ "-w", options ]
   if optimize  args += "-O"  end
-  if debug     args += "-gstabs"  end
+  if debug     args += "-g"  end
   return try_exec ("@" & SYSTEM_CC, args, "-c", source)
 end
 

--- a/m3-sys/cminstall/src/config/IRIX5
+++ b/m3-sys/cminstall/src/config/IRIX5
@@ -257,7 +257,7 @@ M3_BACKEND_MODE = "3"
 proc compile_c (source, object, options, optimize, debug) is
   local args = [ "-Dvfork=fork", "-cckr", options ]
   if optimize  args += "-O2"  end
-  if debug     args += "-gstabs"  end
+  if debug     args += "-g"  end
   return try_exec ("@" & SYSTEM_CC, args, "-c", source)
 end
 

--- a/m3-sys/cminstall/src/config/LINUXELF
+++ b/m3-sys/cminstall/src/config/LINUXELF
@@ -263,7 +263,7 @@ M3_BACKEND_MODE = "3"
 proc compile_c (source, object, options, optimize, debug) is
   local args = [ "-fPIC", options ]
   if optimize  args += "-O"  end
-  if debug     args += "-gstabs"  end
+  if debug     args += "-g"  end
   return try_exec ("@" & SYSTEM_CC, args, "-c", source)
 end
 

--- a/m3-sys/cminstall/src/config/SPARC
+++ b/m3-sys/cminstall/src/config/SPARC
@@ -272,7 +272,7 @@ M3_BACKEND_MODE = "3"
 proc compile_c (source, object, options, optimize, debug) is
   local args = [ "-PIC", options ]
   if optimize  args += "-O"  end
-  if debug     args += "-gstabs"  end
+  if debug     args += "-g"  end
   return try_exec ("@" & SYSTEM_CC, args, "-c", source)
 end
 


### PR DESCRIPTION
Config: gcc/gdb -gstabs and -gstabs+ is buggy.
 gdb shows incorrect information.
Use plain -g for compiling C.
This does not change m3cc/cm3cg command lines.
This does change linking command lines, but it does not appear to matter.
-gstabs was never really well motivated here anyway.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99457