### PR TITLE
atomic:Write atomic conditional on processor not complete system.

### DIFF
--- a/m3-libs/m3core/src/atomic/m3makefile
+++ b/m3-libs/m3core/src/atomic/m3makefile
@@ -5,10 +5,15 @@ Atomic("Address")
 Atomic("Integer")
 Atomic("Refany")
 
-if not ({"PPC_LINUX", "PPC_DARWIN", "PPC32_OPENBSD",
-         "SPARC32_LINUX"} contains TARGET)
+% It is possible atomic Longint does not work on
+% 32bit PowerPC or 32bit SPARC or other architectures.
+%
+% Wait and see if users with failures materialize.
+% (Including possibly Qemu-based CI in future).
+%
+%if not ({"PPC", "PPC32", "SPARC", "SPARC32"} contains TARGET_ARCH)
   Atomic("Longint")
-end
+%end
 
 Atomic("Boolean")
 Atomic("Char")


### PR DESCRIPTION
Comment out conditional until failures materialize on PPC32, SPARC32.
It is conceivable nobody is or will be running these.
 (PPC_DARWIN is now two architectures old and PPC_LINUX, PPC_OPENBSD, SPARC_LINUX
 likely had no users except me)
32bit x86 can certainly do do atomic longint and we'll see
also about mips32, arm32, riscv32, hppa32, m68k, etc.

Quite possibly though we'll end up with I386_UNIX, AMD64_UNIX, etc.
where Unix = FreeBSD, OpenBSD, NetBSD, DragonflyBSD, Solaris, Linux,
instead of merely Unix32le, Unix64be, etc.,
depending on future build/scripting machination. We'll see.