### PR TITLE
Rework widechar size initialization.

### DIFF
--- a/m3-comm/netobj/src/m3makefile
+++ b/m3-comm/netobj/src/m3makefile
@@ -14,6 +14,7 @@ if defined ("AT_SRC") m3_option("-O") end
 % m3_option ("-verbose")
 % m3_option ("-keep")
 
+import("m3middle")
 import("libm3")
 import("tcp")
 

--- a/m3-sys/cm3/src/Builder.i3
+++ b/m3-sys/cm3/src/Builder.i3
@@ -29,4 +29,8 @@ PROCEDURE EmitPkgImports (READONLY units: M3Unit.Set);
 
 PROCEDURE SetupNamingConventions (mach : QMachine.T);
 
+TYPE State <: REFANY;
+
+PROCEDURE GetConfigItem (s: State;  symbol: TEXT; default: TEXT := NIL): TEXT;
+
 END Builder.

--- a/m3-sys/cm3/src/Builder.m3
+++ b/m3-sys/cm3/src/Builder.m3
@@ -89,8 +89,8 @@ PROCEDURE EmitPkgImports (READONLY units: M3Unit.Set) =
 (*-------------------------------------------------- general compilation ---*)
 (* The "global" variables of a compilation are passed around in a "State". *)
 
-TYPE
-  State = REF RECORD
+REVEAL
+  State = BRANDED REF RECORD
     result_name   : TEXT;               (* base of program or library name *)
     info_name     : TEXT;               (* name of the version stamp file *)
     config_file   : TEXT;               (* name of the current config file *)
@@ -353,7 +353,13 @@ PROCEDURE CompileUnits (main     : TEXT;
       Utils.NoteLocalFileTimes ();
     ETimer.Pop ();
     BuildSearchPaths (s);
-    Utils.InitWidechar (); 
+
+     (* WIDECHAR can be 16 or 32 bits subject to command line and config
+      * If not specified on command line, check config. Default is 16.
+      * "Unicode" means 32.
+      *)
+    Utils.InitWidechar (s);
+
     InhaleLinkInfo (s);
     BuildLibraryPool (s);
 

--- a/m3-sys/cm3/src/Utils.i3
+++ b/m3-sys/cm3/src/Utils.i3
@@ -6,7 +6,7 @@
 
 INTERFACE Utils;
 
-IMPORT File, Wr, Arg, Thread;
+IMPORT File, Wr, Arg, Thread, Builder;
 FROM Ctypes IMPORT const_char_star, int;
 
 PROCEDURE OpenWriter   (name: TEXT;  fatal: BOOLEAN): Wr.T;
@@ -42,7 +42,7 @@ PROCEDURE NoteNewFile      (file: TEXT);
 
 PROCEDURE NoteWidechar16 ();
 PROCEDURE NoteWidecharUni ();
-PROCEDURE InitWidechar (); 
+PROCEDURE InitWidechar (s: Builder.State);
 
 CONST NO_TIME = 0;
 

--- a/m3-sys/m3front/src/builtinTypes/WCharr.i3
+++ b/m3-sys/m3front/src/builtinTypes/WCharr.i3
@@ -7,10 +7,6 @@ IMPORT Type;
 
 VAR T: Type.T;
 
-VAR IsUnicode : BOOLEAN; 
-(* ^Value is set from within package cm3, where it is initially known,
-   prior to calling Initialize. *) 
-
 PROCEDURE Initialize ();
 
 END WCharr.

--- a/m3-sys/m3front/src/builtinTypes/WCharr.m3
+++ b/m3-sys/m3front/src/builtinTypes/WCharr.m3
@@ -4,16 +4,14 @@
 MODULE WCharr;
 
 IMPORT M3, M3ID, EnumType, Tipe, Scope;
+IMPORT Target;
 
 PROCEDURE Initialize () =
   VAR elts: Scope.T;  cs := M3.OuterCheckState;
   VAR NUMBER_WIDECHAR: INTEGER; 
   BEGIN
     elts := Scope.PushNew (FALSE, M3ID.Add ("WIDECHAR"));
-    IF IsUnicode  
-    THEN NUMBER_WIDECHAR := 16_110000
-    ELSE NUMBER_WIDECHAR := 16_10000
-    END; 
+    NUMBER_WIDECHAR := Target.WideCharNumber();
     T := EnumType.New (NUMBER_WIDECHAR, elts);
 (* Widechar Tipe. *) 
 (* This looks OK for new TipeDesc.Op.Widechar.  It's just like Charr. *) 

--- a/m3-sys/m3front/src/exprs/TextExpr.m3
+++ b/m3-sys/m3front/src/exprs/TextExpr.m3
@@ -10,7 +10,6 @@ MODULE TextExpr;
 
 IMPORT M3, CG, Expr, ExprRep, M3String, Textt, Type, M3Buf;
 IMPORT Target, Module, M3RT, M3WString, RunTyme, Procedure;
-IMPORT WCharr;
 
 TYPE
   P = Expr.T OBJECT
@@ -122,10 +121,7 @@ PROCEDURE SetUID (p: P): INTEGER =
         M3String.SetUID (p.value8, uid);
       END;
     ELSE
-      IF WCharr.IsUnicode
-      THEN width := Target.Word32.size
-      ELSE width := Target.Word16.size
-      END; 
+      width := Target.WideCharSize();
       len   := M3WString.Length (p.value32);
       cnt   := - len;
       uid   := M3WString.GetUID (p.value32);

--- a/m3-sys/m3front/src/misc/M3WString.m3
+++ b/m3-sys/m3front/src/misc/M3WString.m3
@@ -3,7 +3,7 @@
 
 MODULE M3WString;
 
-IMPORT M3Buf, Text, Word, CG, WCharr;
+IMPORT M3Buf, Text, Word, CG, Target;
 
 TYPE
   HashTable = REF ARRAY OF T;
@@ -118,10 +118,7 @@ PROCEDURE Init_chars (offset: INTEGER;  t: T;  is_const: BOOLEAN) =
     IF (t = NIL) THEN
       (* done *)
     ELSE
-      IF WCharr.IsUnicode
-      THEN TargetWCBitsize := 32
-      ELSE TargetWCBitsize := 16
-      END; 
+      TargetWCBitsize := Target.WideCharSize();
       IF (t.body # NIL) THEN
         FOR i := 0 TO t.length-1 DO
           CG.Init_intt (offset, TargetWCBitsize, t.body[i], is_const);
@@ -331,7 +328,7 @@ TYPE
 
 PROCEDURE CharLiteral (ch: Char;  VAR(*OUT*) lit: CharBuf): [1..8] =
   BEGIN
-    IF ch > 16_FFFF THEN 
+    IF ch > Target.WideChar16Max THEN
       lit[0] := '\\';  
       lit[1] := 'U';   
       lit[2] := Digits [Word.Extract (ch, 20, 1)];

--- a/m3-sys/m3front/src/misc/Scanner.m3
+++ b/m3-sys/m3front/src/misc/Scanner.m3
@@ -839,7 +839,7 @@ PROCEDURE GetOctalChar (wide: BOOLEAN): INTEGER =
       IF NOT GetOctalDigit (wide, value) THEN RETURN value; END;
       IF NOT GetOctalDigit (wide, value) THEN RETURN value; END;
       IF NOT GetOctalDigit (wide, value) THEN RETURN value; END;
-      IF value > 16_FFFF THEN 
+      IF value > Target.WideChar16Max THEN
         Error.Msg ("Octal escaped WIDECHAR value out of range");
         value := 0; 
       END; 
@@ -885,10 +885,10 @@ PROCEDURE GetHexChar (bytes: [1..3]): INTEGER =
         (* Only get here for a Unicode escape, which is always 6 hex digits. *) 
         IF NOT GetHexDigit (bytes, value) THEN RETURN value; END;
         IF NOT GetHexDigit (bytes, value) THEN RETURN value; END;
-        IF value > 16_10FFFF THEN 
+        IF value > Target.WideChar32Max THEN
           Error.Msg ("Unicode escaped character outside of Unicode range");
           value := 0; 
-        ELSIF NOT WCharr.IsUnicode AND value > 16_FFFF 
+        ELSIF value > Target.WideCharMax()
         THEN 
           Error.Warn
             (2, "Character outside WIDECHAR range, replaced by Unicode replacement character."); 

--- a/m3-sys/m3front/src/values/Module.m3
+++ b/m3-sys/m3front/src/values/Module.m3
@@ -12,7 +12,7 @@ IMPORT M3, M3ID, CG, Value, ValueRep, Scope, Stmt, Error, ESet,  External;
 IMPORT Variable, Type, Procedure, Ident, M3Buf, BlockStmt, Int;
 IMPORT Host, Token, Revelation, Coverage, Decl, Scanner, WebInfo;
 IMPORT ProcBody, Target, M3RT, Marker, File, Tracer, Wr;
-IMPORT WCharr, Jmpbufs;
+IMPORT Jmpbufs;
 
 FROM Scanner IMPORT GetToken, Fail, Match, MatchID, cur;
 
@@ -908,10 +908,7 @@ PROCEDURE Compile (t: T) =
     zz := Scope.Push (t.localScope);
       WebInfo.Reset ();
       CG.Begin_unit ();
-      IF WCharr.IsUnicode
-      THEN CG.Widechar_size (32);
-      ELSE CG.Widechar_size (16);
-      END;
+      CG.Widechar_size (Target.WideCharSize());
       CG.Gen_location (t.origin);
       Host.env.note_unit (t.name, t.interface);
       DeclareGlobalData (t);

--- a/m3-sys/m3linker/src/Mx.i3
+++ b/m3-sys/m3linker/src/Mx.i3
@@ -29,11 +29,6 @@ CONST
 CONST
   BuiltinUnitName = "M3_BUILTIN";
 
-VAR UnicodeWideChar := FALSE; 
-    (* This is set by the front end when it knows.  We do this this hackish
-       way to avoid cyclic package dependencies, as m3 front depends on
-       m3linker. *) 
-
 TYPE
   LinkSet <: REFANY;
 

--- a/m3-sys/m3linker/src/MxIn.m3
+++ b/m3-sys/m3linker/src/MxIn.m3
@@ -9,6 +9,7 @@ MODULE MxIn;
 
 IMPORT Text, File, Wr, Stdio, Fmt, Word, Thread, Atom, AtomList;
 IMPORT Mx, MxRep, M3ID, M3FP, M3File, MxVS, OSError;
+IMPORT Target;
 <*FATAL Wr.Failure, Thread.Alerted*>
 
 CONST
@@ -165,7 +166,7 @@ PROCEDURE ReadMagic (VAR s: State)
     END;
     MagicText := Text.FromChars(SUBARRAY(MagicArr,0,i));
 
-    IF Mx.UnicodeWideChar
+    IF Target.IsWideChar32()
     THEN
       IF Text.Equal(MagicText, Mx.LinkerMagicWCUni)
       THEN (* All is Ok. *)

--- a/m3-sys/m3linker/src/MxOut.m3
+++ b/m3-sys/m3linker/src/MxOut.m3
@@ -12,6 +12,7 @@ MODULE MxOut;
 IMPORT Wr, IntIntTbl;
 IMPORT M3Buf, M3ID;
 IMPORT Mx, MxVS, MxIO;
+IMPORT Target;
 
 TYPE
   State = RECORD
@@ -38,7 +39,7 @@ PROCEDURE WriteUnits (units: Mx.UnitList;  output: Wr.T) =
 
     M3Buf.AttachDrain (s.buf, s.wr);
 
-    IF Mx.UnicodeWideChar 
+    IF Target.IsWideChar32()
     THEN MxIO.PutTxt (s.buf,  Mx.LinkerMagicWCUni, Wr.EOL);
     ELSE MxIO.PutTxt (s.buf,  Mx.LinkerMagicWC16, Wr.EOL);
     END; 
@@ -128,7 +129,7 @@ PROCEDURE WriteOpaques (VAR s: State;  o: Mx.OpaqueType) =
   VAR name: INTEGER; 
   BEGIN
     WHILE (o # NIL) DO
-      IF Mx.UnicodeWideChar AND o.TypeName # M3ID.NoID THEN 
+      IF Target.IsWideChar32() AND o.TypeName # M3ID.NoID THEN
          (* ^Don't write "q" line unless writing >= v4.3 of mx file. *) 
         name := WriteName(s, o.TypeName); 
         MxIO.PutTxt (s.buf,  "q");

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -468,4 +468,15 @@ VAR BackendModeInitialized := FALSE;
 PROCEDURE SetBuild_dir(build_dir: TEXT);
 PROCEDURE CleanupSourcePath(file: TEXT): TEXT;
 
+CONST WideChar16Max = 16_FFFF;
+CONST WideChar32Max = 16_10FFFF;
+
+PROCEDURE SetWideChar16 ();
+PROCEDURE SetWideChar32 ();
+
+PROCEDURE IsWideChar32 (): BOOLEAN; (* WideCharSize() = 32 *)
+PROCEDURE WideCharSize (): INTEGER;
+PROCEDURE WideCharMax (): INTEGER;
+PROCEDURE WideCharNumber (): INTEGER; (* WideCharMax() + 1 *)
+
 END Target.

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -408,5 +408,44 @@ BEGIN
   RETURN file;
 END CleanupSourcePath;
 
+(*-------------------------- range of WIDECHAR ------------------------------*)
+
+VAR wideCharSize        := 16;
+VAR wideCharMax         := WideChar16Max;
+
+PROCEDURE IsWideChar32 (): BOOLEAN =
+BEGIN
+  RETURN wideCharSize = 32;
+END IsWideChar32;
+
+PROCEDURE WideCharSize (): INTEGER =
+BEGIN
+  RETURN wideCharSize;
+END WideCharSize;
+
+PROCEDURE WideCharMax (): INTEGER =
+BEGIN
+  RETURN wideCharMax;
+END WideCharMax;
+
+PROCEDURE WideCharNumber (): INTEGER =
+BEGIN
+  RETURN wideCharMax + 1;
+END WideCharNumber;
+
+PROCEDURE SetWideChar16 () =
+BEGIN
+  wideCharSize := 16;
+  wideCharMax := WideChar16Max;
+END SetWideChar16;
+
+PROCEDURE SetWideChar32 () =
+BEGIN
+  wideCharSize := 32;
+  wideCharMax := WideChar32Max;
+END SetWideChar32;
+
+(*---------------------------------------------------------------------------*)
+
 BEGIN
 END Target.

--- a/m3-sys/m3quake/src/MxConfig.m3
+++ b/m3-sys/m3quake/src/MxConfig.m3
@@ -22,6 +22,9 @@ PROCEDURE FindFile (): TEXT =
   END FindFile;
 
 PROCEDURE Get (param: TEXT): TEXT =
+(* Avoid this function.
+ * It uses a global Quake.Machine and does not honor command line defines.
+ *)
   BEGIN
     LOCK mu DO
       EvalConfig ();
@@ -124,6 +127,9 @@ PROCEDURE TryConfig (a, b, c: TEXT := NIL): BOOLEAN =
   END TryConfig;
 
 PROCEDURE EvalConfig () =
+(* Avoid this function.
+ * It sets a global Quake.Machine and does not honor command line defines.
+ *)
   (* LL = mu *)
   BEGIN
     IF (mach # NIL) THEN RETURN END;


### PR DESCRIPTION
Unfortunately, widechar is 16 or 32bits, depending
on command line and config. This seem dubious but this
PR does not change it.

The initialization worked by evaluating cm3.cfg a second time,
by virtue of MxConfig.Get(), ignoring the command line.

Evaluating cm3.cfg a second time, while ignoring command line
is a bad idea. It issues ignored errors when you try things like
cm3 -DROOT or -DTARGET.

This PR does have the side effect of cm3 command line working
to set the size, via -DUnicode_WIDECHAR

But the real point is to not evaluate cm3.cfg twice,
in particular, the second evaluation ignores the command line.

Previously widechar initialization was in cm3 and poked locals
in m3linker and m3front.

Original author did not realize that m3middle's role is to be shared
by various. And Target seems like the main interface in m3middle.

So this PR moves most of the code to m3linker.

Along with renaming everything.

There is now:

public:
  Target.WideCharMax(): 16_ffff or 16_10ffff
  Target.WideCharNumber():  Max + 1
  Target.WideCharSize(): 16 or 32
  Target.IsWideChar32():  size = 32
  Target.SetWideChar16()
  Target.SetWideChar32()
  const WideChar16Max
  const WideChar32Max