### PR TITLE
m3c:Remove comment target and word_size from C output.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2329,8 +2329,10 @@ END set_error_handler;
 PROCEDURE Prefix_Print(self: T; multipass: Multipass_t) =
 BEGIN
     self.comment("begin unit");
+(*  This breaks portable distribution format.
     self.comment("M3_TARGET = ", Target.System_name);
     self.comment("M3_WORDSIZE = ", IntToDec(Target.Word.size));
+*)
     self.static_link_id := M3ID.Add("_static_link");
     self.alloca_id := M3ID.Add("alloca");
     self.setjmp_id := M3ID.Add("m3_setjmp");


### PR DESCRIPTION
This is useful seeming but breaks portable distribution format.