### PR TITLE
m3c: Replace backward slashes with forward in line directives.

### DIFF
--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -372,6 +372,7 @@ BEGIN
    *)
 
   IF file # NIL AND BackendMode = M3BackendMode_t.C THEN
+    file := TextUtils.SubstChar(file, '\\', '/');
     length := Text.Length(file);
     build_dir := Build_dir;
     build_dir_length := Build_dir_length;


### PR DESCRIPTION
This might have regressed recently, i.e. getting naming conventions
while initializing quake. That should be looked into, but
it doesn't matter much. The naming convention stuff is wierd
because I am not sure it keeps host and target straight.
And Windows supports forward slashes.