### PR TITLE
cm3: Restore prior quake evaluation order so that

### DIFF
--- a/m3-sys/cm3/src/Dirs.m3
+++ b/m3-sys/cm3/src/Dirs.m3
@@ -5,7 +5,6 @@ MODULE Dirs;
 
 IMPORT Atom, FS, File, M3File, OSError, Pathname, Process, RegularFile, Text;
 IMPORT Msg, M3Options, M3Path, Wr;
-IMPORT Target;
 
 CONST
   ModeVerb = ARRAY M3Options.Mode OF TEXT {
@@ -19,9 +18,6 @@ VAR
 PROCEDURE SetUp (target: TEXT) =
   VAR base, parent: TEXT;
   BEGIN
-
-    <*ASSERT Target.BackendModeInitialized *>
-
     TRY
       initial := Process.GetWorkingDirectory ();
     EXCEPT OSError.E(ec) =>

--- a/m3-sys/cm3/src/Main.m3
+++ b/m3-sys/cm3/src/Main.m3
@@ -92,9 +92,6 @@ VAR defs: TextTextTbl.T;
         CheckExpire (Quake.LookUp (mach, "INSTALL_KEY"));
         *)
 
-        Target.BackendMode := Builder.GetBackendMode (mach);
-        Target.BackendModeInitialized := TRUE;
-
         (* figure out where we are and get where we want to be *)
         build_dir := Quake.LookUp (mach, "BUILD_DIR");
         IF (build_dir = NIL) THEN
@@ -102,6 +99,9 @@ VAR defs: TextTextTbl.T;
         END;
         Target.SetBuild_dir (build_dir);
         Dirs.SetUp (build_dir);
+
+        Target.BackendMode := Builder.GetBackendMode (mach);
+        Target.BackendModeInitialized := TRUE;
 
         (* define the "builtin" quake functions *)
         M3Build.SetUp (mach, Dirs.package, Dirs.to_package,


### PR DESCRIPTION
cross builds work, i.e. computation of TARGET.
Broken today/yesterday.