### PR TITLE
Extend atomics support on arm32, mips64.

### DIFF
--- a/m3-libs/m3core/src/atomic/m3makefile
+++ b/m3-libs/m3core/src/atomic/m3makefile
@@ -1,5 +1,3 @@
-if not equal(TARGET, "ARMEL_LINUX")
-
 Generic_module("Atomic")
 template("atomic")
 
@@ -12,10 +10,6 @@ if not ({"PPC_LINUX", "PPC_DARWIN", "PPC32_OPENBSD",
   Atomic("Longint")
 end
 
-if not ({"MIPS64_OPENBSD", "MIPS64EL_OPENBSD"} contains TARGET)
-  Atomic("Boolean")
-  Atomic("Char")
-  Atomic("WideChar")
-end
-
-end
+Atomic("Boolean")
+Atomic("Char")
+Atomic("WideChar")


### PR DESCRIPTION
Current MIPS64/Linux and ARM32/Linux (armhf) seem to support atomics over 1, 2, 4, 8
so remove prohibition against similar but not same:
ARMEL_LINUX, MIPS64_OPENBSD, MIPS64EL_OPENBSD.

PPC and Sparc32 remains as purportedly missing atomic double.
mips32 probably too. Investigate later/never.

It is possible OpenBSD's compiler has less support.
And when ARMEL_LINUX was introduced it was like v5 or v6.

These otherwise are a barrier to portable distribution.
Perhaps we do need a way to tunnel through this conditionality though.