### PR TITLE
int64 tests: Add small excerpt from p240 that

### DIFF
--- a/m3-sys/m3tests/src/m3makefile
+++ b/m3-sys/m3tests/src/m3makefile
@@ -826,6 +826,9 @@ p_test ("p2", "p265", "grisu-based")
 % This fails in Grisu when using C backend.
 p_test ("p2", "p268", "grisuc")
 
+% This fails an assert in integrated backend.
+p_test ("p2", "p269", "Long.LT")
+
 %------------------------------------------------------------------- rtests ---
 %  RUNTIME tests: modules containing runtime error where the generated
 %    error messages are of interest.

--- a/m3-sys/m3tests/src/p2/p269/Main.m3
+++ b/m3-sys/m3tests/src/p2/p269/Main.m3
@@ -1,0 +1,12 @@
+MODULE Main;
+
+IMPORT Cstdint, Long;
+
+VAR vi8:Cstdint.int8_t;
+VAR vu64:Cstdint.uint64_t;
+
+BEGIN
+
+EVAL Long.LT(vu64,VAL(vi8, LONGINT));
+
+END Main.

--- a/m3-sys/m3tests/src/p2/p269/m3makefile
+++ b/m3-sys/m3tests/src/p2/p269/m3makefile
@@ -1,0 +1,6 @@
+% This is an excerpt from from p240 that fails
+% an assert in the integrated backend.
+
+implementation("Main")
+build_standalone()
+include ("../../Test.common")

--- a/m3-sys/m3tests/src/p2/p269/m3overrides
+++ b/m3-sys/m3tests/src/p2/p269/m3overrides
@@ -1,0 +1,1 @@
+include(ROOT & "/m3overrides")


### PR DESCRIPTION
fails an assert in integrated backend. p269.
https://github.com/modula3/cm3/issues/58