### PR TITLE
Revert "Add struct_sockaddr to the Darwin/BSD Uin."

### DIFF
--- a/m3-libs/m3core/src/unix/uin-len/Uin.i3
+++ b/m3-libs/m3core/src/unix/uin-len/Uin.i3
@@ -22,13 +22,6 @@ TYPE
     sin_zero: ARRAY [0..7] OF char;
   END;
 
-  (* generic struct to get the family before casting *)
-  struct_sockaddr = RECORD
-    sin_len: unsigned_char; (* This is absent on other platforms. *)
-    sin_family: unsigned_char; (* This is 16 bits on other platforms. *)
-    data       : ARRAY [0..13] OF CHAR;
-  END;
-
 <*EXTERNAL "Uin__ntohl"*> PROCEDURE ntohl(x: unsigned): unsigned;
 <*EXTERNAL "Uin__ntohs"*> PROCEDURE ntohs(x: unsigned_short): unsigned_short;
 <*EXTERNAL "Uin__htonl"*> PROCEDURE htonl(x: unsigned): unsigned;


### PR DESCRIPTION
This reverts commit a9886790444fa05ffad31d857abc2c9aa8ca9ec8.

It wasn't needed as I thought, and now delete both.