### PR TITLE
m3middle: Remove long list of targets.

### DIFF
--- a/m3-sys/m3front/src/builtinInfo/InfoModule.m3
+++ b/m3-sys/m3front/src/builtinInfo/InfoModule.m3
@@ -8,13 +8,15 @@ IMPORT Type, Value, M3ID, Error;
 IMPORT InfoThisFile, InfoThisPath, InfoThisLine, InfoThisException;
 
 CONST
+  (*
   Platform_names = Target.SystemNames;
+  *)
   OS_names = Target.OSNames;
   Endian_names = Target.EndianNames; 
 
 PROCEDURE Initialize () =
   VAR zz: Scope.T;  
-      os_type, endian, platform_type: Type.T;  
+      os_type, endian (* , platform_type *) : Type.T;
       enum: Value.T;  
       nm: TEXT;
   BEGIN
@@ -33,9 +35,6 @@ PROCEDURE Initialize () =
     endian := EnumType.Build (Endian_names);
     Tipe.Define ("ENDIAN", endian, FALSE);
 
-    platform_type := EnumType.Build (Platform_names);
-    Tipe.Define ("Platform", platform_type, FALSE);
-
     nm := Target.OS_name;
     IF NOT EnumType.LookUp (os_type, M3ID.Add (nm), enum) THEN
       Error.Txt (nm, "Unknown Compiler.OS value");
@@ -43,13 +42,17 @@ PROCEDURE Initialize () =
     END;
     Constant.Declare ("ThisOS", Value.ToExpr (enum), FALSE);
 
+(*
+    platform_type := EnumType.Build (Platform_names);
+    Tipe.Define ("Platform", platform_type, FALSE);
+
     nm := Target.System_name;
     IF NOT EnumType.LookUp (platform_type, M3ID.Add (nm), enum) THEN
       Error.Txt (nm, "Unknown Compiler.Platform value"); 
       <*ASSERT FALSE*>
     END;
     Constant.Declare ("ThisPlatform", Value.ToExpr (enum), FALSE);
-
+*)
     IF Target.Little_endian THEN nm := "LITTLE" ELSE nm := "BIG" END; 
     IF NOT EnumType.LookUp (endian, M3ID.Add (nm), enum) THEN
       Error.Txt (nm, "Unknown Compiler.ENDIAN value");

--- a/m3-sys/m3middle/src/Target.i3-old2
+++ b/m3-sys/m3middle/src/Target.i3-old2
@@ -23,6 +23,123 @@ INTERFACE Target;
 
 IMPORT TInt, TWord;
 
+TYPE
+  Systems = {
+    ALPHA32_VMS,
+    ALPHA64_VMS,
+    ALPHA_LINUX,
+    ALPHA_OPENBSD,
+    ALPHA_OSF,
+    AMD64_DARWIN,
+    AMD64_FREEBSD,
+    AMD64_LINUX,
+    AMD64_NETBSD,
+    AMD64_OPENBSD,
+    AMD64_SOLARIS,
+    ARM_DARWIN,
+    ARM_LINUX,    (* little endian, v6, hard float, vfp *)
+    ARMEL_LINUX,  (* same thing *)
+    FreeBSD4,
+    I386_CYGWIN,
+    I386_DARWIN,
+    I386_FREEBSD,
+    I386_INTERIX,
+    I386_LINUX,
+    I386_MINGW,
+    I386_NETBSD,
+    I386_NT,
+    I386_OPENBSD,
+    I386_SOLARIS,
+    IA64_FREEBSD,
+    IA64_HPUX,
+    IA64_LINUX,
+    IA64_NETBSD,
+    IA64_NT,
+    IA64_OPENBSD,
+    IA64_VMS,
+    LINUXLIBC6,
+    MIPS64_OPENBSD, (* e.g. SGI *)
+    MIPS64EL_OPENBSD, (* e.g. Loongson *)
+    NT386,
+    PA32_HPUX,
+    PA64_HPUX,
+    PPC32_OPENBSD,
+    PPC64_DARWIN,
+    PPC_DARWIN,
+    PPC_LINUX,
+    SOLgnu,
+    SOLsun,
+    SPARC32_LINUX,
+    SPARC32_SOLARIS,
+    SPARC64_LINUX,
+    SPARC64_OPENBSD,
+    SPARC64_SOLARIS,
+    AMD64_NT,
+    ARM64_DARWIN,
+    ARM64_LINUX,
+    ARM64_NT,
+    RISCV64_LINUX,
+    Undefined
+  };
+
+CONST
+  SystemNames = ARRAY OF TEXT {
+    "ALPHA32_VMS",
+    "ALPHA64_VMS",
+    "ALPHA_LINUX",
+    "ALPHA_OPENBSD",
+    "ALPHA_OSF",
+    "AMD64_DARWIN",
+    "AMD64_FREEBSD",
+    "AMD64_LINUX",
+    "AMD64_NETBSD",
+    "AMD64_OPENBSD",
+    "AMD64_SOLARIS",
+    "ARM_DARWIN",
+    "ARM_LINUX",    (* little endian, v6, hard float, vfp *)
+    "ARMEL_LINUX",  (* same thing *)
+    "FreeBSD4",
+    "I386_CYGWIN",
+    "I386_DARWIN",
+    "I386_FREEBSD",
+    "I386_INTERIX",
+    "I386_LINUX",
+    "I386_MINGW",
+    "I386_NETBSD",
+    "I386_NT",
+    "I386_OPENBSD",
+    "I386_SOLARIS",
+    "IA64_FREEBSD",
+    "IA64_HPUX",
+    "IA64_LINUX",
+    "IA64_NETBSD",
+    "IA64_NT",
+    "IA64_OPENBSD",
+    "IA64_VMS",
+    "LINUXLIBC6",
+    "MIPS64_OPENBSD",
+    "MIPS64EL_OPENBSD",
+    "NT386",
+    "PA32_HPUX",
+    "PA64_HPUX",
+    "PPC32_OPENBSD",
+    "PPC64_DARWIN",
+    "PPC_DARWIN",
+    "PPC_LINUX",
+    "SOLgnu",
+    "SOLsun",
+    "SPARC32_LINUX",
+    "SPARC32_SOLARIS",
+    "SPARC64_LINUX",
+    "SPARC64_OPENBSD",
+    "SPARC64_SOLARIS",
+    "AMD64_NT",
+    "ARM64_DARWIN",
+    "ARM64_LINUX",
+    "ARM64_NT",
+    "RISCV64_LINUX"
+  };
+
 CONST
   OSNames = ARRAY OF TEXT { "POSIX", "WIN32" };
   EndianNames = ARRAY OF TEXT { "LITTLE", "BIG" }; 
@@ -137,7 +254,12 @@ PROCEDURE Init
    was successful.  *)
 
 VAR (*CONST*)
+  System: Systems := Systems.Undefined; (* initialized by "Init" *)
+
+VAR (*CONST*)
   System_name: TEXT := NIL; (* initialized by "Init" *)
+
+VAR (*CONST*)
   OS_name: TEXT := NIL; (* initialized by "Init" *)
 
 (*------------------------------------------ machine/code generator types ---*)

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -10,8 +10,41 @@ MODULE Target;
 
 IMPORT Text, TargetMap, M3RT, TextUtils;
 
+TYPE
+  (* Just a few systems need special handling and are listed here.
+   * Far more targets than this are supported.
+   * See m3-sys/cminstall/src/config-no-install and scripts/python/targets.txt
+   * for an idea as to the working targets.
+   *
+   * SystemNames and Systems need to roughly match.
+   *)
+  Systems = {
+    Undefined,
+    FreeBSD4,
+    I386_CYGWIN,
+    I386_INTERIX,
+    I386_MINGW,
+    I386_NT,
+    LINUXLIBC6,
+    NT386,
+    Other
+  };
+
+CONST
+  SystemNames = ARRAY OF TEXT {
+    "",
+    "FreeBSD4",
+    "I386_CYGWIN",
+    "I386_INTERIX",
+    "I386_MINGW",
+    "I386_NT",
+    "LINUXLIBC6",
+    "NT386"
+  };
+
 VAR (*CONST*)
   CCs : ARRAY [0..8] OF CallingConvention;
+  System: Systems;
 
 PROCEDURE Init64 () =
   BEGIN
@@ -47,11 +80,10 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     (* lookup the system -- linear search *)
     IF (system = NIL) THEN RETURN FALSE END;
     WHILE NOT Text.Equal (system, SystemNames[sys]) DO
-      INC (sys);  IF (sys >= NUMBER (SystemNames)) THEN RETURN FALSE END;
+      INC (sys);  IF (sys >= NUMBER (SystemNames)) THEN EXIT END;
     END;
     System := VAL(sys, Systems);
-    System_name := SystemNames[sys];
-
+    System_name := system;
     OS_name := in_OS_name;
 
     (* common values *)

--- a/www/upgrading.html
+++ b/www/upgrading.html
@@ -54,6 +54,12 @@
       packages again (do-cm3-core.sh).
     </p>
     <p>
+	The above is no longer true. The large enum listing all targets
+	no longer exists. However the compiler and m3core are tightly
+	coupled and there can still be incompatible changes in them.
+	Therefore:
+    </p>
+    <p>
       As of Sat Jul 19, 2003, there is a script that performs a safe
       update for you by compiling and shipping the right packages in
       the correct order:
@@ -65,6 +71,36 @@
       You can call it with the -n (no action) option to see what it
       would do.
     </p>
+
+	<p>
+	  It is recommended to instead
+      <blockquote>
+	  <tt>scripts/python/upgrade.py</tt>
+      </blockquote>
+	  to upgrade just the compiler, m3core, libm3
+
+	  Or
+      <blockquote>
+	  <tt>scripts/python/upgrade-full.sh</tt>
+      </blockquote>
+	  or
+      <blockquote>
+	  <tt>scripts/python/upgrade-full.cmd</tt>
+      </blockquote>
+
+	  to upgrade the compiler and then rebuild the entire system with that.
+	  <br>
+	  There are other ways, that need more development.
+	  Specifically, ideally, the system is not updated in place while
+	  it is building.
+      <blockquote>
+	  <tt>scripts/python/make-dist.py</tt>
+      </blockquote>
+	  does this well (TODO) and a new script should be derived from it.
+	  It copies a minimal system away (cm3, m3core, libm3),
+	  uses that to build a minimal system, and then uses that to build
+	  the entire system.
+	</p>
 
     <hr>
     <address><a href="mailto:m3-support{at}elego.de">m3-support{at}elego.de</a></address>


### PR DESCRIPTION
Remove ThisPlatform enum from runtime.
Nobody uses it and it is a build and maintenance problem.
The string form remains.

Update out of date documentation a little.
Removing the list of targets from the runtime
relaxes requirements on build order, when adding targets,
but cm3/m3core coupling can still trigger similar situation.