### PR TITLE
m3core: Add AtForkPrepareOutsideFork to .i3 so it does not

### DIFF
--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
@@ -193,6 +193,8 @@ PROCEDURE DecInCritical();
 <*EXTERNAL "ThreadPThread__Solaris"*>
 PROCEDURE Solaris(): BOOLEAN;
 
+PROCEDURE AtForkPrepareOutsideFork(); (* called from C *)
+
 (*---------------------------------------------------------------------------*)
 
 END ThreadPThread.


### PR DESCRIPTION
get removed by some platforms. i.e. fix linking on some targets.