### PR TITLE
scripts: Fix boot2.py on Windows.

### DIFF
--- a/scripts/python/boot2.cmd
+++ b/scripts/python/boot2.cmd
@@ -1,6 +1,9 @@
-.\make-dist-cfg.py || goto :eof
-.\do-cm3-all.py realclean || goto :eof
-.\do-pkg.py m3core libm3 buildship || goto :eof
-.\upgrade.py skipgcc || goto :eof
-.\do-cm3-all.py realclean skipgcc || goto :eof
-.\do-cm3-all.py buildship || goto :eof
+@rem .\make-dist-cfg.py || goto :eof
+@rem .\do-cm3-all.py realclean || goto :eof
+@rem .\do-pkg.py m3core libm3 buildship || goto :eof
+@rem .\upgrade.py skipgcc || goto :eof
+@rem .\do-cm3-all.py realclean skipgcc || goto :eof
+@rem .\do-cm3-all.py buildship || goto :eof
+
+echo ERROR: Use boot2.py instead of boot2.cmd.
+exit /b 1

--- a/scripts/python/boot2.py
+++ b/scripts/python/boot2.py
@@ -13,7 +13,7 @@
 #./do-cm3-all.py realclean skipgcc $*
 #./do-cm3-all.py buildship $*
 
-import os, sys
+import os, sys, pylib
 argv = sys.argv
 
 def RemoveTrailingSpaces(a):
@@ -31,11 +31,19 @@ def Run(command):
 # ./do-pkg.py doesn't like skipgcc plus just m3cc -- no packages to build
 # Which is why this was rewritten in Python from Bourne shell.
 
-Run("./make-dist-cfg.py")
+c = ""
+if _CBackend:
+    c = "c"
+
+pyexe = "python2"
+if not pylib.SearchPath(pyexe):
+    pyexe = "py.exe"
+
+Run(pyexe + " ./make-dist-cfg.py")
 if not _CBackend:
-    Run("./do-pkg.py m3cc buildship")
-Run("./do-cm3-all.py realclean skipgcc")
-Run("./do-pkg.py m3cc m3core libm3 buildship")
-Run("./upgrade.py skipgcc")
-Run("./do-cm3-all.py realclean skipgcc")
-Run("./do-cm3-all.py buildship")
+    Run(pyexe + " ./do-pkg.py m3cc buildship " + c)
+Run(pyexe + " ./do-cm3-all.py realclean skipgcc " + c)
+Run(pyexe + " ./do-pkg.py m3cc m3core libm3 buildship " + c)
+Run(pyexe + " ./upgrade.py skipgcc " + c)
+Run(pyexe + " ./do-cm3-all.py realclean skipgcc " + c)
+Run(pyexe + " ./do-cm3-all.py buildship " + c)

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -427,6 +427,15 @@ for a in _PossibleCm3Flags:
     if a in sys.argv:
         CM3_FLAGS = CM3_FLAGS + " -" + a
 
+def PassThroughDefines():
+    result = " "
+    for a in sys.argv:
+        if a.startswith("-D"):
+            result = result + " " + a
+    return result
+
+CM3_FLAGS += PassThroughDefines()
+
 CM3 = ConvertPathForPython(getenv("CM3")) or "cm3"
 CM3 = SearchPath(CM3)
 


### PR DESCRIPTION
if python2 not in path, use py.exe

scripts:Pass through -D.

So you can say e.g.
 do-pkg.py -DM3_BACKEND_MODE=C I386_NT -DROOT=/s/cm3 m3core buildship commands
 do-pkg.py -DM3_BACKEND_MODE=0 I386_NT -DROOT=/s/cm3 m3core buildship commands
 etc.

boot2.py Windows: Run python2 or wow that's new \windows\py.exe
So we get all the pylib.py command line handling
and don't need boot2.cmd.

This is all esp. better now that the widechar initialization is fixed.
Environment variables should not be needed and loops are more easily
written on Windows.

Deprecate boot2.cmd like boot2.sh.

Pass C through boot2.py.
boot2.py could use more in terms of command line pass through.
It should probably call functions instead of running command lines, which would have fixed the .exe too.

Granted, still should be using Quake more.