### PR TITLE
m3middle: Make All_floats_legal constant true instead of variable.

### DIFF
--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -551,11 +551,14 @@ VAR (*CONST*)
        a small offset.
     *)
 
-VAR (*CONST*)
   (* floating point values *)
-  All_floats_legal : BOOLEAN;
+  All_floats_legal = TRUE;
   (* If all bit patterns are "legal" floating point values (i.e. they can
-     be assigned without causing traps or faults). *)
+   * be assigned without causing traps or faults).
+   * This is true for all targets except VAX.
+   *)
+
+VAR (*CONST*)
 
   Has_stack_walker: BOOLEAN;
   (* TRUE => generate PC-tables for exception scopes.  Otherwise, generate

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -67,7 +67,6 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     (* this is overly optimistic... *)
 
     Allow_packed_byte_aligned := FALSE;
-    All_floats_legal          := TRUE;
     Little_endian             := TRUE;
 
     IF backend_mode = M3BackendMode_t.C THEN


### PR DESCRIPTION
This breaks only VAX, and leave a comment as such.