### PR TITLE
Revert "m3c:m3front does not always reveal_opaque in the same order,"

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2988,20 +2988,15 @@ BEGIN
     x.Type_Init(NEW(Type_t, cgtype := Target.Address.cg_type, typeid := typeid), typedef := TRUE); (* TODO? *)
 END declare_opaque;
 
-PROCEDURE reveal_opaque(self: DeclareTypes_t; lhs, rhs: TypeUID) =<*NOWARN*>
-(* VAR x := self.self; *)
+PROCEDURE reveal_opaque(self: DeclareTypes_t; lhs, rhs: TypeUID) =
+VAR x := self.self;
 BEGIN
-    (* m3front does not always reveal_opaque in the same order,
-     * damaging ability to diff output. So do not output the comment.
-     * This needs further attention.
-     *
-     * IF DebugVerbose(x) THEN
-     *  x.comment("reveal_opaque lhs:", TypeIDToText(lhs),
-     *      " rhs:" & TypeIDToText(rhs));
-     * ELSE
-     *  x.comment("reveal_opaque");
-     * END;
-     *)
+    IF DebugVerbose(x) THEN
+        x.comment("reveal_opaque lhs:", TypeIDToText(lhs),
+            " rhs:" & TypeIDToText(rhs));
+    ELSE
+        x.comment("reveal_opaque");
+    END;
 END reveal_opaque;
 
 PROCEDURE declare_exception(self: DeclareTypes_t; name: Name; arg_type: TypeUID; raise_proc: BOOLEAN; base: M3CG.Var; offset: INTEGER) =


### PR DESCRIPTION
This reverts commit 819bd8b87da764f1dc9f582ceb404e6be3e92f92.

This will be fixed correctly.