### PR TITLE
Solaris config: Add -lXft -lfontconfig.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/Solaris.common
+++ b/m3-sys/cminstall/src/config-no-install/Solaris.common
@@ -140,7 +140,7 @@ SYSTEM_LIBS = {
     % "OPENGL" below
     % "ODBC"     : [ ],
     "MOTIF"      : [ "-lXm" ],
-    "X11"        : [ "-lXaw", "-lXmu", "-lXext", "-lXt", "-lX11" ],
+    "X11"        : [ "-lXft", "-lfontconfig", "-lXaw", "-lXmu", "-lXext", "-lXt", "-lX11" ],
     "Z"          : [ "-lz" ],
     "TCP"        : [ ]
 }


### PR DESCRIPTION
This fixes building e.g. m3-ui/ui.
Mentor is still broken due to arrays.