### PR TITLE
config and scripts: Remove the special support for suppressing symbols,

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -655,22 +655,12 @@ proc compile_c_ms(source, object, options, optimize, debug) is
         options
     ]
 
-    %
     % Put type information in .objs/.libs instead of shared in vc80.pdb, etc.
     % vc80.pdb can be renamed with /Fd, we'd need the target name.
     % This is bigger/slower but has advantages too.
     % Debug information does not inhibit optimization so always generate it.
     %
-    % Set CM3_NO_SYMBOLS to "bootstrap backwards" -- build with newer toolsets
-    % such that you can subsequently build with older toolsets.
-    %
-    if not defined("NO_SYMBOLS")
-        NO_SYMBOLS = equal($CM3_NO_SYMBOLS, "1")
-    end
-
-    if not NO_SYMBOLS
-        args += ["-Z7"]
-    end
+    args += ["-Z7"]
 
     if USE_MSVCRT
         %

--- a/scripts/python/make-dist-multiple-jay.cmd
+++ b/scripts/python/make-dist-multiple-jay.cmd
@@ -6,9 +6,7 @@ xcopy /fiverdy \net\mod3\cm3-min-WIN32-NT386-5.1.3a \cm3
 
 call \dev2\j\env\cm3\cm3.vc50
 .\do-cm3-all.py realclean
-set CM3_NO_SYMBOLS=1
 .\upgrade.py || goto :eof
-set CM3_NO_SYMBOLS=
 
 call \dev2\j\env\cm3\cm3.vc20
 .\make-dist.py || goto :eof

--- a/scripts/python/make-dist.py
+++ b/scripts/python/make-dist.py
@@ -271,10 +271,7 @@ def Setup(ExistingCompilerRoot, NewRoot):
 
 Setup(InstallRoot, InstallRoot_CompilerWithPrevious)
 RealClean(Packages) or FatalError()
-# NoSymbols increases success when bootstrapping to older tools.
-os.environ["CM3_NO_SYMBOLS"] = "1"
 BuildShip(Packages) or FatalError()
-del(os.environ["CM3_NO_SYMBOLS"])
 ShipCompiler() or FatalError()
 if "m3cc" in Packages:
     Packages.remove("m3cc")


### PR DESCRIPTION
that I added, for the sake of bouncing between C toolsets.
Only for NT (which possibly has the worst compat in this area,
of mixing C toolset versions). It surely worked, but bouncing toolset version is probably
too much hassle to be worth it. The reliable approach that involves
no toolset mixing is to bootstrap from generated C which is
totally viable now (I need to double check NT386, but even so).

If someone again starts the exercise of mixing .objs among toolsets,
or creating packages that interoperate across toolsets, this
could be brought back.

It really is a nice idea to create a Modula-3 NT redistributable
toolset, that is not tied to a specific Visual C++ compiler/linker/runtime,
but it might be too much trouble.

Maybe better off to reduce static linking, which is where these
problems creep in.

In general trying to reduce crufty warty obscure hacks/code in the system, esp. stuff that surely nobody used except me, nobody else will likely ever use, and I don't see a huge need for any longer.
The cognitive costs add up fast.