### PR TITLE
Wintrestle: Fix new alignment/loophole warnings.

### DIFF
--- a/m3-libs/m3core/src/win32/WinDef.i3
+++ b/m3-libs/m3core/src/win32/WinDef.i3
@@ -213,7 +213,7 @@ TYPE
   SIZEL = SIZE;
   PSIZEL = UNTRACED REF SIZE;
 
-  PPOINTS = UNTRACED REF POINTS;
+  PPOINTS = UNTRACED REF POINTS; (* s is for signed 16bit short, not plural *)
   LPPOINTS = PPOINTS; (* compat *)
   POINTS = RECORD
     x: INT16;

--- a/m3-libs/m3core/src/win32/WinGDI.i3
+++ b/m3-libs/m3core/src/win32/WinGDI.i3
@@ -17,14 +17,14 @@
 
 INTERFACE WinGDI;
 
-FROM Ctypes IMPORT char;
+FROM Ctypes IMPORT char, int;
 FROM Word IMPORT Or, Shift;
 FROM WinDef IMPORT INT16, BOOL, UINT16, UINT32, PUINT32, PVOID, HDC,
                    LPARAM, POINT, HBRUSH, RECT, UINT8, PUINT8, HBITMAP, PRECT,
                    PINT32, HRGN, PPOINT, INT32, COLORREF, WFLOAT,
                    HGDIOBJ, HMETAFILE, HMODULE, HFONT, HPEN, HPALETTE, HGLOBAL,
                    RECTL, SIZEL, PFLOAT, PSIZE, HENHMETAFILE, HGLRC, WCHAR,
-                   PSTR, PWSTR, PCSTR, PCWSTR, SIZE_T;
+                   POINTS, PSTR, PWSTR, PCSTR, PCWSTR, SIZE_T;
 
 (* Binary raster ops *)
 CONST
@@ -456,7 +456,14 @@ TYPE
   END;
   (*???  #pragma pack() *)
 
-(*!  ???  #define MAKEPOINTS(l) (*((POINTS FAR *)&(l))) *)
+(* Replace macros with functions. *)
+(* s in points is for signed 16bit short, not plural *)
+<*EXTERNAL "WinGDI__MAKEPOINTS"*>   PROCEDURE MAKEPOINTS(lParam: LPARAM; points: UNTRACED REF POINTS);
+<*EXTERNAL "WinGDI__GET_X_LPARAM"*> PROCEDURE GET_X_LPARAM(lParam: LPARAM): int;
+<*EXTERNAL "WinGDI__GET_Y_LPARAM"*> PROCEDURE GET_Y_LPARAM(lParam: LPARAM): int;
+
+(* Make up a new one. *)
+<*EXTERNAL "WinGDI__PointsToLParam"*> PROCEDURE PointsToLParam(points: UNTRACED REF POINTS): LPARAM;
 
 (* Clipboard Metafile Picture Structure *)
 TYPE

--- a/m3-libs/m3core/src/win32/m3makefile
+++ b/m3-libs/m3core/src/win32/m3makefile
@@ -53,6 +53,7 @@ c_source   ("WinNTc")
 implementation ("WinGDI") % part of the implementation is portable
 implementation ("WinUser") % part of the implementation is portable
 c_source   ("WinUserC")
+c_source   ("WinGDIc")
 
 % New interfaces added March 2003 by darkov
 if equal(WORD_SIZE, "32BITS") % temporary hack

--- a/m3-ui/ui/src/winvbt/WinTrestle.m3
+++ b/m3-ui/ui/src/winvbt/WinTrestle.m3
@@ -2040,12 +2040,15 @@ PROCEDURE TimerTick (hwnd: WinDef.HWND) =
    VAR
     status   : WinDef.BOOL;
     screenPos: WinDef.POINT;
+    shortPos : WinDef.POINTS; (* s is for 16bit short *)
     lParam   : WinDef.LPARAM;
   BEGIN
     IF trsl.mouseFocus = NIL THEN
       status := WinUser.GetCursorPos (ADR (screenPos));
       <* ASSERT status # False *>
-      lParam := LOOPHOLE (WinDef.POINTS {screenPos.x, screenPos.y}, WinDef.UINT32);
+      shortPos.x := screenPos.x; (* truncate 32bit to 16bit *)
+      shortPos.y := screenPos.y;
+      lParam := WinGDI.PointsToLParam(ADR (shortPos));
       DeliverMousePos (hwnd, lParam, 0);
     END;
   END TimerTick;


### PR DESCRIPTION
"..\src\winvbt\WinTrestle.m3", line 2048: warning: LOOPHOLE: expression's alignment may differ from type's

Expose windows.h:
 MAKEPOINTS
 GET_X_LPARAM
 GET_Y_LPARAM

macros as functions, as well as the implied
inverse PointsToLParam. This fix use that last
one.

Again it would be nice if READONLY and VAR
were guaranteeably pointers. Without such
guarantees we use UNTRACED REF and ADR.

LPARAM is size_t or ptrdiff_t.
POINTS is a struct containing two 16bit integers.