### PR TITLE
m3c:CleanupSourcePath more.

### DIFF
--- a/m3-sys/m3front/src/builtinInfo/InfoThisFile.m3
+++ b/m3-sys/m3front/src/builtinInfo/InfoThisFile.m3
@@ -5,6 +5,7 @@ MODULE InfoThisFile;
 
 IMPORT CallExpr, Expr, ExprRep, Procedure, ProcType, Textt;
 IMPORT Formal, Value, Scanner, TextExpr, M3String;
+IMPORT Target;
 
 VAR Z: CallExpr.MethodList;
 VAR formals: Value.T;
@@ -61,6 +62,7 @@ PROCEDURE GetValue () =
   BEGIN
     IF (value = NIL) THEN
       Scanner.LocalHere (file, line);
+      file := Target.CleanupSourcePath (file);
       value := TextExpr.New8 (M3String.Add (file));
     END;
   END GetValue;

--- a/m3-sys/m3front/src/values/Module.m3
+++ b/m3-sys/m3front/src/values/Module.m3
@@ -1136,11 +1136,10 @@ PROCEDURE GenLinkerInfo (t: T;  proc_info, type_map, rev_full, rev_part: INTEGER
   BEGIN
     Scanner.offset := t.origin;
     IF (t.genericFile # NIL) THEN
-      offs := CG.EmitText (t.genericFile, is_const := TRUE);
-    ELSE
-      Scanner.Here (file, line);
-      offs := CG.EmitText (file, is_const := TRUE);
+      file := t.genericFile;
     END;
+    file := Target.CleanupSourcePath (file);
+    offs := CG.EmitText (file, is_const := TRUE);
     CG.Init_var (M3RT.MI_file, vc, offs, is_const := FALSE);
     CG.Comment (offs, TRUE, "file name");
 


### PR DESCRIPTION
i.e. for Compiler.ThisFile and LinkerInfo.

This another significant move toward having the C backend output be the same across platforms.