### PR TITLE
config: Fallback to -gstabs for caltech-other/newuoa.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/Unix.common
+++ b/m3-sys/cminstall/src/config-no-install/Unix.common
@@ -225,8 +225,11 @@ if not defined ("compile_c")
 
 proc compile_c(source, object, options, optimize, debug) is
 
-    % hack
-
+    % hack: The C compiler driver generally accepts .s files
+    % for assembly source, but some files do not work here.
+    %
+    % Passing all .s files to assemble seems reasonable.
+    %
     if equal(source, "../src/runtime/SOLgnu/RTMachineASM.s")
         return assemble(source, object)
     end
@@ -254,6 +257,15 @@ proc compile_c(source, object, options, optimize, debug) is
         % NOTE: This is gcc specific.
         ret_code = try_exec (SYSTEM_CC, args, "-xc -c", source, "-o", object)
     end
+
+    % Try with -gstabs sometimes also.
+    % This is required for caltech-other/newuoa.
+    %
+    if not equal(ret_code, 0) and equal(pn_lastext(source), "s")
+      args += "-gstabs"
+      ret_code = try_exec (SYSTEM_CC, args, "-c", source, "-o", object)
+    end
+
     return ret_code
 end
 


### PR DESCRIPTION
For the sake of caltech-other/newuoa, when CC fails, try again with -gstabs.

There is no great answer here.
Maybe best is to add fortran_source, upon gfortran or ifort,
and build these from .f instead of .s. Building from .s is pretty bad.

I removed -gstabs+ recently from SYSTEM_CC because it does generate incorrect symbols for recent shipping gcc, which is quite frustrating.