### PR TITLE
Wintrestle: Fix more recent compilation breaks.

### DIFF
--- a/m3-ui/ui/src/vbt/ScrnColorMap.i3
+++ b/m3-ui/ui/src/vbt/ScrnColorMap.i3
@@ -113,8 +113,8 @@ TYPE
   Cube = RECORD lo, hi: Pixel END;
   Pixel = INTEGER;
   RGB = RECORD r, g, b: REAL END;
-  XRGB = RECORD red, green, blue, alpha: INTEGER END;
-  Entry = RECORD pix: Pixel; rgb: RGB; xrgb : XRGB END;
+  XRGB = RECORD red, green, blue, alpha := 0 END;
+  Entry = RECORD pix: Pixel; rgb: RGB; xrgb := XRGB{}; END;
 
 (* The field "cm.depth" is the depth of "cm", and "cm.readOnly" is
    "TRUE" if "cm" cannot be written.  The field "cm.ramp" defines


### PR DESCRIPTION
"..\src\MGPaintOp.m3", line 60: No value specified for record constructor field (2.6.8). (xrgb)
"..\src\MGPaintOp.m3", line 97: No value specified for record constructor field (2.6.8). (xrgb)
2 errors encountered

Just initialize to zero.
We could remove this data on Wintrestle but it does not seem worth it.