### PR TITLE
m3core:Remove struct_sockaddr_in6 and struct_in6_addr.

### DIFF
--- a/m3-libs/m3core/src/unix/uin-common/Uin.i3
+++ b/m3-libs/m3core/src/unix/uin-common/Uin.i3
@@ -21,18 +21,6 @@ TYPE
     sin_zero: ARRAY [0..7] OF char;
   END;
 
-  struct_in6_addr = RECORD
-    u6_addr8 : ARRAY[0..15] OF char;
-  END;
-
-  struct_sockaddr_in6 = RECORD
-    sin6_family : unsigned_short;   (* AF_INET6 *)
-    sin6_port   : unsigned_short;   (* port number *)
-    sin6_flowinfo : unsigned;       (* IPv6 flow information *)
-    sin6_addr : struct_in6_addr;    (* IPv6 address *)
-    sin6_scope_id : unsigned;       (* Scope ID (new in 2.4) *)
-  END;
-
 <*EXTERNAL "Uin__ntohl"*> PROCEDURE ntohl(x: unsigned): unsigned;
 <*EXTERNAL "Uin__ntohs"*> PROCEDURE ntohs(x: unsigned_short): unsigned_short;
 <*EXTERNAL "Uin__htonl"*> PROCEDURE htonl(x: unsigned): unsigned;


### PR DESCRIPTION
They are missing for Darwin/BSD and are not used.