### PR TITLE
Fix Solaris/C++ wrt _setjmp vs. sigsetjmp.

### DIFF
--- a/m3-libs/m3core/src/C/Common/Csetjmp.i3
+++ b/m3-libs/m3core/src/C/Common/Csetjmp.i3
@@ -5,23 +5,14 @@
 UNSAFE INTERFACE Csetjmp;
 FROM Ctypes IMPORT int;
 
-(* TODO? Move this to C?
-
-   "u" in "ulongjmp" is probably for "underscore".
-   This variant of longjmp never restores the signal mask.
-   Because we believe we never change it?
-   And restoring it is less efficient? (Requires possible kernel
-   interaction?)
-
-   If the platform only has "regular" longjmp and no signal mask,
-   e.g. Win32, then this is resolved to that.
-
-   This function does not return in the usual sense.
-   This is used to raise an exception.
-   This is subject to be removed, either by using C, or "libunwind", or
-   Win32 exceptions, or C++ exceptions.
-
-*)
+(* temporary for compat, not used; u is for underscore;
+ * _longjmp does not save/restore signal mask, saving much time
+ *)
 <*EXTERNAL "Csetjmp__ulongjmp" *> PROCEDURE ulongjmp (env: ADDRESS; val: int);
+
+(* Modula-3 exception uses setjmp/longjmp, without signal mask save/restore
+ * TODO: Use C++ exceptions or Win32 exceptions or libunwind.
+ *)
+<*EXTERNAL "Csetjmp__m3_longjmp" *> PROCEDURE m3_longjmp (env: ADDRESS; val: int);
 
 END Csetjmp.

--- a/m3-libs/m3core/src/C/Common/CsetjmpC.c
+++ b/m3-libs/m3core/src/C/Common/CsetjmpC.c
@@ -1,11 +1,64 @@
 #include "m3core.h"
 
-/* wrapper for longjmp / _longjmp
-   u is for underscore
-   underscore version explicitly does not manipulate signal mask */
+// _longjmp does not work on Solaris/C++ because it is std::_longjump.
+#if !defined(__sun) || !defined(__cplusplus)
 
+// Temporary for compat, not used.
+// u is for underscore, do not save/restore signal mask.
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__)
 M3WRAP_RETURN_VOID(Csetjmp__ulongjmp, longjmp, (jmp_buf env, int val), (env, val))
 #else
 M3WRAP_RETURN_VOID(Csetjmp__ulongjmp, _longjmp, (jmp_buf env, int val), (env, val))
+#endif
+
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// This is messy.
+//  - _setjmp does not work in Solaris C++; it is accidentally placed in std::
+//  - sigsetjmp is a good portable idea.
+//  - But sigsetjmp should be paired with siglongjmp.
+//  - And siglongjmp is not portably linkable, like with Linux/m3cc.
+//
+// There is only one m3core for all backends.
+//
+// Therefore:
+//   C backend gets "m3_setjmp"
+//    => NT setjmp
+//    => Solaris sigsetjmp
+//    => else _setjmp as usual
+//
+//  m3cc:
+//    => non-Solaris _setjmp as usual
+//    => Solaris sigsetjmp, not tested
+//
+//  m3core:
+//    => NT longjmp
+//    => Solaris sigsetjmp
+//    => else _longjmp as usual
+//
+// Wrapper for longjmp / siglongjmp specifically for use by Modula-3 exception handling.
+//
+#ifdef __sun
+void __cdecl Csetjmp__m3_longjmp(sigjmp_buf env, int val)
+{
+    siglongjmp(env, val);
+}
+#else
+void __cdecl Csetjmp__m3_longjmp(jmp_buf env, int val)
+{
+#if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__)
+    // No signal mask to save/restore, longjmp is the only longjmp.
+    longjmp(env, val);
+#else
+    _longjmp(env, val);
+#endif
+}
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif

--- a/m3-libs/m3core/src/runtime/ex_frame/RTExFrame.m3
+++ b/m3-libs/m3core/src/runtime/ex_frame/RTExFrame.m3
@@ -177,9 +177,9 @@ PROCEDURE InvokeHandler (f: Frame;  READONLY a: RT0.RaiseActivation) RAISES ANY 
     p.info := a;                         (* copy the exception to the new frame *)
     IF Alloca_jmpbuf THEN
       <* ASSERT p.jmpbuf # NIL *>
-      Csetjmp.ulongjmp (p.jmpbuf, 1);      (* and jump... *)
+      Csetjmp.m3_longjmp (p.jmpbuf, 1);      (* and jump... *)
     ELSE
-      Csetjmp.ulongjmp (ADR(p.jmpbuf), 1);  (* and jump... *)
+      Csetjmp.m3_longjmp (ADR(p.jmpbuf), 1); (* and jump... *)
     END;
     RAISE OUCH;
   END InvokeHandler;

--- a/m3-libs/m3core/src/unix/Common/Uconstants.c
+++ b/m3-libs/m3core/src/unix/Common/Uconstants.c
@@ -45,7 +45,12 @@ typedef int CheckMax[248 - sizeof(CheckMax_t)];
 #define X(x) EXTERN_CONST int Uerror__##x = x;
 #include "UerrorX.h"
 
+// This is messy, see CsetjmpC.c.
+#if defined(__sun)
+EXTERN_CONST INTEGER m3_jmpbuf_size = sizeof(sigjmp_buf);
+#else
 EXTERN_CONST INTEGER m3_jmpbuf_size = sizeof(jmp_buf);
+#endif
 
 #ifndef _WIN32
 

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -2204,7 +2204,9 @@ PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: 
     name := M3ID.ToText(p.name);
     p.lvProc := LLVM.LLVMAddFunction(modRef, LT(name), p.procTy);
 
-    IF Text.Equal(name,"_setjmp") THEN
+    IF Text.Equal(name,"_setjmp") OR
+       Text.Equal(name,"setjmp") OR
+       Text.Equal(name,"sigsetjmp") THEN
       p.returnsTwice := TRUE;
     END;
 

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -3033,15 +3033,19 @@ PROCEDURE include_setjmp_h(self: T) =
  * Avoid including setjmp.h unless needed, to speed up compilation.
  *
  * In future, replace exception handling with optimized C++.
+ * _setjmp sort of does not work in Solaris. The headers
+ * put it in std:: for C++.
  *)
 BEGIN
+  (* This is messy. See CsetjmpC.c. *)
   IF NOT self.done_include_setjmp_h THEN
     print(self,
         "#include <setjmp.h>\n" &
-        "#if defined(_WIN32) || defined(__vms)\n" &
+        "#if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__)\n" &
         "#define m3_setjmp(env) (setjmp(env))\n" &
+        "#elif defined(__sun)\n" &
+        "#define m3_setjmp(env) (sigsetjmp((env), 0))\n" &
         "#else\n" &
-        "/* Do not save/restore signal mask. Doing so is much more expensive. TODO: sigsetjmp. */\n" &
         "#define m3_setjmp(env) (_setjmp(env))\n" &
         "#endif\n");
     self.done_include_setjmp_h := TRUE;

--- a/m3-sys/m3front/src/misc/Marker.i3
+++ b/m3-sys/m3front/src/misc/Marker.i3
@@ -66,7 +66,10 @@ PROCEDURE SetLock (acquire: BOOLEAN;  var: CG.Var;  offset: INTEGER);
 
 PROCEDURE CaptureState (frame: CG.Var;  jmpbuf: CG.Var;  handler: CG.Label);
 (* frame.jmpbuf = jmpbuf
-   if (setjmp(jmpbuf)) goto handler *)
+   if (setjmp(jmpbuf)) goto handler
+   or
+   if (sigsetjmp(jmpbuf, 0)) goto handler
+*)
 
 PROCEDURE Reset ();
 

--- a/m3-sys/m3front/src/values/Module.m3
+++ b/m3-sys/m3front/src/values/Module.m3
@@ -157,9 +157,10 @@ END GetJmpbufSize;
 PROCEDURE GetSetjmp (t: T): CG.Proc =
 VAR new := FALSE;
 BEGIN
-  (* int setjmp(void* ); *)
+  (*    int setjmp(void* );
+   * or int sigsetjmp(void*, int); *)
   IF t.setjmp = NIL THEN
-    t.setjmp := CG.Import_procedure (M3ID.Add (Target.Setjmp), 1,
+    t.setjmp := CG.Import_procedure (M3ID.Add (Target.Setjmp), 1 + ORD(Target.Sigsetjmp),
                                      Target.Integer.cg_type,
                                      Target.DefaultCall, new);
     IF new THEN
@@ -167,6 +168,12 @@ BEGIN
                              Target.Address.align, CG.Type.Addr, 0,
                              in_memory := FALSE, up_level := FALSE,
                              f := CG.Never);
+      IF Target.Sigsetjmp THEN
+        EVAL CG.Declare_param (M3ID.Add ("save_mask"), Target.Int32.size, (* int *)
+                               Target.Int32.align, CG.Type.Int32, 0,
+                               in_memory := FALSE, up_level := FALSE,
+                               f := CG.Never);
+      END;
     END;
   END;
   RETURN t.setjmp;

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -451,6 +451,7 @@ VAR (*CONST*)
   (* TRUE => generate PC-tables for exception scopes.  Otherwise, generate
        an explicit stack of exception handler frames. *)
 
+  Sigsetjmp: BOOLEAN; (* one param or two? *)
   Setjmp: TEXT;
   (* The C name of the routine used to capture the machine state in
        an exception handler frame. *)


### PR DESCRIPTION
This is to fix building Solaris C++.
Use sigsetjmp instead of _setjmp.
This is a nice portable idea.
But, sigsetjmp should be paired with siglongjmp, which is ok, but also sigsetjmp is not portably linkable,
i.e. it fails with Linux/m3cc.

So do it for Solaris only.

Solaris/m3cc not tested, just Solaris/m3c will be.