### PR TITLE
scripts: Make BUILD_DIR agree between config and scripts.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -761,6 +761,8 @@ M3GDB = (M3GDB or CM3_GDB)
 Scripts = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PKGSDB = os.path.join(Scripts, "PKGS")
 
+CM3_FLAGS = CM3_FLAGS + " -DBUILD_DIR=" + BuildDir
+
 #-----------------------------------------------------------------------------
 
 def GetConfigForDistribution(Target):


### PR DESCRIPTION
There is this question of appending "C" to BUILD_DIR.
This remains in question.
Previously scripts would try to guess what config would do.
If they disagreed, annoying error.
This made me want to not append C ever.
Yet there is a reason, that is hard to argue away -- the C backend
is not quite ABI compatible with gcc or integrated backends, because
of how static links are passed.

In considering this yet again after a build break, I realized
what should happen is scripts should just tell config what
it wants, rather than trying to coordinate.