### PR TITLE
m3core:Remove Compiler.ThisPlatform_String.

### DIFF
--- a/m3-libs/m3core/src/runtime/common/Compiler.tmpl
+++ b/m3-libs/m3core/src/runtime/common/Compiler.tmpl
@@ -15,7 +15,9 @@ readonly Compiler_i3 = [
   "CONST",
   "  ThisOS       = OS." & OS_TYPE & ";",
   "  ThisOS_String  = \"" & OS_TYPE & "\";",
-  "  ThisPlatform_String = \"" & TARGET & "\";",
+ % This makes C backend output different for every platform.
+ % Nobody in-tree uses it. If it is really needed, just omit it when using C backend.
+ %"  ThisPlatform_String = \"" & TARGET & "\";",
   "  ThisEndian = ENDIAN." & TARGET_ENDIAN & ";",
   "  ThisEndian_String = \"" & TARGET_ENDIAN & "\";",
   "",


### PR DESCRIPTION
Nobody in-tree uses it.

The problem with Compiler.ThisPlatform_String is it makes
the C backend output different for every system, for m3core.

It isn't even all that old, no time to build up users.

I replaced Compiler.ThisPlatform with it around 10 years ago.
The problem with Compiler.ThisPlatform was it forced
the matter of not rebuilding m3core with new compiler when
adding a platform. Because the compiler and runtime both
had a big enum with all platforms. The enum is now gone from
both places. I guess nobody was using that either.

If someone really uses this, choices:
 - They can compute it ad-hoc but not terrible in ifdef C.
 - They can compute it at runtime with uname on Unix.
 - They can restore this, but not if using C backend or
   if bootstrapping (see how we handle the thread libraries,
   compile all for boot-C, compile one normally;
   though maybe "clean" that up).

It is mostly a bad idea -- what are you going to do with string?
Print it? Write a portability adaption library?
Printing isn't worth a lot. A portability library, maybe.
We kinda just need to start using autoconf and/or cmake
within the system to establish some replacement patterns,
that meet everyone's goals.