### PR TITLE
Ongoing sockaddr removal.

### DIFF
--- a/m3-comm/tcp/src/POSIX/TCP.m3
+++ b/m3-comm/tcp/src/POSIX/TCP.m3
@@ -9,7 +9,7 @@
 
 UNSAFE MODULE TCP EXPORTS TCP, TCPMisc, TCPSpecial;
 
-IMPORT Atom, AtomList, IP, Rd, Wr, Thread;
+IMPORT Atom, AtomList, IP, IPInternal, Rd, Wr, Thread;
 IMPORT Usocket, Uerror, Uin, Unix, Uuio, Utypes,
        SchedulerPosix, Fmt, Word;
 IMPORT ConnFD;
@@ -49,7 +49,6 @@ VAR ClosedErr: AtomList.T;
 PROCEDURE NewConnector (ep: IP.Endpoint): Connector RAISES {IP.Error} =
   VAR
     res                := NEW(Connector, ep := ep);
-    name  : SockAddrIn;
     status: INTEGER;
     True: int := 1;  (* CONST *)
   BEGIN
@@ -66,11 +65,7 @@ PROCEDURE NewConnector (ep: IP.Endpoint): Connector RAISES {IP.Error} =
     MakeNonBlocking (res.fd);
     EVAL Usocket.setsockopt(res.fd, Usocket.SOL_SOCKET, Usocket.SO_REUSEADDR,
       ADR(True), BYTESIZE(True));
-    name.sin_family := Usocket.AF_INET;
-    name.sin_port := Uin.htons(ep.port);
-    name.sin_addr.s_addr := LOOPHOLE(ep.addr, Utypes.u_int);
-    name.sin_zero := Sin_Zero;
-    status := Usocket.bind(res.fd, ADR(name), BYTESIZE(SockAddrIn));
+    status := IPInternal.NewConnector_Bind(res.fd, ADR(ep.addr.a[0]), ep.port);
     IF status # 0 THEN
       IF Cerrno.GetErrno() = Uerror.EADDRINUSE THEN
         Raise(IP.PortBusy);

--- a/m3-comm/tcp/src/POSIX/TCPExtras.m3
+++ b/m3-comm/tcp/src/POSIX/TCPExtras.m3
@@ -16,7 +16,7 @@ PROCEDURE LocalEndpoint (conn: TCP.T): IP.Endpoint RAISES {IP.Error} =
         IPError.RaiseUnexpected ();
       END;
     END;
-    ep.port := Uin.ntohs(port);
+    ep.port := port;
     RETURN ep;
   END LocalEndpoint;
 

--- a/m3-comm/tcp/src/common/IPInternal.i3
+++ b/m3-comm/tcp/src/common/IPInternal.i3
@@ -3,6 +3,7 @@ IMPORT Ctypes, IP;
 
 TYPE
   char_star = Ctypes.char_star;
+  const_char_star = Ctypes.const_char_star;
   EP = IP.EP;
   int = Ctypes.int;
   Address4 = IP.Address4;
@@ -55,5 +56,8 @@ PROCEDURE GetNameInfo(family, port: int; addr: ADDRESS; VAR host, service: TEXT)
 
 <*EXTERNAL "IPInternal__getsockname"*>
 PROCEDURE getsockname(fd: INTEGER; address: char_star; VAR port: INTEGER): INTEGER;
+
+<*EXTERNAL "IPInternal__NewConnector_Bind"*>
+PROCEDURE NewConnector_Bind(fd: INTEGER; address: const_char_star; port: INTEGER): INTEGER;
 
 END IPInternal.


### PR DESCRIPTION
This is so that Unix systems are more similar and C backend output can be identical at least in some places.