### PR TITLE
Revert "Compute backend mode earlier."

### DIFF
--- a/m3-sys/cm3/src/Builder.i3
+++ b/m3-sys/cm3/src/Builder.i3
@@ -3,7 +3,7 @@
 
 INTERFACE Builder;
 
-IMPORT Arg, M3Unit, Quake, QMachine, Target;
+IMPORT Arg, M3Unit, Quake, QMachine;
 
 PROCEDURE BuildPgm (prog: TEXT;  READONLY units: M3Unit.Set;
                     sys_libs: Arg.List;  shared: BOOLEAN;  m: Quake.Machine);
@@ -28,7 +28,5 @@ PROCEDURE EmitPkgImports (READONLY units: M3Unit.Set);
 (* Output all imported packages *)
 
 PROCEDURE SetupNamingConventions (mach : QMachine.T);
-
-PROCEDURE GetBackendMode (mach : Quake.Machine): Target.M3BackendMode_t;
 
 END Builder.

--- a/m3-sys/cm3/src/Builder.m3
+++ b/m3-sys/cm3/src/Builder.m3
@@ -259,21 +259,6 @@ VAR s := NEW (State); (* TODO: Refactor to avoid creating garbage. *)
     SetupNamingConventionsInternal (s, mach);
   END SetupNamingConventions;
 
-PROCEDURE GetBackendMode (mach : Quake.Machine): Target.M3BackendMode_t =
-VAR s := NEW (State); (* TODO: Refactor to avoid creating garbage. *)
-    value: QValue.Binding;
-  BEGIN
-    s.machine := mach;
-    value := GetDefn (s, "M3_BACKEND_MODE");
-    IF value = NIL THEN
-      value := GetDefn (s, "BACKEND_MODE");
-    END;
-    IF value = NIL THEN
-        ConfigErr (s, "BACKEND_MODE or M3_BACKEND_MODE", "not defined");
-    END;
-    RETURN ConvertBackendModeStringToEnum(s, value);
-  END GetBackendMode;
-
 PROCEDURE CompileUnits (main     : TEXT;
                READONLY units    : M3Unit.Set;
                         sys_libs : Arg.List;
@@ -303,8 +288,16 @@ PROCEDURE CompileUnits (main     : TEXT;
 
     s.target := GetConfigItem (s, "TARGET");
 
-    <*ASSERT Target.BackendModeInitialized *>
-    s.m3backend_mode := Target.BackendMode;
+    value := GetDefn (s, "M3_BACKEND_MODE");
+    IF value = NIL THEN
+      value := GetDefn (s, "BACKEND_MODE");
+    END;
+    IF value = NIL THEN
+        ConfigErr (s, "BACKEND_MODE or M3_BACKEND_MODE", "not defined");
+    END;
+    s.m3backend_mode := ConvertBackendModeStringToEnum(s, value);
+    Target.BackendMode := Target.BackendMode;
+    Target.BackendModeInitialized := TRUE;
 
     value := GetDefn (s, "TARGET_NAMING");
     IF value # NIL THEN

--- a/m3-sys/cm3/src/Main.m3
+++ b/m3-sys/cm3/src/Main.m3
@@ -92,6 +92,8 @@ VAR defs: TextTextTbl.T;
         CheckExpire (Quake.LookUp (mach, "INSTALL_KEY"));
         *)
 
+        Builder.SetupNamingConventions (mach);
+
         (* figure out where we are and get where we want to be *)
         build_dir := Quake.LookUp (mach, "BUILD_DIR");
         IF (build_dir = NIL) THEN
@@ -99,9 +101,6 @@ VAR defs: TextTextTbl.T;
         END;
         Target.SetBuild_dir (build_dir);
         Dirs.SetUp (build_dir);
-
-        Target.BackendMode := Builder.GetBackendMode (mach);
-        Target.BackendModeInitialized := TRUE;
 
         (* define the "builtin" quake functions *)
         M3Build.SetUp (mach, Dirs.package, Dirs.to_package,


### PR DESCRIPTION
This reverts commit 7508af6f1bec3f293153017914ae103531822234.

It turned out not to be useful, and, unrelated, accidentally
removed Builder.SetupNamingConventions.

On the timing, the thing is, it is set before we create/run
the backend. It is set in config before config does
conditionals. So it is probably set early enough.