### PR TITLE
m3middle: Cleanup CoffTime.

### DIFF
--- a/m3-sys/m3middle/src/CoffTime.c
+++ b/m3-sys/m3middle/src/CoffTime.c
@@ -43,9 +43,8 @@ CoffTime__Now(void)
 
 INTEGER /* should be LONGINT */
 __cdecl
-CoffTime__OfFile(TEXT tpath)
+CoffTime__OfFile(const char* path)
 {
-    const char* path = (tpath ? M3toC__SharedTtoS(tpath) : NULL);
     INTEGER t = { 0 }; /* ignore error */
     if (path)
     {
@@ -61,7 +60,6 @@ CoffTime__OfFile(TEXT tpath)
         if (stat(path, &st) == 0)
             t = st.st_mtime;
 #endif
-        M3toC__FreeSharedS(tpath, path);
     }
     return t;
 }

--- a/m3-sys/m3middle/src/CoffTime.i3
+++ b/m3-sys/m3middle/src/CoffTime.i3
@@ -12,6 +12,9 @@ INTERFACE CoffTime;
 
 <*EXTERNAL CoffTime__Now*>PROCEDURE Now (): INTEGER;
 
-<*EXTERNAL CoffTime__OfFile*>PROCEDURE OfFile (file: TEXT): INTEGER;
+(* This code is not used.
+<*EXTERNAL*> CoffTime__OfFileC*>PROCEDURE OfFileC (file: Ctypes.const_char_star): LONGINT;
+PROCEDURE OfFile (file: TEXT): LONGINT;
+ *)
 
 END CoffTime.

--- a/m3-sys/m3middle/src/POSIX/CoffTime.c
+++ b/m3-sys/m3middle/src/POSIX/CoffTime.c
@@ -21,20 +21,17 @@ CoffTime__Now(void)
 
 INTEGER /* should be LONGINT */
 __cdecl
-CoffTime__OfFile(TEXT tpath)
+CoffTime__OfFile(const char* path)
 {
-    const char* path;
     struct stat st;
     int i;
 
-    if (tpath == NULL)
+    if (path == NULL)
         return 0;
 
     ZERO_MEMORY(st);
-    path = M3toC__SharedTtoS(tpath);
 
     i = stat(path, &st);
-    M3toC__FreeSharedS(tpath, path);
     if (i) /* ignore error */
         return 0;
     return st.st_mtime;

--- a/m3-sys/m3middle/src/POSIX/CoffTime.i3
+++ b/m3-sys/m3middle/src/POSIX/CoffTime.i3
@@ -10,8 +10,12 @@ INTERFACE CoffTime;
 
 CONST EpochAdjust = 0.0d0; (* to 1/1/1970 *)
 
+(* TODO Change INTEGER to LONGINT *)
 <*EXTERNAL CoffTime__Now*>PROCEDURE Now (): INTEGER;
 
-<*EXTERNAL CoffTime__OfFile*>PROCEDURE OfFile (file: TEXT): INTEGER;
+(* This code is not used.
+<*EXTERNAL*> CoffTime__OfFileC*>PROCEDURE OfFileC (file: Ctypes.const_char_star): LONGINT;
+PROCEDURE OfFile (file: TEXT): LONGINT;
+ *)
 
 END CoffTime.

--- a/m3-sys/m3middle/src/POSIX/m3core.h
+++ b/m3-sys/m3middle/src/POSIX/m3core.h
@@ -43,20 +43,6 @@ typedef __int64 INTEGER;
 typedef ptrdiff_t INTEGER;
 #endif
 
-typedef void* TEXT;
-
-const char*
-__cdecl
-M3toC__SharedTtoS(TEXT);
-
-void
-__cdecl
-M3toC__FreeSharedS(TEXT, const char*);
-
-TEXT
-__cdecl
-M3toC__CopyStoT(const char*);
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/m3-sys/m3middle/src/WIN32/CoffTime.i3
+++ b/m3-sys/m3middle/src/WIN32/CoffTime.i3
@@ -10,8 +10,12 @@ INTERFACE CoffTime;
 
 CONST EpochAdjust = 11644473600.0d0; (* seconds from 1/1/1600 -> 1/1/1970 *)
 
+(* TODO Change INTEGER to LONGINT *)
 PROCEDURE Now (): INTEGER;
 
+(* TODO Change INTEGER to LONGINT
+ * This is not used.
 PROCEDURE OfFile (file: TEXT): INTEGER;
+ *)
 
 END CoffTime.

--- a/m3-sys/m3middle/src/WIN32/CoffTime.m3
+++ b/m3-sys/m3middle/src/WIN32/CoffTime.m3
@@ -8,12 +8,17 @@ MODULE CoffTime;
 
 IMPORT Time, File, FS, OSError;
 
+(* TODO Change INTEGER to LONGINT *)
 PROCEDURE Now (): INTEGER =
   VAR now := Time.Now ();
   BEGIN
     RETURN ROUND (now - EpochAdjust);
   END Now;
 
+(* This code is not used.
+ * If it is refactored into C, avoid passing TEXT to C.
+ * TODO Change INTEGER to LONGINT
+ *
 PROCEDURE OfFile (file: TEXT): INTEGER =
   VAR s: File.Status;
   BEGIN
@@ -24,6 +29,7 @@ PROCEDURE OfFile (file: TEXT): INTEGER =
     END;
     RETURN ROUND (s.modificationTime - EpochAdjust);
   END OfFile;
+*)
 
 BEGIN
 END CoffTime.


### PR DESCRIPTION
 - Add comments that INTEGER should be LONGINT.
 - Add comments that C code should not traffic in
   traced references (it inhibits transition to precise GC).
 - Comment out unused CoffTime.OfFile, which is what prior
   comments are about.