### PR TITLE
m3core: Switch Linux/amd64 from sbrk to mmap.

### DIFF
--- a/m3-libs/m3core/src/runtime/POSIX/m3makefile
+++ b/m3-libs/m3core/src/runtime/POSIX/m3makefile
@@ -10,11 +10,6 @@ module         ("RTPerfTool")
 
 readonly RTOSbrk = {
   %
-  % memory from mmap seemed to be too spread out for the allocator's data structures to describe
-  %
-  "AMD64_LINUX" : 1,
-
-  %
   % Several platforms don't define MAP_ANON or MAP_ANONYMOUS or even have Umman,
   % and sbrk was the historical implementation, but we probably don't care.
   % see http://modula3.elegosoft.com/cgi-bin/cvsweb.cgi/cm3/m3-libs/m3core/src/runtime/POSIX/RTOS.m3?rev=1.1;content-type=text%2Fplain


### PR DESCRIPTION
This was the only current system using sbrk.
The rest are all historical though it might be nice to try them
and move them to mmap.