### PR TITLE
m3c: Output enum element text not internal ids, in comments.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2577,7 +2577,7 @@ VAR enum_value := self.enum_value;
     x := self.self;
 BEGIN
     IF DebugVerbose(x) THEN
-        x.comment("declare_enum_elt name:", IntToDec(name));
+        x.comment("declare_enum_elt name:", NameT(name), "=", IntToDec(self.enum_value));
     ELSE
         x.comment("declare_enum_elt");
     END;


### PR DESCRIPTION
m3c: When putting declare_enum_elt in the comments in the C, really, the comments (for debugging)..
output the textual name of the enum elements, not the internal M3ID.
The M3IDs are unfortunately not stable across targets.
That should be investigated.
But the text was the intent here anyway. Also output the integer value (of the enum, not the internal text).
This goes a long way toward converging the C output across targets.