### PR TITLE
cm3: Move version from C object to C source, using

### DIFF
--- a/m3-sys/cm3/src/Makefile.m3
+++ b/m3-sys/cm3/src/Makefile.m3
@@ -1,11 +1,11 @@
 (* Copyright 1996-2000 Critical Mass, Inc. All rights reserved.    *)
 (* See file COPYRIGHT-CMASS for details. *)
 
-MODULE Makefile;
+UNSAFE MODULE Makefile;
 
 IMPORT FS, M3File, M3Timers, OSError, Params, Process, Text, Thread, Wr;
 IMPORT Arg, M3Build, M3Options, M3Path, Msg, Utils, TextSeq, TextTextTbl;
-IMPORT MxConfig, Dirs, Version;
+IMPORT MxConfig, Dirs, Version, M3toC;
 
 TYPE
   NK = M3Path.Kind;
@@ -758,7 +758,7 @@ BEGIN
   EVAL defs.put("CM3_VERSION", Version.Number);(* version as number *)
   EVAL defs.put("CM3_CHANGED", Version.LastChanged); (* date of last change *)
   EVAL defs.put("CM3_CREATED", Version.LastChanged); (* backw. compatibility *)
-  EVAL defs.put("CM3_COMPILED", Version.Created); (* date of compilation *)
+  EVAL defs.put("CM3_COMPILED", M3toC.StoT(Version.Created())); (* date of compilation *)
   EVAL defs.put("M3_PROFILING", "");           (* no profiling by default *)
   EVAL defs.put("EOL", Wr.EOL);
 END Makefile.

--- a/m3-sys/cm3/src/Version.c
+++ b/m3-sys/cm3/src/Version.c
@@ -1,0 +1,87 @@
+#include <assert.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+const char* Version__Created(void); // declare for gcc/clang
+
+// Convert:
+//            1         2
+//  012345678901234567890123
+//  Wed Mar 17 23:52:48 2021 __TIMESTAMP__
+//  Mar 18 202100:14:43     __DATE__ __TIME__;
+// to:
+//  2021-03-18 04:44:17
+
+//static const char versionCreated1[] = __TIMESTAMP__;
+static const char versionCreated1[] = __DATE__ __TIME__;
+static char versionCreated2[] = __DATE__ __TIME__;
+
+const char* Version__Created(void)
+{
+    const char* month = versionCreated1;
+    int i = -1;
+    int j = 6;
+    versionCreated2[++i] = versionCreated1[++j];
+    versionCreated2[++i] = versionCreated1[++j];
+    versionCreated2[++i] = versionCreated1[++j];
+    versionCreated2[++i] = versionCreated1[++j];
+    versionCreated2[++i] = '-';
+    j = 0;
+#if 1
+         if (!memcmp(month, "Jan", 3)) j = 1;
+    else if (!memcmp(month, "Feb", 3)) j = 2;
+    else if (!memcmp(month, "Mar", 3)) j = 3;
+    else if (!memcmp(month, "Apr", 3)) j = 4;
+    else if (!memcmp(month, "May", 3)) j = 5;
+    else if (!memcmp(month, "Jun", 3)) j = 6;
+    else if (!memcmp(month, "Jul", 3)) j = 7;
+    else if (!memcmp(month, "Aug", 3)) j = 8;
+    else if (!memcmp(month, "Sep", 3)) j = 9;
+    else if (!memcmp(month, "Oct", 3)) j = 10;
+    else if (!memcmp(month, "Nov", 3)) j = 11;
+    else if (!memcmp(month, "Dec", 3)) j = 12;
+#else
+         if (month[2] == 'l') j = 7; // Jul
+    else if (month[1] == 'u') j = 6; // Jun
+    else if (month[0] == 'J') j = 1; // Jan
+    else if (month[0] == 'F') j = 2; // Feb
+    else if (month[2] == 'y') j = 5; // May
+    else if (month[3] == 'g') j = 8; // Aug
+    else if (month[0] == 'M') j = 3; // Mar
+    else if (month[0] == 'A') j = 4; // Apr
+    else if (month[0] == 'S') j = 9; // Sep
+    else if (month[0] == 'O') j = 10; // Oct
+    else if (month[0] == 'N') j = 11; // Nov
+    else if (month[0] == 'D') j = 12; // Dec
+#endif
+    assert(j);
+    versionCreated2[++i] = '0' + (j / 10);
+    versionCreated2[++i] = '0' + (j % 10);
+    versionCreated2[++i] = '-';
+    j = 3;
+    versionCreated2[++i] = versionCreated1[++j];
+    versionCreated2[++i] = versionCreated1[++j];
+    versionCreated2[++i] = ' ';
+    return versionCreated2;
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#if 0
+
+#include <stdio.h>
+
+int main()
+{
+    printf("%s\n", versionCreated1);
+    printf("%s\n", Version__Created());
+    return 0;
+}
+
+#endif

--- a/m3-sys/cm3/src/m3makefile
+++ b/m3-sys/cm3/src/m3makefile
@@ -34,6 +34,7 @@ import ("m3quake")
 
 include ("version.quake")
 version_impl ("Version")
+c_source ("Version")
 
 module ("M3Backend")
 import ("m3objfile")

--- a/m3-sys/cm3/src/version.quake
+++ b/m3-sys/cm3/src/version.quake
@@ -63,11 +63,16 @@ proc version_impl(name) is
     end
     include(".." & SL & ".." & SL & ".." & SL & "scripts" & SL & "version.quake")
     >> tempname in
+        write("IMPORT Ctypes;", CR)
         write("CONST", CR)
         write("  Text = \"", CM3VERSION, "\";", CR)
         write("  Number = \"", CM3VERSIONNUM, "\";", CR)
         write("  LastChanged = \"", CM3LASTCHANGED, "\";", CR)
-        write("  Created = \"", NOW, "\";", CR)
+
+        % This comment serves to retain the old behavior where
+        % cm3 prints the time it built, if any of it changes.
+        % This does not end up in the C backend output.
+        write("  (* Created = \"", NOW, "\"; *)", CR)
 
         %
         % When cm3 uses this data, it is describing the HOST.
@@ -145,6 +150,9 @@ proc version_impl(name) is
         end
         write("  TargetNaming      = \"", TargetNaming, "\";", CR)
         write("  NamingConventions = \"", TargetNaming, "\";", CR)
+
+        % TODO Generating a constant TEXT in C would be nice maybe.
+        write("<*EXTERNAL \"Version__Created\"*> PROCEDURE Created():Ctypes.const_char_star;", CR)
 
         write("END ", name, ".", CR)
     end


### PR DESCRIPTION
m3: Move version from C object to C source, using `__TIME__` and `__DATE__.` This enables diffing
compiler output across multiple runs. Otherwise there is always a difference.

The behavior where cm3 recompiles a little and relinks
every time, is preserved. The offending content is placed
in a comment.

This is a little gross, but comparability of bootstraps is worth something.