### PR TITLE
version.quake: Trim more host properties intended

### DIFF
--- a/m3-sys/cm3/src/version.quake
+++ b/m3-sys/cm3/src/version.quake
@@ -74,82 +74,12 @@ proc version_impl(name) is
         % This does not end up in the C backend output.
         write("  (* Created = \"", NOW, "\"; *)", CR)
 
-        %
         % When cm3 uses this data, it is describing the HOST.
         % They are reasonable defaults for the TARGET, ASSUMING a NATIVE build.
         %
         write("  Target = \"", TARGET, "\";", CR)
         write("  OSType = \"", OS_TYPE, "\";", CR)
         write("  WordSize = \"", WORD_SIZE, "\";", CR)
-
-        local GNUPlatform = ""
-        if defined ("GNU_PLATFORM")
-            GNUPlatform = GNU_PLATFORM
-        end
-        write("  GNUPlatform = \"", GNUPlatform, "\";", CR)
-
-        local CCompiler = ""
-        if defined ("C_COMPILER")
-            CCompiler = C_COMPILER
-        end
-        write("  CCompiler = \"", CCompiler, "\";", CR)
-
-        local Linker = ""
-        if defined ("LINKER")
-            Linker = LINKER
-        end
-        write("  Linker = \"", Linker, "\";", CR)
-
-        local ThreadLibrary = ""
-        if defined ("THREAD_LIBRARY")
-            ThreadLibrary = THREAD_LIBRARY
-        end
-        write("  ThreadLibrary = \"", ThreadLibrary, "\";", CR)
-
-        local WindowLibrary = ""
-        if defined ("WINDOW_LIBRARY")
-            WindowLibrary = WINDOW_LIBRARY
-        end
-        write("  WindowLibrary = \"", WindowLibrary, "\";", CR)
-
-        local GNUMake = "make"
-        if defined("GNU_MAKE")
-            GNUMake = GNU_MAKE
-        end
-        write("  GNUMake = \"", GNUMake, "\";", CR)
-
-        local readonly proc map(a, b) is
-            if a contains b
-                return a{b}
-            end
-            return b
-        end
-
-        write("  BackendMode = \"",
-            map({"0" : "IntegratedObject",
-                 "1" : "IntegratedAssembly",
-                 "2" : "ExternalObject",
-                 "3" : "ExternalAssembly",
-                 "4" : "C",
-                 "5" : "IntLlvmObj",
-                 "6" : "IntLlvmAsm",
-                 "7" : "ExtLlvmObj",
-                 "8" : "ExtLlvmAsm",
-                 "9" : "StAloneLlvmObj",
-                 "10": "StAloneLlvmAsm"}
-               , M3_BACKEND_MODE), "\";", CR)
-
-        local TargetNaming = ""
-        if defined("TARGET_NAMING")
-            TargetNaming = TARGET_NAMING
-        else if defined("NAMING_CONVENTIONS")
-            TargetNaming = NAMING_CONVENTIONS
-        end end
-        if TargetNaming
-            TargetNaming = map({"0" : "Unix", "1" : "GrumpyUnix", "2" : "Win32"}, TargetNaming)
-        end
-        write("  TargetNaming      = \"", TargetNaming, "\";", CR)
-        write("  NamingConventions = \"", TargetNaming, "\";", CR)
 
         % TODO Generating a constant TEXT in C would be nice maybe.
         write("<*EXTERNAL \"Version__Created\"*> PROCEDURE Created():Ctypes.const_char_star;", CR)


### PR DESCRIPTION
to be target defaults, but that can be set from config
or command line and are most likely never used from here:
  GNUPlatform
  CCompiler
  Linker
  ThreadLibrary
  WindowLibrary
  GNUMake
  BackendMode
  TargetNaming
  NamingConventions

Using them would cause changes in backend output and is not particularly worthwhile.
If they are really needed, we can feed them into generated C instead of .m3/.i3
so they do not affect backend output, but that still breaks portable redistributable.

Another way to do is configure defaults when you compile cm3, such as autoconf/cmake do.
That can generate .c or .i3/.m3, but just do it later.

We could imagine a two phase build where we build cm3 w/o default, then run this
quake to update cm3 w/ defaults. But I don't think anyone ever really used this code
and we can restore it then.

Or just write a text file next to the executable, i.e. the config.
It depends on your taste for quantity of files and text parsing and startup I/O.
i.e. the other extreme is bundling config into binaries, like gnu ld spec files,
which would be nice, if users really tend not to need to edit them (which the escape
hatch of dump specs, and edit or use the path if it exists).