### PR TITLE
Remove build_dir from C output. (i.e. roughly target)

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2423,8 +2423,24 @@ END end_unit;
 PROCEDURE set_source_file(self: T; file: TEXT) =
 (* Sets the current source file name. Subsequent statements
    and expressions are associated with this source location. *)
+VAR pos := 0; length := 0;
 BEGIN
-    file := TextUtils.SubstChar(file, '\\', '/');
+    IF file # NIL THEN
+      file := TextUtils.SubstChar(file, '\\', '/');
+
+      (* m3front does like:
+       * set_source_file("../AMD64_DARWINc/WordMod.m3 => ../src/builtinWord/Mod.mg")
+       * which damages debugging (this file does not exist) and is unnecessarily
+       * target specific, damaging portable redistribution formats.
+       *)
+      length := Text.Length(file);
+      IF length > 0 AND Text.GetChar(file, length - 1) = 'g' THEN
+        pos := TextUtils.Pos(file, " => ");
+        IF pos # -1 THEN
+          file := Text.Sub(file, pos + 4, length - pos - 4);
+        END
+      END;
+    END;
     IF DebugVerbose(self) THEN
         self.comment("set_source_file file:", file);
     ELSE


### PR DESCRIPTION
m3front does like:
 set_source_file("../AMD64_DARWINc/WordMod.m3 => ../src/builtinWord/Mod.mg")

That one string with two obvious files, is considered one file.
This damages debugging (this file does not exist) and is unnecessarily
target specific, damaging portable redistribution formats.

For now as an optimization hack we trigger off of:
 last char is 'g'
 contains " => "

but a more complete slower approach is to replace
 build_dir value with literal "build_dir" or such.

Or have a two level build_dir:
 ../output
 ../output/amd64_darwin

and then only the first would appear usually, which at least
addresses the portable distribution problem I was
initially handling while still leaving debugging broken.