### PR TITLE
Partially fix WinTrestle breaks since XFontConfig changes.

### DIFF
--- a/m3-ui/ui/src/winvbt/WinScrnFont.m3
+++ b/m3-ui/ui/src/winvbt/WinScrnFont.m3
@@ -172,8 +172,7 @@ PROCEDURE Match (self           : Oracle;
     RETURN List (self, fname, maxResults)
   END Match;
 
-
-PROCEDURE Lookup (<* UNUSED *> self: Oracle; name: TEXT): ScrnFont.T
+PROCEDURE Lookup (<*UNUSED*>self: Oracle; name: TEXT; <*UNUSED*>xft := TRUE): ScrnFont.T
     RAISES {ScrnFont.Failure} =
   VAR res: ScrnFont.T;
   BEGIN


### PR DESCRIPTION
Add new defaulted unused boolean parameter to lookup.