### PR TITLE
Export build_dir to backend via middle.

### DIFF
--- a/m3-sys/cm3/src/M3Build.m3
+++ b/m3-sys/cm3/src/M3Build.m3
@@ -7,7 +7,7 @@ IMPORT Env, IntArraySort, IntRefTbl, M3ID, Pathname, Text, TextList, Thread, Wr;
 IMPORT Quake, QValue, QCode, QMachine, QVal, QVSeq, QVTbl, M3Timers;
 IMPORT Arg, Builder, M3Loc, M3Options, M3Path, M3Unit, Msg, Utils;
 FROM QMachine IMPORT PushBool, PushText, PopText, PopID, PopBool;
-IMPORT MxConfig;
+IMPORT MxConfig, Target;
 IMPORT OSError, Process, Dirs, TextUtils;
 
 TYPE
@@ -152,6 +152,7 @@ PROCEDURE SetUp (t: T;  pkg, to_pkg, build_dir: TEXT)
     t.build_pkg_dir   := M3ID.Add (pkg);
     t.build_dir       := M3ID.Add (build_dir);
     t.text_build_dir  := build_dir;
+    Target.Build_dir  := build_dir;
 
     t.pkg_use         := GetConfigPath (t, "PKG_USE");
     t.pkg_install     := GetConfigPath (t, "PKG_INSTALL");

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -455,6 +455,14 @@ VAR (*CONST*)
   (* The C name of the routine used to capture the machine state in
        an exception handler frame. *)
 
+  Build_dir: TEXT;
+  (* The directory containing derived files. This to aid the C
+   * backend in converging target-dependent output to be target-independent.
+   * It occurs unnecessarily in some places such as line directives.
+   * m3front communicates to m3back via m3middle, a string that backend
+   * might want to change.
+   *)
+
   CONST Aligned_procedures = FALSE;
   (* TRUE => all procedure values are aligned to at least Integer.align
      and can be safely dereferenced.  Otherwise, the code generated to


### PR DESCRIPTION
This might enable making output more target-independent.