### PR TITLE
config: Let BUILD_DIR from command line always dominate config files.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/I386_CYGWIN
+++ b/m3-sys/cminstall/src/config-no-install/I386_CYGWIN
@@ -33,7 +33,9 @@ else
     readonly PROFILING_P = ""
 end
 
-readonly BUILD_DIR = TARGET & PROFILING_P
+if not defined("BUILD_DIR")
+    readonly BUILD_DIR = TARGET & PROFILING_P
+end
 
 readonly M3_BACKEND_MODE = "3"
 % -- defines how the frontend, backend, and assembler interact

--- a/m3-sys/cminstall/src/config-no-install/I386_MINGW
+++ b/m3-sys/cminstall/src/config-no-install/I386_MINGW
@@ -29,7 +29,9 @@ else
     readonly PROFILING_P = ""
 end
 
-readonly BUILD_DIR = TARGET & PROFILING_P
+if not defined("BUILD_DIR")
+    readonly BUILD_DIR = TARGET & PROFILING_P
+end
 
 % see the NT386 file for information
 readonly M3_BACKEND_MODE = "3" % other values are 0, 1, 2

--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -43,7 +43,9 @@ else
     readonly PROFILING_P = ""
 end
 
-readonly BUILD_DIR = TARGET & PROFILING_P
+if not defined("BUILD_DIR")
+    readonly BUILD_DIR = TARGET & PROFILING_P
+end
 
 % for bootstrapping from older tools
 readonly NAMING_CONVENTIONS = "2"


### PR DESCRIPTION
cm3cfg.common already said:
if not defined("BUILD_DIR")
    readonly BUILD_DIR = ...
end

But NT, Cygwin, Mingw unconditional:
readonly BUILD_DIR = ...

The result of this is that on non-NT systems you can say:

cm3 -DBUILD_DIR=output
but on NT that gives an error about assigning to a readonly variable.

The underlying code is a bit confusing.
First we do the assignment in code.
 I think I put that in.
And we write out quake code to do the assignment,
and before evaluating that we evaluate the config file.

So the sequence is:
  BUILD_DIR=output
  readonly BUILD_DIR=something else
  BUILD_DIR=output error

With this change it should be:
  BUILD_DIR=output
  skip readonly BUILD_DIR=something else
  BUILD_DIR=output no error

Probably it should be possible to say readonly.