### PR TITLE
config: On NT host default to native compile, not I386_NT.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/cm3.cfg
+++ b/m3-sys/cminstall/src/config-no-install/cm3.cfg
@@ -55,7 +55,12 @@ local readonly proc CM3TargetProbe() is
     end
 
     if equal($OS, "Windows_NT")
-        TARGET = "I386_NT"
+        % TODO run cl.exe and detect its target
+        if equal($PROCESSOR_ARCHITECTURE, "x86")
+          TARGET = "I386_NT"
+        else
+          TARGET = $PROCESSOR_ARCHITECTURE & "_NT"
+        end
         write("defaulting to native build: ", TARGET, EOL)
         return
     end


### PR DESCRIPTION
i.e. $PROCESSOR_ARCHITECTURE, except translating x86 to I386.

Really this should run cl.exe and detect its target.