### PR TITLE
Revert "Solaris config: Limit C backend to AMD64_SOLARIS for now. (#2…

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_SOLARIS
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_SOLARIS
@@ -13,7 +13,5 @@ m3back_debug = "-gstabs" % Sun assembler doesn't like .stabd.
 %SolarisAssemblerFlags = "-Qy -s -xarch=generic64"
 readonly SYSTEM_ASM = "/usr/ccs/bin/as -Qy -s -xarch=generic64"
 
-M3_BACKEND_MODE = "C"
-
 include("AMD64.common")
 include("Solaris.common")

--- a/m3-sys/cminstall/src/config-no-install/Solaris.common
+++ b/m3-sys/cminstall/src/config-no-install/Solaris.common
@@ -10,6 +10,8 @@ readonly TARGET_OS = "SOLARIS"
 readonly SYSTEM_AR = "/usr/ccs/bin/ar"
 readonly WordSize = {"32BITS" : "32", "64BITS" : "64"}{WORD_SIZE}
 
+M3_BACKEND_MODE = "C"
+
 proc configure_c_compiler() is
 end
 


### PR DESCRIPTION
…66)"

This reverts commit 29476ba259365fbc58be7e8e8c64a9d5fe8ec576.

Things are looking much better now that 32bit target alignment
of 64bit types is restored to 64bits, as they were forever.