### PR TITLE
m3c:Print the printing of init_chars parameters.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4876,7 +4876,7 @@ BEGIN
 
     IF DebugVerbose(self) THEN
       self.comment("init_chars offset:" & IntToDec(offset) &
-        " length:" & IntToDec(length) & " value:" & value);
+        " length:" & IntToDec(length) & " value:" & debug_print);
     ELSE
       self.comment("init_chars");
     END;


### PR DESCRIPTION
It was avoiding printing strings that might close a comment but oops.