### PR TITLE
m3tests: Add small regressed program involving arrays.

### DIFF
--- a/m3-sys/m3tests/src/p2/p285/Main.m3
+++ b/m3-sys/m3tests/src/p2/p285/Main.m3
@@ -1,0 +1,24 @@
+(* This used to work.
+ * PackedVars work has it not currently compiling.
+ *)
+MODULE Main;
+IMPORT RTIO;
+
+TYPE Point = ARRAY [0..0] OF INTEGER;
+     (* Point = RECORD a: INTEGER END; this works *)
+     PointsArray = ARRAY [0..0] OF Point;
+
+PROCEDURE F2(): Point =
+BEGIN
+  RETURN Point{123};
+END F2;
+
+PROCEDURE F1(): PointsArray =
+BEGIN
+  RETURN PointsArray{F2()};
+END F1;
+
+BEGIN
+ RTIO.PutInt(F1()[0][0]);
+ RTIO.Flush();
+END Main.

--- a/m3-sys/m3tests/src/p2/p285/m3makefile
+++ b/m3-sys/m3tests/src/p2/p285/m3makefile
@@ -1,0 +1,5 @@
+% Small program with array initializer that used to work.
+
+implementation("Main")
+build_standalone()
+include ("../../Test.common")


### PR DESCRIPTION
This used to work but with PackedVars it no longer compiles.