### PR TITLE
m3front: Add returns to non-void functions.

### DIFF
--- a/m3-sys/m3front/src/exprs/CallExpr.m3
+++ b/m3-sys/m3front/src/exprs/CallExpr.m3
@@ -176,6 +176,7 @@ PROCEDURE NoBounds (t: T;  VAR min, max: Target.Int) =
 
 PROCEDURE NotAddressable (<*UNUSED*> t: T) =
   BEGIN
+    Error.Msg ("Internal compiler error CallExpr.NotAddressable");
     <* ASSERT FALSE *>
   END NotAddressable;
 

--- a/m3-sys/m3front/src/exprs/Expr.m3
+++ b/m3-sys/m3front/src/exprs/Expr.m3
@@ -432,7 +432,9 @@ PROCEDURE BadOperands (op: TEXT;  a, b: M3.Type := NIL): M3.Type =
 
 PROCEDURE NoType (<*UNUSED*> t: T): Type.T =
   BEGIN
+    Error.Msg ("Internal compiler error Expr.NoType");
     <* ASSERT FALSE *>
+    RETURN NIL; <*NOWARN*>
   END NoType;
 
 PROCEDURE NoCheck (<*UNUSED*> t: T;  <*UNUSED*> VAR cs: CheckState) =

--- a/m3-sys/m3front/src/values/Value.m3
+++ b/m3-sys/m3front/src/values/Value.m3
@@ -313,12 +313,16 @@ PROCEDURE Init (t: T;  name: M3ID.T;  c: Class) =
 
 PROCEDURE NoExpr (<*UNUSED*> t: T): Expr.T =
   BEGIN
+    Error.Msg ("Internal compiler error Value.NoExpr");
     <* ASSERT FALSE *>
+    RETURN NIL; <*NOWARN*>
   END NoExpr;
 
 PROCEDURE NoType (<*UNUSED*> t: T): Type.T =
   BEGIN
+    Error.Msg ("Internal compiler error Value.NoType");
     <* ASSERT FALSE *>
+    RETURN NIL; <*NOWARN*>
   END NoType;
 
 PROCEDURE NoLoader (<*UNUSED*> t: T) =


### PR DESCRIPTION
Some backends reject non-valid functions w/o return.
e.g. m3c/Sun C++ and LLVM.
LLVM fixes it itself, m3c/Sun C++ does not yet.
Maybe undo this later when m3c handles it, by adding a return there.

Add internal error messages before assert(false)