### PR TITLE
cm3: Remove commented out code to default target to host properties:

### DIFF
--- a/m3-sys/cm3/src/Main.m3
+++ b/m3-sys/cm3/src/Main.m3
@@ -67,11 +67,6 @@ VAR defs: TextTextTbl.T;
 
         DefineIfNotDefined (mach, "TARGET", MxConfig.HOST);
         DefineIfNotDefined (mach, "OS_TYPE", MxConfig.HOST_OS_TYPE);
-        (* DefineIfNotDefined (mach, "BACKEND_MODE", Version.BackendMode); *)
-        (* DefineIfNotDefined (mach, "C_COMPILER", Version.CCompiler); *)
-        (* DefineIfNotDefined (mach, "LINKER", Version.Linker); *)
-        (* DefineIfNotDefined (mach, "THREAD_LIBRARY", Version.ThreadLibrary); *)
-        (* DefineIfNotDefined (mach, "WINDOW_LIBRARY", Version.WindowLibrary); *)
         DefineIfNotDefined (mach, "WORD_SIZE", MxConfig.HOST_WORD_SIZE);
 
         (* Even if the config file overrides the defaults, such as to do
@@ -82,7 +77,6 @@ VAR defs: TextTextTbl.T;
 
         Quake.Define(mach, "HOST", MxConfig.HOST);
         Quake.Define(mach, "HOST_OS_TYPE", MxConfig.HOST_OS_TYPE);
-        (* Quake.Define(mach, "HOST_GNU_MAKE", Version.GNUMake); *)
 
         (* define the site configuration *)
         Msg.Verbose ("EVAL (\"", config, "\")");


### PR DESCRIPTION
 C_COMPILER: meant to be SUN or GNU (i.e. on Solaris targets)
 LINKER: MS or GNU (i.e. I386_NT or I386_CYGWIN)
   Affects linker switch format.
 WINDOWS_LIBRARY: MS (win32) or X
 THREAD_LIBRARY: MS (Win32) or pthread
   Cygwin was actually configured to use MS but either make sense.
 BACKEND_MODE: 0-3, C
 HOST_GNU_MAKE: make vs. gmake etc.

The code was never active here and is little known.
The options, which remain a useful and implemented
 factoring of config, can be set from command line with -D
  or config file or ideally but probably not environment (hopefully with CM3_ prefix).

Defaulting them to host would introduce somewhat undesirable host variation.
  Granted, a host variation that might be sticky anyway (i.e.
  these correlate strongly with Win32 vs. Posix, a factoring we might
  be stuck with forever).

The idea being to not factor on coarse grained Win32 vs. Posix,
but pieces. Because you can have pthreads on Win32, for example.

If this default target=host is desired, refactor into C.
That will be done for the non-commented out ones.