### PR TITLE
m3core:Assume C99 for float on all current Unix platforms.

### DIFF
--- a/m3-libs/m3core/src/float/m3makefile
+++ b/m3-libs/m3core/src/float/m3makefile
@@ -16,13 +16,10 @@ _FloatPieces = {
 %  "FreeBSD4"      : [ "IEEE", "IEEE-le", "C99" ]
 }
 
+% C99 might require Solaris 2.10 or newer for {I386,SPARC32,SPARC64}_SOLARIS.
+% AMD64_SOLARIS presumably requires Solaris 2.10.
 _FloatPiecesNoC99 = {
     "NT",
-    "SOLsun",           % Solaris <2.10
-    "SOLgnu",           % Solaris <2.10
-    "SPARC32_SOLARIS",  % Solaris <2.10
-    "SPARC64_SOLARIS",  % Solaris <2.10
-    "I386_SOLARIS",     % Solaris <2.10
 }
 
 _FloatPiecesC99 = {


### PR DESCRIPTION
NT remains a hold out though current toolsets do support it.
We can probably also write platform specific code for it.

The only Unix hold out was {I386,SPARC32,SPARC64}_SOLARIS
with the comment that it was for Solaris < 2.10.
I did at some point test AMD64_SOLARIS, and Solaris 2.10 is already
quite old, and this holds back all Solaris builds, since
we don't discern precise version, just aimed for low common denominators.

Just m3makefile change.
Various old code remains, should someone really need it.

This will help converge C backend output though I hadn't checked these.