### PR TITLE
m3core:OpenBSD dropped pthread_suspend_np, pthread_resume_np years ago

### DIFF
--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadOpenBSD.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadOpenBSD.c
@@ -1,3 +1,7 @@
+// OpenBSD 5.2 dropped thread suspend/resume,
+// and ThreadPThread__ProcessStopped does not seem to work here either.
+void __cdecl ThreadOpenBSD__Dummy(void) { } /* avoid empty file */
+#if 0
 /* Copyright (C) 2005, Purdue Research Foundation                  */
 /* All rights reserved.                                            */
 /* See the file COPYRIGHT-PURDUE for a full description.           */
@@ -14,11 +18,7 @@
 
 M3_EXTERNC_BEGIN
 
-#ifndef __OpenBSD__
-
-void __cdecl ThreadOpenBSD__Dummy(void) { } /* avoid empty file */
-
-#else /* OpenBSD */
+#ifdef __OpenBSD__
 
 int
 __cdecl
@@ -85,3 +85,4 @@ ThreadPThread__ProcessStopped (m3_pthread_t mt, char *bottom, char *context,
 #endif /* OpenBSD */
 
 M3_EXTERNC_END
+#endif

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -4,8 +4,8 @@
 
 #include "m3core.h"
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-/* See ThreadApple.c, ThreadFreeBSD.c, ThreadOpenBSD.c. */
+#if defined(__APPLE__) || defined(__FreeBSD__)
+/* See ThreadApple.c, ThreadFreeBSD.c. */
 #define M3_DIRECT_SUSPEND
 #endif
 
@@ -22,8 +22,8 @@
 
 #ifdef M3_DIRECT_SUSPEND
 #define M3_DIRECT_SUSPEND_ASSERT_FALSE do {                     \
-    assert(0 && "MacOS X, FreeBSD, OpenBSD should not get here."); \
-    fprintf(stderr, "MacOS X, FreeBSD, OpenBSD should not get here.\n"); \
+    assert(0 && "MacOS X, FreeBSD should not get here."); \
+    fprintf(stderr, "MacOS X, FreeBSD should not get here.\n"); \
     abort();                                                    \
   } while(0);
 #endif
@@ -47,7 +47,7 @@ void __cdecl SignalHandler(int signo, siginfo_t *info, void *context);
     Cygwin: 19 -- er, but maybe that's wrong
     Linux: 64
     FreeBSD: 31 (not used)
-    OpenBSD: 31 (not used)
+    OpenBSD: 31
     HPUX: 44
   Look at the history of Usignal and RTMachine to find more values.  There was
   RTMachine.SIG_SUSPEND and SIG was aliased to it.  Both SIG and SIG_SUSPEND

--- a/m3-libs/m3core/src/thread/PTHREAD/m3makefile
+++ b/m3-libs/m3core/src/thread/PTHREAD/m3makefile
@@ -26,10 +26,10 @@ if defined("TARGET_OS") and not defined("M3_BOOTSTRAP") and not equal(M3_BACKEND
     c_source ("ThreadFreeBSD")
   end
   if equal(TARGET_OS, "OPENBSD")
-    c_source ("ThreadOpenBSD")
+    %c_source ("ThreadOpenBSD")
   end
 else
   c_source ("ThreadApple")
   c_source ("ThreadFreeBSD")
-  c_source ("ThreadOpenBSD")
+  %c_source ("ThreadOpenBSD")
 end


### PR DESCRIPTION
and the OpenBSD ThreadPThread__ProcessStopped was failing assertions also.

Use the portable code instead, that unfortunately has
to squat on a signal (global resource with no arbitration),
and send signals (which initially hurt debugging but configuration
fixes that).

We really need cooperative suspend.
I am seeing a free of an invalid pointer sometimes now though.