### PR TITLE
m3_comm: Somewhat refactor.

### DIFF
--- a/m3-comm/tcp/src/POSIX/TCPExtras.m3
+++ b/m3-comm/tcp/src/POSIX/TCPExtras.m3
@@ -12,7 +12,7 @@ PROCEDURE LocalEndpoint (conn: TCP.T): IP.Endpoint RAISES {IP.Error} =
   BEGIN
     LOCK conn DO
       IF conn.closed THEN IPError.Raise (TCP.Closed); END;
-      IF IPInternal.getsockname (conn.fd, ADR(ep.addr.a[0]), port) < 0 THEN
+      IF IPInternal.getsockname_in (conn.fd, ADR(ep.addr.a[0]), port) < 0 THEN
         IPError.RaiseUnexpected ();
       END;
     END;

--- a/m3-comm/tcp/src/common/IPInternal.i3
+++ b/m3-comm/tcp/src/common/IPInternal.i3
@@ -54,10 +54,10 @@ PROCEDURE GetAddrInfo(VAR endpoint: EP; node, port: char_star): int;
 <*EXTERNAL "IPInternal__GetNameInfo"*>
 PROCEDURE GetNameInfo(family, port: int; addr: ADDRESS; VAR host, service: TEXT): int;
 
-<*EXTERNAL "IPInternal__getsockname"*>
-PROCEDURE getsockname(fd: INTEGER; address: char_star; VAR port: INTEGER): INTEGER;
+<*EXTERNAL "IPInternal__getsockname_in"*>
+PROCEDURE getsockname_in(fd: INTEGER; address: char_star; VAR port: INTEGER): INTEGER;
 
-<*EXTERNAL "IPInternal__NewConnector_Bind"*>
-PROCEDURE NewConnector_Bind(fd: INTEGER; address: const_char_star; port: INTEGER): INTEGER;
+<*EXTERNAL "IPInternal__bind_in"*>
+PROCEDURE bind_in(fd: INTEGER; address: const_char_star; port: INTEGER): INTEGER;
 
 END IPInternal.

--- a/m3-comm/tcp/src/common/IP_h.h
+++ b/m3-comm/tcp/src/common/IP_h.h
@@ -77,7 +77,7 @@ IPError__Die(void);
 
 INTEGER
 __cdecl
-IPInternal__getsockname(INTEGER fd, char* address, INTEGER* port);
+IPInternal__getsockname_in(INTEGER fd, char* address, INTEGER* port);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/m3-comm/udp/src/Common/UDP_c.c
+++ b/m3-comm/udp/src/Common/UDP_c.c
@@ -44,47 +44,6 @@ UDPInternal__Assert(void)
 
 INTEGER
 __cdecl
-UDPInternal__Init(
-    INTEGER* fd,
-    char* addr,
-    INTEGER port,
-    INTEGER* err,
-    INTEGER* status)
-// addr is array of char so we cannot assume alignment.
-{
-    sockaddr_in sockaddr = {0};
-
-    ZERO_MEMORY(sockaddr);
-
-    Scheduler__DisableSwitching();
-
-    // create socket via socket(2) system call
-    *fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (*fd == -1)
-    {
-        *err = errno;
-    }
-    else
-    {
-        // bind socket via bind(2) system call
-        sockaddr.sin_family = AF_INET;
-        sockaddr.sin_port = htons(port);
-
-        // Copy possibly unaligned 4 character array to 4 byte integer.
-        memcpy(&sockaddr.sin_addr.s_addr, addr, 4);
-
-        *status = bind(*fd, &sockaddr, sizeof(sockaddr));
-        if (*status)
-        {
-            *err = errno;
-        }
-    }
-
-    Scheduler__EnableSwitching();
-}
-
-INTEGER
-__cdecl
 UDPInternal__Send(
     INTEGER fd,
     void const* volatile* data,


### PR DESCRIPTION
The "abstraction" recognized at least to fit legacy code, is protocol specific wrappers.
i.e. IPv4 specific.

i.e.
instead of
WrappingUpSepcificHighLevelFunctions as I was doing or low level bind(generic sockaddr* that must match underlying system), introduce bind_in(ipv4 address and port)

Along with these though, to support existing low level code, we can provide bind(portable/ideal sockaddr
that gets converted, so the older code can be left asis.

Older as in, it does not work with ipv6 w/o some work.

The protocol specific functions should be moved to Usocket.