### PR TITLE
Solaris: pthread_atfork handlers run with signals deferred/disable.

### DIFF
--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
@@ -190,4 +190,9 @@ PROCEDURE DecInCritical();
 
 (*---------------------------------------------------------------------------*)
 
+<*EXTERNAL "ThreadPThread__Solaris"*>
+PROCEDURE Solaris(): BOOLEAN;
+
+(*---------------------------------------------------------------------------*)
+
 END ThreadPThread.

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -577,4 +577,15 @@ InitC(int *bottom)
 #endif
 }
 
+INTEGER
+__cdecl
+ThreadPThread__Solaris(void)
+{
+#ifdef __sun
+    return TRUE;
+#else
+    return FALSE;
+#endif
+}
+
 M3_EXTERNC_END


### PR DESCRIPTION
Solaris: pthread_atfork handlers run with signals deferred/disabled,
leading to deadlock between fork and collect.
It may be desirable to have the collector "back off" more,
releasing locks. However instead here "for now" instead
run the fork handlers outside of fork on Solaris where
signals work, so forker will suspend.
The usual suspect better approaches of cooperative suspend and spawn instead of fork + exec are not solutions on their own.
The fork handlers are for anyone in the process that forks without exec.
The scenario of anyone doing that, on Solaris, not going through m3core, remains subject to lock and state corruption.