### PR TITLE
m3tcp: Ongoing struct_sockaddr removal.

### DIFF
--- a/m3-comm/tcp/src/POSIX/TCPExtras.m3
+++ b/m3-comm/tcp/src/POSIX/TCPExtras.m3
@@ -4,22 +4,19 @@
 
 UNSAFE MODULE TCPExtras;
 
-IMPORT Ctypes, IP, IPError, TCP, TCPPosix, Uin, Usocket;
+IMPORT Ctypes, IP, IPError, IPInternal, TCP, TCPPosix, Uin;
 
 PROCEDURE LocalEndpoint (conn: TCP.T): IP.Endpoint RAISES {IP.Error} =
-  VAR
-    addr : Uin.struct_sockaddr_in;
-    len  : Usocket.socklen_t := BYTESIZE (addr);
-    ep   : IP.Endpoint;
+  VAR port := 0;
+      ep   : IP.Endpoint;
   BEGIN
     LOCK conn DO
       IF conn.closed THEN IPError.Raise (TCP.Closed); END;
-      IF Usocket.getsockname (conn.fd, ADR (addr), ADR(len)) < 0 THEN
+      IF IPInternal.getsockname (conn.fd, ADR(ep.addr.a[0]), port) < 0 THEN
         IPError.RaiseUnexpected ();
       END;
     END;
-    ep.addr := LOOPHOLE (addr.sin_addr, IP.Address);
-    ep.port := Uin.ntohs (addr.sin_port);
+    ep.port := Uin.ntohs(port);
     RETURN ep;
   END LocalEndpoint;
 

--- a/m3-comm/tcp/src/common/IPInternal.i3
+++ b/m3-comm/tcp/src/common/IPInternal.i3
@@ -53,4 +53,7 @@ PROCEDURE GetAddrInfo(VAR endpoint: EP; node, port: char_star): int;
 <*EXTERNAL "IPInternal__GetNameInfo"*>
 PROCEDURE GetNameInfo(family, port: int; addr: ADDRESS; VAR host, service: TEXT): int;
 
+<*EXTERNAL "IPInternal__getsockname"*>
+PROCEDURE getsockname(fd: INTEGER; address: char_star; VAR port: INTEGER): INTEGER;
+
 END IPInternal.

--- a/m3-comm/tcp/src/common/IP_h.h
+++ b/m3-comm/tcp/src/common/IP_h.h
@@ -75,6 +75,10 @@ void
 __cdecl
 IPError__Die(void);
 
+INTEGER
+__cdecl
+IPInternal__getsockname(INTEGER fd, char* address, INTEGER* port);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
It should be removed from the entire tree so that it can be removed from m3core and all the Unix platforms look the same in this regard.