### PR TITLE
m3middle: Remove long list of targets, it is not needed.

### DIFF
--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -24,120 +24,41 @@ INTERFACE Target;
 IMPORT TInt, TWord;
 
 TYPE
+  (* Just a few systems need special handling and are listed here.
+   * Far more targets than this are supported.
+   * See m3-sys/cminstall/src/config-no-install and scripts/python/targets.txt
+   * for an idea as to the working targets.
+   *
+   * SystemNames and Systems must have a matching (analogous) prefix.
+   *)
   Systems = {
-    ALPHA32_VMS,
-    ALPHA64_VMS,
-    ALPHA_LINUX,
-    ALPHA_OPENBSD,
-    ALPHA_OSF,
-    AMD64_DARWIN,
-    AMD64_FREEBSD,
-    AMD64_LINUX,
-    AMD64_NETBSD,
-    AMD64_OPENBSD,
-    AMD64_SOLARIS,
-    ARM_DARWIN,
-    ARM_LINUX,    (* little endian, v6, hard float, vfp *)
-    ARMEL_LINUX,  (* same thing *)
     FreeBSD4,
     I386_CYGWIN,
-    I386_DARWIN,
-    I386_FREEBSD,
     I386_INTERIX,
-    I386_LINUX,
     I386_MINGW,
-    I386_NETBSD,
     I386_NT,
-    I386_OPENBSD,
-    I386_SOLARIS,
-    IA64_FREEBSD,
-    IA64_HPUX,
-    IA64_LINUX,
-    IA64_NETBSD,
-    IA64_NT,
-    IA64_OPENBSD,
-    IA64_VMS,
     LINUXLIBC6,
-    MIPS64_OPENBSD, (* e.g. SGI *)
-    MIPS64EL_OPENBSD, (* e.g. Loongson *)
     NT386,
-    PA32_HPUX,
-    PA64_HPUX,
-    PPC32_OPENBSD,
-    PPC64_DARWIN,
-    PPC_DARWIN,
-    PPC_LINUX,
-    SOLgnu,
-    SOLsun,
-    SPARC32_LINUX,
-    SPARC32_SOLARIS,
-    SPARC64_LINUX,
-    SPARC64_OPENBSD,
-    SPARC64_SOLARIS,
-    AMD64_NT,
-    ARM64_DARWIN,
-    ARM64_LINUX,
-    ARM64_NT,
-    RISCV64_LINUX,
+    PlentyMoreNotListed,
     Undefined
   };
 
 CONST
+  (* Just a few systems need special handling and are listed here.
+   * Far more targets than this are supported.
+   * See m3-sys/cminstall/src/config-no-install and scripts/python/targets.txt
+   * for an idea as to the working targets.
+   *
+   * SystemNames and Systems must have a matching (analogous) prefix.
+   *)
   SystemNames = ARRAY OF TEXT {
-    "ALPHA32_VMS",
-    "ALPHA64_VMS",
-    "ALPHA_LINUX",
-    "ALPHA_OPENBSD",
-    "ALPHA_OSF",
-    "AMD64_DARWIN",
-    "AMD64_FREEBSD",
-    "AMD64_LINUX",
-    "AMD64_NETBSD",
-    "AMD64_OPENBSD",
-    "AMD64_SOLARIS",
-    "ARM_DARWIN",
-    "ARM_LINUX",    (* little endian, v6, hard float, vfp *)
-    "ARMEL_LINUX",  (* same thing *)
     "FreeBSD4",
     "I386_CYGWIN",
-    "I386_DARWIN",
-    "I386_FREEBSD",
     "I386_INTERIX",
-    "I386_LINUX",
     "I386_MINGW",
-    "I386_NETBSD",
     "I386_NT",
-    "I386_OPENBSD",
-    "I386_SOLARIS",
-    "IA64_FREEBSD",
-    "IA64_HPUX",
-    "IA64_LINUX",
-    "IA64_NETBSD",
-    "IA64_NT",
-    "IA64_OPENBSD",
-    "IA64_VMS",
     "LINUXLIBC6",
-    "MIPS64_OPENBSD",
-    "MIPS64EL_OPENBSD",
-    "NT386",
-    "PA32_HPUX",
-    "PA64_HPUX",
-    "PPC32_OPENBSD",
-    "PPC64_DARWIN",
-    "PPC_DARWIN",
-    "PPC_LINUX",
-    "SOLgnu",
-    "SOLsun",
-    "SPARC32_LINUX",
-    "SPARC32_SOLARIS",
-    "SPARC64_LINUX",
-    "SPARC64_OPENBSD",
-    "SPARC64_SOLARIS",
-    "AMD64_NT",
-    "ARM64_DARWIN",
-    "ARM64_LINUX",
-    "ARM64_NT",
-    "RISCV64_LINUX"
+    "NT386"
   };
 
 CONST

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -47,10 +47,10 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     (* lookup the system -- linear search *)
     IF (system = NIL) THEN RETURN FALSE END;
     WHILE NOT Text.Equal (system, SystemNames[sys]) DO
-      INC (sys);  IF (sys >= NUMBER (SystemNames)) THEN RETURN FALSE END;
+      INC (sys);  IF (sys >= NUMBER (SystemNames)) THEN EXIT END;
     END;
     System := VAL(sys, Systems);
-    System_name := SystemNames[sys];
+    System_name := system;
 
     OS_name := in_OS_name;
 

--- a/www/upgrading.html
+++ b/www/upgrading.html
@@ -54,6 +54,10 @@
       packages again (do-cm3-core.sh).
     </p>
     <p>
+	The above is no longer true. The large enum listing all targets is
+	no longer in the runtime.
+    </p>
+    <p>
       As of Sat Jul 19, 2003, there is a script that performs a safe
       update for you by compiling and shipping the right packages in
       the correct order:


### PR DESCRIPTION
Update long out of date documentation a little.

The sensitivity to the long list of platforms in the removed
was long ago removed, as we just copy along a string, not an enum.
I fixed that many years ago.