### PR TITLE
m3c:Fix calling conventions. It was very little code.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2882,7 +2882,10 @@ END declare_indirect;
 PROCEDURE CallingConventionToText(callingConvention: CallingConvention): TEXT =
 BEGIN
     IF callingConvention = NIL THEN RETURN "<NIL>" END;
-    RETURN callingConvention.name;
+    (* Return underlying __stdcall and __cdecl instead of aliases like WINAPI.
+     * RETURN callingConvention.name;
+     *)
+    RETURN Target.ConventionFromID(callingConvention.m3cg_id).name;
 END CallingConventionToText;
 
 PROCEDURE declare_proctype(self: DeclareTypes_t; typeid: TypeUID; param_count: INTEGER; result: TypeUID; raise_count: INTEGER; callingConvention: CallingConvention) =
@@ -4399,7 +4402,9 @@ TYPE FunctionPrototype_t = { Declare, Define };
 
 PROCEDURE function_prototype(proc: Proc_t; kind: FunctionPrototype_t): TEXT =
 VAR params := proc.params;
-    text := cgtypeToText[proc.return_type] & "\n__cdecl\n" & NameT(proc.name);
+    text := cgtypeToText[proc.return_type] & "\n" &
+            CallingConventionToText(proc.callingConvention) & "\n" &
+            NameT(proc.name);
     after_param: TEXT := NIL;
     ansi := TRUE (*NOT is_exception_handler*);
     define_kr := NOT ansi AND kind = FunctionPrototype_t.Define;

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -244,8 +244,7 @@ PROCEDURE InitCallingConventions(backend_mode: M3BackendMode_t;
   PROCEDURE New(name: TEXT; id: [0..1]): CallingConvention =
     VAR cc := NEW(CallingConvention, name := name);
     BEGIN
-      (* This stuff seems messed up. *)
-      IF (*backend_mode = M3BackendMode_t.C OR*) target_has_calling_conventions THEN
+      IF backend_mode = M3BackendMode_t.C OR target_has_calling_conventions THEN
         cc.m3cg_id            := id;
       ELSE
         cc.m3cg_id            := 0;
@@ -271,16 +270,6 @@ PROCEDURE InitCallingConventions(backend_mode: M3BackendMode_t;
       RETURN cc;
     END New;
   BEGIN
-    (* 0 is __cdecl, 1 is __stdcall. *)
-    CCs := ARRAY OF CallingConvention{ New("C",          0),
-                                       New("WINAPIV",    0),
-                                       New("__cdecl",    0),
-                                       New("WINAPI",     1),
-                                       New("CALLBACK",   1),
-                                       New("APIENTRY",   1),
-                                       New("APIPRIVATE", 1),
-                                       New("PASCAL",     1),
-                                       New("__stdcall",  1) };
     (* 0 is __cdecl, 1 is __stdcall. *)
     CCs := ARRAY OF CallingConvention{ New("__cdecl",    0), (* must be first *)
                                        New("__stdcall",  1), (* must be second *)


### PR DESCRIPTION
This suppports I386_NT and hopefully no other platorm
has multiple calling conventions.
And cleanup a little.