### PR TITLE
gnucc.common: Fix after 21d3342e2c550812fcf4cabefc339131b5a7e5c4

### DIFF
--- a/m3-sys/m3cc/src/gnucc.common
+++ b/m3-sys/m3cc/src/gnucc.common
@@ -142,7 +142,7 @@ if Native and (equal(nTARGET, "SPARC32_SOLARIS") or equal(TARGET, "SPARC64_SOLAR
             gcc = "/usr/sfw/bin:"
         else if FileExists("/opt/csw/gcc4/bin/gcc")
             gcc = "/opt/csw/gcc4/bin:"
-        end end end end end end end end end
+        end end end end end end end end end end end end
     end
 
     if ccs or gcc


### PR DESCRIPTION
Forgot to add three ends for Quake.