### PR TITLE
m3front: Remove <*LazyAlign*> and <*StrictAlign*>

### DIFF
--- a/m3-sys/m3front/src/values/Decl.m3
+++ b/m3-sys/m3front/src/values/Decl.m3
@@ -70,11 +70,13 @@ PROCEDURE Parse (interface, top_level: BOOLEAN;  VAR fails: M3.ExSet) =
           GetToken (); (* convention name *)
           Match (TK.tENDPRAGMA);
       | TK.tLAZYALIGN =>
+          Error.Msg ("<*LazyAlign*> is no longer supported");
           att.isLazyAligned := TRUE;
           Module.SetLazyAlignment (TRUE);
           GetToken (); (* LAZYALIGN *)
           Match (TK.tENDPRAGMA);
       | TK.tSTRICTALIGN =>
+          Error.Msg ("<*StrictAlign*> is no longer supported");
           att.isLazyAligned := FALSE;
           Module.SetLazyAlignment (FALSE);
           GetToken (); (* LAZYALIGN *)


### PR DESCRIPTION
Along with, I think Allow_packed_byte_aligned,
they threaten to induce gratituitous target-specific layout.
They are not used anywhere in-tree and I am told they are not needed.

This change makes them an error but leaves the rest of the support in,
so it can be restored if needed. In which case I'd still want
them gone when using the C backend.