### PR TITLE
m3front: Restore declaration of record types.

### DIFF
--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -953,6 +953,7 @@ PROCEDURE GenStruct
           THEN (* Pass address.  Copy will be made by callee prolog. *)
             CG.Pop_param (CG.Type.Addr);
           ELSE
+            Type.Compile (formVal.repType);
             CG.Pop_struct
               (Type.GlobalUID (formVal.repType), formRepTypeInfo.size,
                formRepTypeInfo.alignment);


### PR DESCRIPTION
The C backend insists that all records passed as parameters to functions be of declared types.

Even though pop_struct implies passing a pointer, and the backend could
just pass it as void* or forward declare the struct.

Ideally, eventually, pop_struct passes by value, leaving the ABI details to the backend.

Lately builds fail because m3front is skipping record declarations.

For example:
C:\s\cm3\m3-ui\ui\src\trestle\InstalledVBT.m3

```
PROCEDURE InitChild (j: Join; ch: VBT.T; p: DeleteProc)=
  VAR
    grandChild := NEW(GrandChild, proc := p);
    child      := StableVBT.New(grandChild);
  BEGIN
    EVAL grandChild.init(ch); (* line 41 *)
    j.trueChild := ch;
    EVAL j.init(child)
  END InitChild;
```

The init call has some default parameters.
It is actually:

C:\s\cm3\m3-ui\ui\src\split\HighlightVBT.i3(31):
```
    init(ch: VBT.T;
      op: PaintOp.T := PaintOp.TransparentSwap;
      txt: Pixmap.T := Pixmap.Gray;
      READONLY delta := Point.T{h := 0, v := 1}): T
```
The C backend produces:
```
#line 41 "../src/trestle/InstalledVBT.m3"
(*(ADDRESS*)(&L_72_L_73))=(ADDRESS)(((ADDRESS)(((ADDRESS (__cdecl*)(DOTDOTDOT))L_78_L_79)(
 ((ADDRESS)(grandChild_L_52)),
 ((ADDRESS)(ch_L_55)),
 ((T79A5AEBB*)(*((ADDRESS*)(INT64_(232)+((ADDRESS)(*((ADDRESS*)(INT64_(1000)+((ADDRESS)(&M_InstalledVBT_L_44)))))))))),
 ((T23E73F69*)(*((ADDRESS*)(INT64_(120)+((ADDRESS)(*((ADDRESS*)(INT64_(1024)+((ADDRESS)(&M_InstalledVBT_L_44)))))))))),
 ((ADDRESS)(&L_76_L_77))))));
```
The third and fourth parameters are records.

Before packedVar the records were declared here:
```
0:000> k12
   Child-SP          RetAddr               Call Site
00 00000086`b66fd600 00007ff6`1b4b9312     cm3!CG__Declare_record+0x12 [C:\s\cm3\m3-sys\m3front\src\misc\CG.m3 @ 268]
01 00000086`b66fd650 00007ff6`1b425806     cm3!RecordType__Compiler+0x252 [C:\s\cm3\m3-sys\m3front\src\types\RecordType.m3 @ 325]
02 00000086`b66fd6d0 00007ff6`1b5a9b58     cm3!Type__Compile+0x126 [C:\s\cm3\m3-sys\m3front\src\types\Type.m3 @ 627]
03 00000086`b66fd750 00007ff6`1b5a5b8d     cm3!Formal__GenRecord+0x1b8 [C:\s\cm3\m3-sys\m3front\src\values\Formal.m3 @ 628]
04 00000086`b66fd7f0 00007ff6`1b49b95d     cm3!Formal__EmitArg+0x17d [C:\s\cm3\m3-sys\m3front\src\values\Formal.m3 @ 465]
05 00000086`b66fd840 00007ff6`1b5b1d33     cm3!UserProc__Prep+0x93d [C:\s\cm3\m3-sys\m3front\src\types\UserProc.m3 @ 132]
06 00000086`b66fd9c0 00007ff6`1b59d176     cm3!CallExpr__Prep+0xe3 [C:\s\cm3\m3-sys\m3front\src\exprs\CallExpr.m3 @ 343]
07 00000086`b66fda20 00007ff6`1b5c831a     cm3!Expr__Prep+0x96 [C:\s\cm3\m3-sys\m3front\src\exprs\Expr.m3 @ 200]
08 00000086`b66fda70 00007ff6`1b4d13ac     cm3!EvalStmt__Compile+0x8a [C:\s\cm3\m3-sys\m3front\src\stmts\EvalStmt.m3 @ 43]
09 00000086`b66fdac0 00007ff6`1b4d06cf     cm3!Stmt__Compile+0xac [C:\s\cm3\m3-sys\m3front\src\stmts\Stmt.m3 @ 115]
0a 00000086`b66fdb20 00007ff6`1b4d13ac     cm3!BlockStmt__Compile+0x40f [C:\s\cm3\m3-sys\m3front\src\stmts\BlockStmt.m3 @ 103]
0b 00000086`b66fdb80 00007ff6`1b46967f     cm3!Stmt__Compile+0xac [C:\s\cm3\m3-sys\m3front\src\stmts\Stmt.m3 @ 115]
0c 00000086`b66fdbe0 00007ff6`1b46909e     cm3!Procedure__GenBody+0x5cf [C:\s\cm3\m3-sys\m3front\src\values\Procedure.m3 @ 598]
0d 00000086`b66fdc70 00007ff6`1b4588b3     cm3!Procedure__EmitBody+0xae [C:\s\cm3\m3-sys\m3front\src\values\Procedure.m3 @ 563]
0e 00000086`b66fdcc0 00007ff6`1b4576e5     cm3!ProcBody__EmitBody+0x303 [C:\s\cm3\m3-sys\m3front\src\misc\ProcBody.m3 @ 171]
0f 00000086`b66fdd40 00007ff6`1b43607e     cm3!ProcBody__EmitAll+0x135 [C:\s\cm3\m3-sys\m3front\src\misc\ProcBody.m3 @ 65]
10 00000086`b66fddd0 00007ff6`1b430d78     cm3!Module__CompileModule+0x29e [C:\s\cm3\m3-sys\m3front\src\values\Module.m3 @ 992]
11 00000086`b66fde60 00007ff6`1b4172ab     cm3!Module__Compile+0x398 [C:\s\cm3\m3-sys\m3front\src\values\Module.m3 @ 923]
```
This was lost here:

commit f39c54e1003a737cf4765ba63972ee8bac4af31b
Date:   Mon Apr 27 20:47:23 2020 -0500
Initial cut at passing packed parameters.
Including some misc fixes and infrastructure additions.

git difftool -dy f39c54e1003a737cf4765ba63972ee8bac4af31b~1..f39c54e1003a737cf4765ba63972ee8bac4af31b

In Formal.m3, GenRecord became GenStruct and the Type.Compile call was lost before pop_struct.