### PR TITLE
m3quake:When assigning over a readonly variable and failing,

### DIFF
--- a/m3-sys/m3quake/src/QMachine.m3
+++ b/m3-sys/m3quake/src/QMachine.m3
@@ -367,7 +367,9 @@ PROCEDURE Eval (t: T)
                  as it already has; the old value is kept *)
               val := bind.value;
             ELSE
-              Err (t, "cannot assign to readonly variable: " & t.map.id2txt(arg));
+              Err (t, "cannot assign to readonly variable: " & t.map.id2txt(arg) &
+                   " old:" & t.map.id2txt(bind.value.int) &
+                   " new:" & t.map.id2txt(val.int));
             END;
           END;
           bind.value := val;


### PR DESCRIPTION
print the existing and attemped values.
This might help, a little.