### PR TITLE
Win32: Add some "BITS FOR".

### DIFF
--- a/m3-libs/m3core/src/win32/WinBase.i3
+++ b/m3-libs/m3core/src/win32/WinBase.i3
@@ -178,8 +178,8 @@ TYPE
   PFILETIME = UNTRACED REF FILETIME;
   LPFILETIME = PFILETIME; (* compat *)
   FILETIME = RECORD
-    dwLowDateTime : UINT32;
-    dwHighDateTime: UINT32;
+    dwLowDateTime : BITS BITSIZE(UINT32) FOR UINT32;
+    dwHighDateTime: BITS BITSIZE(UINT32) FOR UINT32;
   END;
 
 (* System time is represented with the following structure: *)
@@ -1585,16 +1585,16 @@ TYPE
   PBY_HANDLE_FILE_INFORMATION = UNTRACED REF BY_HANDLE_FILE_INFORMATION;
   LPBY_HANDLE_FILE_INFORMATION = UNTRACED REF BY_HANDLE_FILE_INFORMATION;
   BY_HANDLE_FILE_INFORMATION = RECORD
-    dwFileAttributes    : UINT32;
-    ftCreationTime      : FILETIME;
-    ftLastAccessTime    : FILETIME;
-    ftLastWriteTime     : FILETIME;
-    dwVolumeSerialNumber: UINT32;
-    nFileSizeHigh       : UINT32;
-    nFileSizeLow        : UINT32;
-    nNumberOfLinks      : UINT32;
-    nFileIndexHigh      : UINT32;
-    nFileIndexLow       : UINT32;
+    dwFileAttributes    : BITS BITSIZE(UINT32) FOR UINT32;
+    ftCreationTime      : BITS BITSIZE(FILETIME) FOR FILETIME;
+    ftLastAccessTime    : BITS BITSIZE(FILETIME) FOR FILETIME;
+    ftLastWriteTime     : BITS BITSIZE(FILETIME) FOR FILETIME;
+    dwVolumeSerialNumber: BITS BITSIZE(UINT32) FOR UINT32;
+    nFileSizeHigh       : BITS BITSIZE(UINT32) FOR UINT32;
+    nFileSizeLow        : BITS BITSIZE(UINT32) FOR UINT32;
+    nNumberOfLinks      : BITS BITSIZE(UINT32) FOR UINT32;
+    nFileIndexHigh      : BITS BITSIZE(UINT32) FOR UINT32;
+    nFileIndexLow       : BITS BITSIZE(UINT32) FOR UINT32;
   END;
 
 <*EXTERNAL GetFileInformationByHandle:WINAPI*>
@@ -2280,14 +2280,14 @@ TYPE
   PWIN32_FIND_DATAA = UNTRACED REF WIN32_FIND_DATAA;
   LPWIN32_FIND_DATAA = UNTRACED REF WIN32_FIND_DATAA;
   WIN32_FIND_DATAA = RECORD
-    dwFileAttributes  : UINT32;
-    ftCreationTime    : FILETIME;
-    ftLastAccessTime  : FILETIME;
-    ftLastWriteTime   : FILETIME;
-    nFileSizeHigh     : UINT32;
-    nFileSizeLow      : UINT32;
-    dwReserved0       : UINT32;
-    dwReserved1       : UINT32;
+    dwFileAttributes  : BITS BITSIZE(UINT32) FOR UINT32;
+    ftCreationTime    : BITS BITSIZE(FILETIME) FOR FILETIME;
+    ftLastAccessTime  : BITS BITSIZE(FILETIME) FOR FILETIME;
+    ftLastWriteTime   : BITS BITSIZE(FILETIME) FOR FILETIME;
+    nFileSizeHigh     : BITS BITSIZE(UINT32) FOR UINT32;
+    nFileSizeLow      : BITS BITSIZE(UINT32) FOR UINT32;
+    dwReserved0       : BITS BITSIZE(UINT32) FOR UINT32;
+    dwReserved1       : BITS BITSIZE(UINT32) FOR UINT32;
     cFileName         : ARRAY [0 .. MAX_PATH - 1] OF CHAR;
     cAlternateFileName: ARRAY [0 .. 14 - 1] OF CHAR;
   END;
@@ -2295,14 +2295,14 @@ TYPE
   PWIN32_FIND_DATAW = UNTRACED REF WIN32_FIND_DATAW;
   LPWIN32_FIND_DATAW = UNTRACED REF WIN32_FIND_DATAW;
   WIN32_FIND_DATAW = RECORD
-    dwFileAttributes  : UINT32;
-    ftCreationTime    : FILETIME;
-    ftLastAccessTime  : FILETIME;
-    ftLastWriteTime   : FILETIME;
-    nFileSizeHigh     : UINT32;
-    nFileSizeLow      : UINT32;
-    dwReserved0       : UINT32;
-    dwReserved1       : UINT32;
+    dwFileAttributes  : BITS BITSIZE(UINT32) FOR UINT32;
+    ftCreationTime    : BITS BITSIZE(FILETIME) FOR FILETIME;
+    ftLastAccessTime  : BITS BITSIZE(FILETIME) FOR FILETIME;
+    ftLastWriteTime   : BITS BITSIZE(FILETIME) FOR FILETIME;
+    nFileSizeHigh     : BITS BITSIZE(UINT32) FOR UINT32;
+    nFileSizeLow      : BITS BITSIZE(UINT32) FOR UINT32;
+    dwReserved0       : BITS BITSIZE(UINT32) FOR UINT32;
+    dwReserved1       : BITS BITSIZE(UINT32) FOR UINT32;
     cFileName         : ARRAY [0 .. MAX_PATH - 1] OF WCHAR;
     cAlternateFileName: ARRAY [0 .. 14 - 1] OF WCHAR;
   END;


### PR DESCRIPTION
Record layout rules recently changed.
This broke the important coincidence between windows.h
and the Modula-3 rewrite of it in .i3 files.
Which perhaps were wrong all along, or skirting the rules.
This causes getting a file's size to be misreported,
as very large, and then memory allocation to hold it to fail.

In particular
FILETIME = RECORD
 high, low: UINT32
END;

got 8 byte alignment and then catastrophe putting
that in other records, padding got inserted, offsets
changed, etc.

This goes to show perhaps that rewriting .h files
in .i3 is a bad idea, if you do not have control of those .h files.

If we owned the .h we would only have INTEGER and LONGINT
and nothing ever smaller. And we'd have even number of runs
of INTEGER, so there'd never be any implicit padding for alignment.

And we'd have only what we use, and we might assert correctness
at startup.

There could very well be impact to other platforms esp. 64bit ones.
Within the Critical Mass system, impact is mitigated by reducing
such header rewrites, but they are not eliminated, there could still
be trouble?