### PR TITLE
m3front: Before failing assert(false) indicate

### DIFF
--- a/m3-sys/m3front/src/exprs/CallExpr.m3
+++ b/m3-sys/m3front/src/exprs/CallExpr.m3
@@ -188,6 +188,7 @@ PROCEDURE PrepArgs (t: T) =
 
 PROCEDURE NoLValue (<*UNUSED*> t: T; <*UNUSED*> traced: BOOLEAN) =
   BEGIN
+    Error.Msg ("Internal compiler error CallExpr.NoLValue");
     <*ASSERT FALSE*>
   END NoLValue;
 
@@ -195,6 +196,7 @@ PROCEDURE NotBoolean (<*UNUSED*> t: T;
                       <*UNUSED*> true, false: CG.Label;
                       <*UNUSED*> freq: CG.Frequency) =
   BEGIN
+    Error.Msg ("Internal compiler error CallExpr.NotBoolean");
     <*ASSERT FALSE*>
   END NotBoolean;
 


### PR DESCRIPTION
which line of input the compiler is having trouble with.