### PR TITLE
m3-comm:Refactor sockaddr_in usage into C to

### DIFF
--- a/m3-comm/udp/src/Common/UDPInternal.i3
+++ b/m3-comm/udp/src/Common/UDPInternal.i3
@@ -2,9 +2,8 @@ UNSAFE INTERFACE UDPInternal;
 
 (* Isolate Modula-3 from /usr/include e.g. struct sockaddr *)
 
-IMPORT IP;
-FROM Ctypes IMPORT int;
-TYPE Address4 = Ctypes.char_star; (* instead of IP.Address4 for clarity of ABI *)
+FROM Ctypes IMPORT int, char_star;
+TYPE Address4 = char_star; (* instead of IP.Address4 for clarity of ABI *)
 
 <*EXTERNAL "UDPInternal__Init"*>
 PROCEDURE Init(VAR fd: INTEGER; addr: Address4; port: int; VAR err, status: int);

--- a/m3-comm/udp/src/POSIX/UDPPosix.m3
+++ b/m3-comm/udp/src/POSIX/UDPPosix.m3
@@ -44,7 +44,7 @@ PROCEDURE Init(self: T; myPort: IP.Port; myAddr: IP.Address): T
     self.myEnd.port := myPort;
     self.myEnd.addr := myAddr;
 
-    UDPInternal.Init(self.fileno, myAddr, myPort, err, status);
+    UDPInternal.Init(self.fileno, ADR(myAddr.a[0]), myPort, err, status);
 
     (* create socket via socket(2) system call *)
     IF self.fileno = -1 THEN


### PR DESCRIPTION
drive C backend convergence and portability.

Clarify the calling convention.