### PR TITLE
m3middle: For C backend only, make Allow_packed_byte_aligned constant false.

### DIFF
--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -118,10 +118,11 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
       Little_endian := FALSE;
     END;
 
-    (* x86 and AMD64 allow unaligned loads/stores *)
-
-    IF IsX86() OR IsAMD64() THEN
-      Allow_packed_byte_aligned := TRUE;
+    (* x86 and AMD64 allow unaligned loads/stores but converge C *)
+    IF backend_mode # M3BackendMode_t.C THEN
+      IF IsX86() OR IsAMD64() THEN
+        Allow_packed_byte_aligned := TRUE;
+      END;
     END;
 
     InitCallingConventions (backend_mode,


### PR DESCRIPTION
This does not affect m3cc, llvm, or integrated backend.
Though that isn't a bad idea.