### PR TITLE
Compute backend mode earlier.

### DIFF
--- a/m3-sys/cm3/src/Builder.i3
+++ b/m3-sys/cm3/src/Builder.i3
@@ -3,7 +3,7 @@
 
 INTERFACE Builder;
 
-IMPORT Arg, M3Unit, Quake, QMachine;
+IMPORT Arg, M3Unit, Quake, QMachine, Target;
 
 PROCEDURE BuildPgm (prog: TEXT;  READONLY units: M3Unit.Set;
                     sys_libs: Arg.List;  shared: BOOLEAN;  m: Quake.Machine);
@@ -28,5 +28,7 @@ PROCEDURE EmitPkgImports (READONLY units: M3Unit.Set);
 (* Output all imported packages *)
 
 PROCEDURE SetupNamingConventions (mach : QMachine.T);
+
+PROCEDURE GetBackendMode (mach : Quake.Machine): Target.M3BackendMode_t;
 
 END Builder.

--- a/m3-sys/cm3/src/Dirs.m3
+++ b/m3-sys/cm3/src/Dirs.m3
@@ -5,6 +5,7 @@ MODULE Dirs;
 
 IMPORT Atom, FS, File, M3File, OSError, Pathname, Process, RegularFile, Text;
 IMPORT Msg, M3Options, M3Path, Wr;
+IMPORT Target;
 
 CONST
   ModeVerb = ARRAY M3Options.Mode OF TEXT {
@@ -18,6 +19,9 @@ VAR
 PROCEDURE SetUp (target: TEXT) =
   VAR base, parent: TEXT;
   BEGIN
+
+    <*ASSERT Target.BackendModeInitialized *>
+
     TRY
       initial := Process.GetWorkingDirectory ();
     EXCEPT OSError.E(ec) =>

--- a/m3-sys/cm3/src/Main.m3
+++ b/m3-sys/cm3/src/Main.m3
@@ -5,7 +5,7 @@ MODULE Main;
 
 IMPORT M3Timers, Pathname, Process, Quake;
 IMPORT RTCollector, RTParams, RTutils, Thread, Wr;
-IMPORT TextTextTbl;
+IMPORT TextTextTbl, Target;
 
 IMPORT Builder, Dirs, M3Build, M3Options, Makefile, Msg, Utils, WebFile;
 IMPORT MxConfig(*, M3Config, CMKey, CMCurrent *);
@@ -92,7 +92,9 @@ VAR defs: TextTextTbl.T;
         CheckExpire (Quake.LookUp (mach, "INSTALL_KEY"));
         *)
 
-        Builder.SetupNamingConventions (mach);
+        (* Get backendmode before Dirs.Setup. *)
+        Target.BackendMode := Builder.GetBackendMode (mach);
+        Target.BackendModeInitialized := TRUE;
 
         (* figure out where we are and get where we want to be *)
         build_dir := Quake.LookUp (mach, "BUILD_DIR");

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -461,4 +461,8 @@ VAR (*CONST*)
      test for nested procedures passed as parameters must be more
      elaborate (e.g. HPPA). *)
 
+(* Ideally the value 0 would be uninitialized, but it is used publically in Quake? *)
+VAR BackendMode: M3BackendMode_t;
+VAR BackendModeInitialized := FALSE;
+
 END Target.


### PR DESCRIPTION
This is possibly useful.
Expose through a global in Target, which I really do not love, but is the existing practise.
It breaks multithreaded compilating to multiple targets.
Modules are overrated, objects/records/structs are really the thing to use, for state/variables.
Modules are good for functions and types and constants.