### PR TITLE
m3c:Move the logic to cleanup source paths

### DIFF
--- a/m3-sys/cm3/src/M3Build.m3
+++ b/m3-sys/cm3/src/M3Build.m3
@@ -7,7 +7,7 @@ IMPORT Env, IntArraySort, IntRefTbl, M3ID, Pathname, Text, TextList, Thread, Wr;
 IMPORT Quake, QValue, QCode, QMachine, QVal, QVSeq, QVTbl, M3Timers;
 IMPORT Arg, Builder, M3Loc, M3Options, M3Path, M3Unit, Msg, Utils;
 FROM QMachine IMPORT PushBool, PushText, PopText, PopID, PopBool;
-IMPORT MxConfig, Target;
+IMPORT MxConfig;
 IMPORT OSError, Process, Dirs, TextUtils;
 
 TYPE
@@ -152,7 +152,6 @@ PROCEDURE SetUp (t: T;  pkg, to_pkg, build_dir: TEXT)
     t.build_pkg_dir   := M3ID.Add (pkg);
     t.build_dir       := M3ID.Add (build_dir);
     t.text_build_dir  := build_dir;
-    Target.Build_dir  := build_dir;
 
     t.pkg_use         := GetConfigPath (t, "PKG_USE");
     t.pkg_install     := GetConfigPath (t, "PKG_INSTALL");

--- a/m3-sys/cm3/src/Main.m3
+++ b/m3-sys/cm3/src/Main.m3
@@ -92,7 +92,6 @@ VAR defs: TextTextTbl.T;
         CheckExpire (Quake.LookUp (mach, "INSTALL_KEY"));
         *)
 
-        (* Get backendmode before Dirs.Setup. *)
         Target.BackendMode := Builder.GetBackendMode (mach);
         Target.BackendModeInitialized := TRUE;
 
@@ -101,6 +100,7 @@ VAR defs: TextTextTbl.T;
         IF (build_dir = NIL) THEN
           Msg.FatalError (NIL, "configuration file didn't specify BUILD_DIR");
         END;
+        Target.SetBuild_dir (build_dir);
         Dirs.SetUp (build_dir);
 
         (* define the "builtin" quake functions *)

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -455,14 +455,6 @@ VAR (*CONST*)
   (* The C name of the routine used to capture the machine state in
        an exception handler frame. *)
 
-  Build_dir: TEXT;
-  (* The directory containing derived files. This to aid the C
-   * backend in converging target-dependent output to be target-independent.
-   * It occurs unnecessarily in some places such as line directives.
-   * m3front communicates to m3back via m3middle, a string that backend
-   * might want to change.
-   *)
-
   CONST Aligned_procedures = FALSE;
   (* TRUE => all procedure values are aligned to at least Integer.align
      and can be safely dereferenced.  Otherwise, the code generated to
@@ -472,5 +464,8 @@ VAR (*CONST*)
 (* Ideally the value 0 would be uninitialized, but it is used publically in Quake? *)
 VAR BackendMode: M3BackendMode_t;
 VAR BackendModeInitialized := FALSE;
+
+PROCEDURE SetBuild_dir(build_dir: TEXT);
+PROCEDURE CleanupSourcePath(file: TEXT): TEXT;
 
 END Target.


### PR DESCRIPTION
from the backend to the middle end, as it will likely get more calls, from m3front.

Also change how characters are compared, so `'\\' == '/'`.