### PR TITLE
Solaris: Use C backend.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/Solaris.common
+++ b/m3-sys/cminstall/src/config-no-install/Solaris.common
@@ -10,6 +10,8 @@ readonly TARGET_OS = "SOLARIS"
 readonly SYSTEM_AR = "/usr/ccs/bin/ar"
 readonly WordSize = {"32BITS" : "32", "64BITS" : "64"}{WORD_SIZE}
 
+M3_BACKEND_MODE = "C"
+
 proc configure_c_compiler() is
 end
 

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -411,7 +411,8 @@ def TargetOnlyHasCBackend(a):
     a = a.lower()
     if a == "i386_nt":
         return false
-    return a.endswith("_nt") or a.startswith("arm64") or a.startswith("riscv")
+    return (a.endswith("_nt") or a.startswith("arm64") or a.startswith("riscv") or
+        a.endswith("solaris") or a.startswith("sol"))
 
 _PossibleCm3Flags = ["boot", "keep", "override", "commands", "verbose", "why", "debug", "trace"]
 _SkipGccFlags = ["nogcc", "skipgcc", "omitgcc"]


### PR DESCRIPTION
Solaris is four targets with six names:
 SPARC32_SOLARIS, SOLgnu, SOLsun
 SPARC64_SOLARIS
 I386_SOLARIS
 AMD64_SOLARIS