### PR TITLE
mklib: Skip __mask@ symbols.

### DIFF
--- a/m3-sys/mklib/src/Main.m3
+++ b/m3-sys/mklib/src/Main.m3
@@ -130,7 +130,7 @@ PROCEDURE IsFloatingPointConstant(sym: TEXT; len: INTEGER): BOOLEAN =
 BEGIN
     RETURN (len = 4 AND Match (sym, 0, "_xmm"))
         OR (len = 5 AND (Match (sym, 0, "_real") OR Match (sym, 0, "__xmm")))
-        OR (len = 6 AND Match (sym, 0, "__real"));
+        OR (len = 6 AND (Match (sym, 0, "__real") OR Match (sym, 0, "__mask")));
 END IsFloatingPointConstant;
 
 PROCEDURE HandleArchitecture(machine: INTEGER): BOOLEAN =


### PR DESCRIPTION
I saw these tonight with Visual C++ 2008/amd64.
It is an old toolset and I am keen on dropping
support for old toolsets, but maybe only much older,
not this one.
ie.
https://www.microsoft.com/en-us/download/details.aspx?id=44266

More generally we could consider skipping any symbol
with a leading underscore or two.