### PR TITLE
cm3,m3middle: Switch to some two level imports.

### DIFF
--- a/m3-sys/cm3/src/Builder.m3
+++ b/m3-sys/cm3/src/Builder.m3
@@ -14,7 +14,6 @@ IMPORT Quake, QMachine, QValue, QVal, QVSeq;
 IMPORT M3Loc, M3Unit, M3Options, MxConfig;
 IMPORT QIdent;
 IMPORT Target; 
-FROM Target IMPORT M3BackendMode_t, BackendModeStrings;
 FROM M3Path IMPORT OSKind, OSKindStrings;
 IMPORT Pathname;
 IMPORT QPromise, QPromiseSeq, RefSeq;
@@ -109,7 +108,7 @@ TYPE
     target        : TEXT;               (* target machine *)
     (* target_oskind is misused; needs work *)
     target_oskind := M3Path.OSKind.Unix; (* target oskind: Win32 or Unix *)
-    m3backend_mode: M3BackendMode_t;    (* tells how to turn M3CG -> object *)
+    m3backend_mode: Target.M3BackendMode_t; (* tells how to turn M3CG -> object *)
     m3backend     : ConfigProc;         (* translate M3CG -> ASM or OBJ *)
     m3llvm        : ConfigProc;         (* translate M3CG -> LLVM bitcode *) 
     llvmbackend   : ConfigProc;         (* translate llvm bitcode -> ASM or OBJ *)
@@ -234,13 +233,13 @@ PROCEDURE ConvertStringToEnum(s: State; name : TEXT; binding: QValue.Binding;
   END ConvertStringToEnum;
 
 PROCEDURE ConvertBackendModeStringToEnum(s: State; binding: QValue.Binding):
-  M3BackendMode_t =
+  Target.M3BackendMode_t =
   BEGIN
     RETURN VAL(ConvertStringToEnum(s, "backend mode", binding,
-                                   ORD(FIRST(M3BackendMode_t)),
-                                   ORD(LAST(M3BackendMode_t)),
-                                   BackendModeStrings),
-               M3BackendMode_t);
+                                   ORD(FIRST(Target.M3BackendMode_t)),
+                                   ORD(LAST(Target.M3BackendMode_t)),
+                                   Target.BackendModeStrings),
+               Target.M3BackendMode_t);
   END ConvertBackendModeStringToEnum;
 
 PROCEDURE ConvertNamingConventionStringToEnum(s: State;
@@ -1228,7 +1227,7 @@ PROCEDURE CompileC (s: State; u: M3Unit.T) =
 
 PROCEDURE CompileM3cc (s: State; u: M3Unit.T) = 
 (* PRE: u.kind IN {UK.IC, UK.MC} *) 
-  TYPE Mode_t = M3BackendMode_t;
+  TYPE Mode_t = Target.M3BackendMode_t;
   VAR tmpS: TEXT := NIL;
       keep := s.keep_files;
       mode := s.m3backend_mode;
@@ -1248,7 +1247,7 @@ PROCEDURE CompileM3cc (s: State; u: M3Unit.T) =
         Utils.NoteNewFile (u.object);
       ELSE 
         Msg.FatalError 
-          (NIL, "Compiler mode " & BackendModeStrings [ mode ] 
+          (NIL, "Compiler mode " & Target.BackendModeStrings [ mode ] 
                 & " cannot compile frontend output (.ic or .mc) files to assembly code.");
       END (*IF*) 
     ELSE 
@@ -1267,7 +1266,7 @@ PROCEDURE CompileM3cc (s: State; u: M3Unit.T) =
           Utils.NoteNewFile (u.object);
       ELSE
         Msg.FatalError 
-          (NIL, "Compiler mode " & BackendModeStrings [ mode ] 
+          (NIL, "Compiler mode " & Target.BackendModeStrings [ mode ] 
                 & " cannot compile frontend output (.ic or .mc) files");
       END (*CASE*);
     END;
@@ -1275,7 +1274,7 @@ PROCEDURE CompileM3cc (s: State; u: M3Unit.T) =
 
 PROCEDURE CompileM3llvm (s: State; u: M3Unit.T) = 
 (* PRE: u.kind IN {UK.IC, UK.MC} *) 
-  TYPE Mode_t = M3BackendMode_t;
+  TYPE Mode_t = Target.M3BackendMode_t;
   VAR tmpS: TEXT := NIL;
       keep := s.keep_files;
       mode := s.m3backend_mode;
@@ -1296,7 +1295,7 @@ PROCEDURE CompileM3llvm (s: State; u: M3Unit.T) =
         Utils.NoteNewFile (u.object);
       ELSE 
         Msg.FatalError 
-          (NIL, "Compiler mode " & BackendModeStrings [ mode ] 
+          (NIL, "Compiler mode " & Target.BackendModeStrings [ mode ] 
                 & " cannot compile frontend output (.ic or .mc) files to assembly code.");
       END (*IF*) 
     ELSE 
@@ -1315,7 +1314,7 @@ PROCEDURE CompileM3llvm (s: State; u: M3Unit.T) =
           Utils.NoteNewFile (u.object);
       ELSE
         Msg.FatalError 
-          (NIL, "Compiler mode " & BackendModeStrings [ mode ] 
+          (NIL, "Compiler mode " & Target.BackendModeStrings [ mode ] 
                 & " cannot compile frontend output (.ic or .mc) files");
       END (*CASE*);
     END;
@@ -1323,7 +1322,7 @@ PROCEDURE CompileM3llvm (s: State; u: M3Unit.T) =
 
 PROCEDURE CompileLlc (s: State; u: M3Unit.T) =
 (* PRE: u.kind IN {UK.IB, UK.MB, UK.B} *) 
-  TYPE Mode_t = M3BackendMode_t;
+  TYPE Mode_t = Target.M3BackendMode_t;
   VAR tmpS: TEXT := NIL;
       mode := s.m3backend_mode;
   BEGIN
@@ -1363,7 +1362,7 @@ PROCEDURE CompileLlc (s: State; u: M3Unit.T) =
         END (*IF*); 
       ELSE 
         Msg.FatalError 
-          (NIL, "Compiler mode " & BackendModeStrings [ mode ] 
+          (NIL, "Compiler mode " & Target.BackendModeStrings [ mode ] 
                 & " cannot compile llvm bitcode (.bc, .ib or .mb) files");
       END (*CASE*);
     END (*IF*);
@@ -1470,7 +1469,7 @@ PROCEDURE Temps_Remove (VAR temps: Temps_t; s: State) =
 
 PROCEDURE PushOneM3 (s: State;  u: M3Unit.T): BOOLEAN =
 (* PRE: u.kind IN {UK.I3, UK.M3} *) 
-  TYPE Mode_t = M3BackendMode_t;
+  TYPE Mode_t = Target.M3BackendMode_t;
   VAR
     temps := Temps_t { };
 

--- a/m3-sys/cm3/src/M3Backend.i3
+++ b/m3-sys/cm3/src/M3Backend.i3
@@ -7,9 +7,9 @@
 INTERFACE M3Backend;
 
 IMPORT Wr, M3CG;
-FROM Target IMPORT M3BackendMode_t;
+IMPORT Target;
 
-PROCEDURE Open (target: Wr.T;  target_name: TEXT;  backend_mode: M3BackendMode_t): M3CG.T;
+PROCEDURE Open (target: Wr.T;  target_name: TEXT;  backend_mode: Target.M3BackendMode_t): M3CG.T;
 PROCEDURE Close (cg: M3CG.T);
 
 END M3Backend.

--- a/m3-sys/cm3/src/M3Backend.m3
+++ b/m3-sys/cm3/src/M3Backend.m3
@@ -11,7 +11,6 @@ IMPORT LLGen; (* Could be a dummy.  See the m3makefile. *)
 IMPORT M3CG, Msg, Utils, NTObjFile, M3x86, M3ObjFile;
 IMPORT M3CG_BinWr;
 IMPORT Target; 
-FROM Target IMPORT M3BackendMode_t;
 
 VAR
   obj_file : M3ObjFile.T := NIL;
@@ -20,9 +19,9 @@ VAR
   log      : Wr.T        := NIL;
   log_name : TEXT        := NIL;
 
-PROCEDURE Open (target: Wr.T;  target_name: TEXT;  backend_mode: M3BackendMode_t): M3CG.T =
+PROCEDURE Open (target: Wr.T;  target_name: TEXT;  backend_mode: Target.M3BackendMode_t): M3CG.T =
   BEGIN
-    IF backend_mode = M3BackendMode_t.C THEN
+    IF backend_mode = Target.M3BackendMode_t.C THEN
       RETURN M3C.New (target);
     END;
     IF backend_mode IN Target.BackendLlvmSet THEN

--- a/m3-sys/m3middle/src/TargetT.i3
+++ b/m3-sys/m3middle/src/TargetT.i3
@@ -9,14 +9,14 @@
 INTERFACE TargetT;
 
 IMPORT Target;
-FROM Target IMORT Int_type, Float_type, CallingConvention, M3BackendMode_t;
+FROM Target IMORT Int_type, Float_type, CallingConvention;
 
 (*  Modula-3 target description *)
 
 TYPE T = RECORD
   system_name: TEXT; (* I386_LINUX, etc., use sparingly *)
   os_name: TEXT; (* POSIX, WIN32 *)
-  backendmode: M3BackendMode_t;
+  backendmode: Target.M3BackendMode_t;
   address   : Int_type;
   integer   : Int_type;
   longint   : Int_type;


### PR DESCRIPTION
i.e.
replace FROM Target IMPORT M3BackendMode_t
...M3BackendMode_t...

with:
IMPORT Target;
Target.M3BackendMode_t

It is a tradeoff. The verbosity is not necessarily more readable,
and the second part of the name is globally unique.

This is only done a little bit, in code I added and code
I am likely to change soon (separating cosmetic and semantic
changes).

This is purely cosmetic. There is no semantic change.