### PR TITLE
Config:Fix and reenable parallel backend for NT.common.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -9,6 +9,8 @@
 % arbitrary configurations can be produced by changing them.
 %
 
+M3_PARALLEL_BACK = 20 % AMD64 machines usually have lots of cores
+
 %-------------------------------------------------------------------
 % defined by cm3, but not the other MxConfig users
 if not defined("CR") CR = "\n" end
@@ -685,7 +687,7 @@ proc compile_c_ms(source, object, options, optimize, debug) is
 
     local Listing = "_m3.lst"
     if defined("pos")
-       Listing = Path_GetBase (source) & ".lst"
+       Listing = Path_GetLastElement (source) & ".lst"
     end
     local readonly Command = ["cl.exe", escape(subst_chars(args, "\\", "/")), "-c", escape(source), "-Fo" & object]
     local ret = try_exec("@" & Command, ">", Listing)


### PR DESCRIPTION
The problem was that given:

Foo.m3
Foo.i3

We do
 cl -c foo.m3.c > foo.lst
 cl -c foo.i3.c > foo.lst

In parallel, colliding on foo.lst.

The fix is to instead:
 cl -c foo.m3.c > foo.m3.lst (or even foo.m3.c.lst)
 cl -c foo.i3.c > foo.i3.lst

We only use the last path element but I believe other parts
of builder require that to work.

The redirection could also be entirely removed. It is just to get more deterministic quieter output.