### PR TITLE
m3middle/m3front: Change from Little_endian: boolean to enum.

### DIFF
--- a/m3-sys/m3front/src/builtinInfo/InfoModule.m3
+++ b/m3-sys/m3front/src/builtinInfo/InfoModule.m3
@@ -53,7 +53,7 @@ PROCEDURE Initialize () =
     END;
     Constant.Declare ("ThisPlatform", Value.ToExpr (enum), FALSE);
 *)
-    IF Target.Little_endian THEN nm := "LITTLE" ELSE nm := "BIG" END; 
+    IF Target.endian = Target.Endian.Little THEN nm := "LITTLE" ELSE nm := "BIG" END;
     IF NOT EnumType.LookUp (endian, M3ID.Add (nm), enum) THEN
       Error.Txt (nm, "Unknown Compiler.ENDIAN value");
       <*ASSERT FALSE*>

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -326,6 +326,10 @@ VAR (*CONST*)
 
 (* sizes are specified in bits *)
 
+TYPE Endian = { Undefined, Little, Big };
+VAR endian: Endian;
+  (* Little => byte[0] of an integer contains its least-significant bits *)
+
 CONST
   Byte = 8;  (* minimum addressable unit (in bits) *)
 
@@ -384,9 +388,6 @@ CONST
    *)
 
 VAR (*CONST*)
-  Little_endian : BOOLEAN;
-  (* TRUE => byte[0] of an integer contains its least-significant bits *)
-
   Allow_packed_byte_aligned: BOOLEAN;
   (* Allow the compiler to align scalar types on byte boundaries when packing.
      The target processor must support byte alignment of scalar store and

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -93,7 +93,7 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     (* this is overly optimistic... *)
 
     Allow_packed_byte_aligned := FALSE;
-    Little_endian             := TRUE;
+    endian := Endian.Little;
 
     IF backend_mode = M3BackendMode_t.C THEN
       Setjmp := "m3_setjmp";
@@ -141,7 +141,7 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
         OR TextUtils.StartsWith(system, "PPC")  (* ambiguous *)
         OR TextUtils.StartsWith(system, "SPARC")
         OR TextUtils.StartsWith(system, "SOL") THEN
-      Little_endian := FALSE;
+      endian := Endian.Big;
     END;
 
     (* x86 and AMD64 allow unaligned loads/stores but converge C *)

--- a/m3-sys/m3middle/src/TargetT.i3
+++ b/m3-sys/m3middle/src/TargetT.i3
@@ -38,8 +38,8 @@ TYPE T = RECORD
   defaultCall: CallingConvention := NIL;
   atomic_lock_free: ARRAY [CGType.Word8 .. CGType.Addr] OF BOOLEAN;
     (* TRUE => platform has lock-free atomic primitives for this type *)
-  little_endian : BOOLEAN;
-    (* TRUE => byte[0] of an integer contains its least-significant bits *)
+  endian    := Endian.Little;
+    (* Little => byte[0] of an integer contains its least-significant bits *)
   PCC_bitfield_type_matters: BOOLEAN := TRUE;
     (* TRUE => the C compiler uses the type rather than the size of
        a bit-field to compute the alignment of the struct *)


### PR DESCRIPTION
m3middle/m3front: Change from Little_endian: boolean to enum Endian {Undefined, Little, Big}.

This is a little more verbose but the point is to have a distinguished value for uninitialized, the popular 0,
so that quake/config can set TARGET_ENDIAN or maybe TARGET_ARCH and not necessarily TARGET,
so the matrix of config file might go away, or at least common code will set Target = BuildDir = arch + os.

This does not really require that, but it might make it clearer if there are multiple sources of same/similar information.