### PR TITLE
m3core: Remove struct_sockaddr_un from .i3 files.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Usocket.i3
+++ b/m3-libs/m3core/src/unix/Common/Usocket.i3
@@ -4,7 +4,7 @@
 
 INTERFACE Usocket;
 
-FROM Ctypes IMPORT int, void_star, const_void_star;
+FROM Ctypes IMPORT int, void_star, const_void_star, const_char_star;
 FROM Cstddef IMPORT size_t;
 FROM Uin IMPORT struct_sockaddr_in;
 IMPORT Utypes, Uin;
@@ -117,7 +117,6 @@ IMPORT Utypes, Uin;
 <*EXTERNAL "Usocket__SOMAXCONN"*>   VAR SOMAXCONN: int; (* Maximum queue length specifiable by listen. *)
 
 TYPE
-  struct_sockaddr_un = Uin.struct_sockaddr_un;
   socklen_t = Utypes.socklen_t; (* size_t *)
   socklen_t_star = UNTRACED REF socklen_t;
 
@@ -171,5 +170,22 @@ PROCEDURE shutdown(s, how: int): int RAISES {};
 
 <*EXTERNAL "Usocket__socket"*>
 PROCEDURE socket(af, type, protocol: int): int RAISES {};
+
+(* Copy path into a struct sockaddr_un.sun_path
+ * set sun_family = AF_UNIX
+ * call bind or connect.
+ * For failure return -1.
+ * If path does not fit in sockaddr, errno = ENAMETOOLONG
+ *
+ * This hides the layout of sockaddr_un from Modula-3.
+ *)
+<*EXTERNAL "Usocket__connect_un"*>
+PROCEDURE connect_un(fd: int; path: const_char_star): int;
+
+<*EXTERNAL "Usocket__bind_un"*>
+PROCEDURE bind_un(fd: int; path: const_char_star): int;
+
+<*EXTERNAL "Usocket__accept_un"*>
+PROCEDURE accept_un(fd: int): int;
 
 END Usocket.

--- a/m3-libs/m3core/src/unix/uin-common/Uin.i3
+++ b/m3-libs/m3core/src/unix/uin-common/Uin.i3
@@ -39,11 +39,6 @@ TYPE
     data       : ARRAY [0..13] OF CHAR;
   END;
 
-  struct_sockaddr_un = RECORD
-    sun_family: unsigned_short; (* this is signed on some platforms; it does not matter *)
-    sun_path: ARRAY [0..103] OF char;
-  END;
-
 <*EXTERNAL "Uin__ntohl"*> PROCEDURE ntohl(x: unsigned): unsigned;
 <*EXTERNAL "Uin__ntohs"*> PROCEDURE ntohs(x: unsigned_short): unsigned_short;
 <*EXTERNAL "Uin__htonl"*> PROCEDURE htonl(x: unsigned): unsigned;

--- a/m3-libs/m3core/src/unix/uin-len/Uin.i3
+++ b/m3-libs/m3core/src/unix/uin-len/Uin.i3
@@ -29,12 +29,6 @@ TYPE
     data       : ARRAY [0..13] OF CHAR;
   END;
 
-  struct_sockaddr_un = RECORD
-    sun_len: unsigned_char;
-    sun_family: unsigned_char;
-    sun_path: ARRAY [0..103] OF char;
-  END;
-
 <*EXTERNAL "Uin__ntohl"*> PROCEDURE ntohl(x: unsigned): unsigned;
 <*EXTERNAL "Uin__ntohs"*> PROCEDURE ntohs(x: unsigned_short): unsigned_short;
 <*EXTERNAL "Uin__htonl"*> PROCEDURE htonl(x: unsigned): unsigned;


### PR DESCRIPTION
Uin-len vs. common is a source of C backend variation
across Unix platforms.

Provide instead:
  INTEGER Uin__bind_un(const char*);
  INTEGER Uin__connect_un(const char*);
  INTEGER Usocket__accept_un(int);

which fill in struct sockaddr_un and call bind or connect or accept.
While there also avoid the silent buffer overflows of the old code.