### PR TITLE
Solaris C++:Add return to RTHeapInfo.Producer.

### DIFF
--- a/m3-libs/m3core/src/runtime/common/RTHeapInfo.m3
+++ b/m3-libs/m3core/src/runtime/common/RTHeapInfo.m3
@@ -53,6 +53,7 @@ PROCEDURE Producer (<*UNUSED*> self: Thread.Closure): REFANY =
 
       Thread.Pause (update);
     END;
+    RETURN NIL; (* not reachable but needed by some backends *)
   END Producer;
 
 PROCEDURE SendTypes (nTypes: INTEGER) =


### PR DESCRIPTION
Otherwise the function has no return and a Solaris C++ compiler errors (not a warning, an error).
Not the best IR here and LLVM might suffer similarly.
Perhaps should be fixed up in m3front. Perhaps m3c can workaround it, probably.
But hopefully this is ok "for now", maybe forever.
Consider definitely a workaround in m3c.
Note that several other C and C++ compilers do not notice (Sun cc, Microsoft C and C++, GNU C and C++; the reasonable outlier is Sun C++, with many others not tested: IBM xlC, Intel, Clang, Green Hills, etc.)