### PR TITLE
m3back/m3makefile: Add comment implicitly requesting

### DIFF
--- a/m3-sys/m3back/src/m3makefile
+++ b/m3-sys/m3back/src/m3makefile
@@ -16,6 +16,12 @@ import ("m3objfile")
 % THEY ARE A MASSIVE HACK BECAUSE THE INTEGRATED BACK-END (m3back)
 % CONTAINS SIGNIFICANT CONFUSION REGARDING TARGET INTEGER TYPES
 % THEY SHOULD BE REMOVED AS SOON AS SOMEONE CAN FIX m3back
+%
+% But first someone should explain what is the problem/hack/confusion here,
+% and what it should be instead. The files are used to implement
+% constant folding of up to 64bit integers, on a system potentially with
+% only 32bit integers, very much like is done in m3front.
+%
 Module ("TIntN")
 Module ("TWordN")
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
a clarification of other comment.
It is said there is a hack here and it should be fixed,
but no details are provided as to what is wrong with the code
or what it should do instead.

I wrote the purported hack and it seems and seemed like a reasonable
correct efficient thing. I'm open to alternative judgement and direction but nothing clear was provided.