### PR TITLE
Unix config: Restore NoEcho on gcc.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/Unix.common
+++ b/m3-sys/cminstall/src/config-no-install/Unix.common
@@ -244,9 +244,9 @@ proc compile_c(source, object, options, optimize, debug) is
     local ret_code = 1
 
     if equal(source, "_m3main.c")
-       ret_code = try_exec (SYSTEM_CXXC, args, "-c -xc++", source, "-o", object)
+       ret_code = try_exec ("@" & SYSTEM_CXXC, args, "-c -xc++", source, "-o", object)
     else
-       ret_code = try_exec (SYSTEM_CC, args, "-c", source, "-o", object)
+       ret_code = try_exec ("@" & SYSTEM_CC, args, "-c", source, "-o", object)
     end
 
     if not equal(ret_code, 0) and equal(source, "_m3main.c")


### PR DESCRIPTION
See commit a7cbbc920531623a10bcddfbe024418b551afa12
  Author: Jay Krell <jaykrell@microsoft.com>
  Date:   Sat May 12 05:11:18 2018 -0700

  Do not disable command echoing, and...

Later consider making it optional but on by default.

It is a little noisy and breaks test automation that wants to verify expected stdout/stderr (and doesn't filter out lines that start SYSTEM_CC)

The logic is remove any number of leading @ not just the first:

C:\s\cm3\m3-sys\m3quake\src\QMachine.m3(1532):        | '@' => echo := FALSE;

      (* strip the leading magic characters *)
      n := 0;
      len := Text.Length (command);
      WHILE n < len DO
        CASE Text.GetChar (command, n) OF
        | '@' => echo := FALSE;
        | '-' => ignore_errors := TRUE;
        ELSE EXIT;
        END;
        INC (n);
      END;
      IF n # 0 THEN
        command := Text.Sub (command, n);
      END;

So you cannot actually run something that starts with @.