### PR TITLE
m3c: Allow invalid IR that m3front produces.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4942,7 +4942,8 @@ BEGIN
         RTIO.Flush();
         Wr.Flush(self.c);
         <* ASSERT ok1 *>
-        <* ASSERT ok2 *>
+        (* There are tests that fail this and m3front allows it, with warnings. *)
+        (* ASSERT ok2 *)
     END;
     IF type = CGType.Int32 AND TInt.EQ(i, TInt.Min32) THEN
         RETURN "-" & intLiteralPrefix[type] & TInt.ToText(TInt.Max32) & intLiteralSuffix[type] & "-1";


### PR DESCRIPTION
When faced with constant initialization that are
range violations, m3front issues a warning and continues
to produce IR like:

INT8 a := 266;

M3c wouldd detect this and rightly fail.

But the tests need to compile, eh? p268.