### PR TITLE
Solaris config: Rewrite so that you do not have to specify

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_SOLARIS
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_SOLARIS
@@ -4,7 +4,6 @@
 readonly TARGET = "AMD64_SOLARIS"
 readonly GNU_PLATFORM = "i586-sun-solaris2.10" % "cpu-os" string for GNU
                                                % deliberately i586
-readonly C_COMPILER = "SUN" % or GNU to use gcc (untested)
 SunXArch = "generic64" % or amd64, equivalent?
 SunXRegs = ""
 m3back_debug = "-gstabs" % Sun assembler doesn't like .stabd.
@@ -16,4 +15,12 @@ readonly SYSTEM_ASM = "/usr/ccs/bin/as -Qy -s -xarch=generic64"
 M3_BACKEND_MODE = "C"
 
 include("AMD64.common")
+
+% Solaris common will look for several compilers.
+% If you favor a specific compiler, set SYSTEM_CC here.
+% If you favor GNU (g++) or SUN compiler, set C_COMPILER = "SUN" or "GNU"
+% to guide the search.
+% readonly C_COMPILER = "SUN" % favor Sun CC
+% readonly C_COMPILER = "GNU" % favor g++
+
 include("Solaris.common")

--- a/m3-sys/cminstall/src/config-no-install/I386_SOLARIS
+++ b/m3-sys/cminstall/src/config-no-install/I386_SOLARIS
@@ -3,13 +3,19 @@
 
 readonly TARGET = "I386_SOLARIS"
 readonly GNU_PLATFORM = "i586-solaris2.10" % "cpu-os" string for GNU
-readonly C_COMPILER = "SUN" % or GNU to use gcc (untested)
 SunXArch = "pentium_pro"
 SunXRegs = ""
 m3back_debug = "-gstabs" % Sun assembler doesn't like .stabd.
 
 % -K PIC ?
 SolarisAssemblerFlags = "-Qy -s"
+
+% Solaris common will look for several compilers.
+% If you favor a specific compiler, set SYSTEM_CC here.
+% If you favor GNU (g++) or SUN compiler, set C_COMPILER = "SUN" or "GNU"
+% to guide the search.
+% readonly C_COMPILER = "SUN" % favor Sun CC
+% readonly C_COMPILER = "GNU" % favor g++
 
 include("I386.common")
 include("Solaris.common")

--- a/m3-sys/cminstall/src/config-no-install/SOLgnu
+++ b/m3-sys/cminstall/src/config-no-install/SOLgnu
@@ -4,5 +4,12 @@
 % Standard configuration file for SOLgnu (Solaris 2.x w/gcc)
 
 readonly TARGET = "SOLgnu"
-readonly C_COMPILER = "GNU" % or SUN (SOLsun/SPARC32_SOLARIS configurations)
+
+% Solaris common will look for several compilers.
+% If you favor a specific compiler, set SYSTEM_CC here.
+% If you favor GNU (g++) or SUN compiler, set C_COMPILER = "SUN" or "GNU"
+% to guide the search.
+% readonly C_COMPILER = "SUN" % favor Sun CC
+readonly C_COMPILER = "GNU" % favor g++
+
 include("SPARC32_SOLARIS.common")

--- a/m3-sys/cminstall/src/config-no-install/SOLsun
+++ b/m3-sys/cminstall/src/config-no-install/SOLsun
@@ -4,5 +4,12 @@
 % Standard configuration file for SOLsun (Solaris 2.x w/Sun C)
 
 readonly TARGET = "SOLsun"
-readonly C_COMPILER = "SUN" % or GNU (SOLgnu configuration)
+
+% Solaris common will look for several compilers.
+% If you favor a specific compiler, set SYSTEM_CC here.
+% If you favor GNU (g++) or SUN compiler, set C_COMPILER = "SUN" or "GNU"
+% to guide the search.
+readonly C_COMPILER = "SUN" % favor Sun CC
+% readonly C_COMPILER = "GNU" % favor g++
+
 include("SPARC32_SOLARIS.common")

--- a/m3-sys/cminstall/src/config-no-install/SPARC32_SOLARIS
+++ b/m3-sys/cminstall/src/config-no-install/SPARC32_SOLARIS
@@ -2,5 +2,12 @@
 % See file COPYRIGHT-CMASS for details.
 
 readonly TARGET = "SPARC32_SOLARIS"
-readonly C_COMPILER = "SUN" % or GNU (SOLgnu configuration)
+
+% Solaris common will look for several compilers.
+% If you favor a specific compiler, set SYSTEM_CC here.
+% If you favor GNU (g++) or SUN compiler, set C_COMPILER = "SUN" or "GNU"
+% to guide the search.
+% readonly C_COMPILER = "SUN" % favor Sun CC
+% readonly C_COMPILER = "GNU" % favor g++
+
 include("SPARC32_SOLARIS.common")

--- a/m3-sys/cminstall/src/config-no-install/SPARC64_SOLARIS
+++ b/m3-sys/cminstall/src/config-no-install/SPARC64_SOLARIS
@@ -3,11 +3,17 @@
 
 readonly TARGET = "SPARC64_SOLARIS"
 readonly GNU_PLATFORM = "sparc64-sun-solaris2.10" % "cpu-os" string for GNU
-readonly C_COMPILER = "SUN"
 SunXArch = "generic64" % or v9, equivalent?
 SunXRegs = "-xregs=no%appl"
 
 SolarisAssemblerFlags = "-Qy -s -K PIC -xarch=v9"
+
+% Solaris common will look for several compilers.
+% If you favor a specific compiler, set SYSTEM_CC here.
+% If you favor GNU (g++) or SUN compiler, set C_COMPILER = "SUN" or "GNU"
+% to guide the search.
+% readonly C_COMPILER = "SUN" % favor Sun CC
+% readonly C_COMPILER = "GNU" % favor g++
 
 include("SPARC64.common")
 include("Solaris.common")

--- a/m3-sys/cminstall/src/config-no-install/Solaris.common
+++ b/m3-sys/cminstall/src/config-no-install/Solaris.common
@@ -37,34 +37,86 @@ proc configure_assembler() is
     error("unable to find assembler among " & possible)
 end
 
+proc configure_c_compiler() is
+  if defined("SYSTEM_CC")
+    return
+  end
 
-if equal (C_COMPILER, "SUN")
+  readonly possible_sun_cc = [
+    "/usr/bin/CC",
+    "/opt/developerstudio12.6/bin/CC",
+    "/opt/developerstudio12.5/bin/CC",
+    "/opt/solarisstudio12.4/bin/CC",
+    "/opt/solarisstudio12.3/bin/CC",
+    "/opt/solstudio12.2/bin/CC",
+    "/opt/studio/SOS12/SUNWspro/bin/CC",
+    "/opt/studio/SOS11/SUNWspro/bin/CC",
+    ]
 
-  proc configure_c_compiler() is
-    if defined("SYSTEM_CC")
-      return
+  readonly possible_gnu_cc = [
+    "/usr/bin/g++",
+    % I386_SOLARIS and AMD64_SOLARIS fail with clang++
+    % /usr/gcc/7/lib/gcc/x86_64-pc-solaris2.11/7.3.0/../../../../include/c++/7.3.0/bits/std_abs.h:102:7: error: __float128 is
+    % not supported on this target
+    % abs(__float128 __x)
+    % ^
+    %"/usr/bin/clang++",
+    % clang can work but let's stick to C++.
+    "/usr/sfw/bin/g++",
+    ]
+
+  local proc find_sun_cc() is
+      foreach a in possible_sun_cc
+          if FileExists(a)
+              return a
+          end
+      end
+      return FALSE
     end
 
-    local proc find_cc() is
-        readonly local possible = [
-            "/usr",
-            "/opt/developerstudio12.6",
-            "/opt/developerstudio12.5",
-            "/opt/solarisstudio12.4",
-            "/opt/solarisstudio12.3",
-            "/opt/solstudio12.2",
-            "/opt/studio/SOS12/SUNWspro",
-            "/opt/studio/SOS11/SUNWspro",
-            ]
-        foreach a in possible
-            local b = a & "/bin/CC"
-            if FileExists(b)
-                return b
-            end
+  local proc find_gnu_cc() is
+    foreach a in possible_gnu_cc
+        if FileExists(a)
+            return a
         end
-        error("unable to find cc (bin/cc) among " & possible)
     end
+    return FALSE
+  end
 
+  local sun_cc = FALSE
+  local gnu_cc = FALSE
+
+  % User set nothing, look for all.
+  if not defined ("C_COMPILER")
+    sun_cc = find_sun_cc ()
+    if sun_cc
+      C_COMPILER = "SUN"
+    else
+      gnu_cc = find_gnu_cc ()
+      if gnu_cc
+        C_COMPILER = "GNU"
+      end
+    end
+    if not sun_cc and not gnu_cc
+      error("unable to find compiler among " & possible_gnu_cc & possible_sun_cc)
+    end
+  end
+
+  % User prefers SUN or GNU, look for just that.
+  if not sun_cc and equal (C_COMPILER, "SUN")
+    sun_cc = find_sun_cc ()
+    if not sun_cc
+      error("unable to find compiler among " & possible_sun_cc)
+    end
+  end
+  if not gnu_cc and equal (C_COMPILER, "GNU")
+    gnu_cc = find_gnu_cc ()
+    if not gnu_cc
+      error("unable to find compiler among " & possible_gnu_cc)
+    end
+  end
+
+  if equal (C_COMPILER, "SUN")
     % newer compiler says:
     % cc: Warning: -xarch=v8plus is deprecated, use -m32 -xarch=sparc instead
     % cc: Warning: -xarch=v9 is deprecated, use -m64 to create 64-bit programs
@@ -75,7 +127,7 @@ if equal (C_COMPILER, "SUN")
     % We presumably can't just always use the new syntax, in case
     % we are using older tools that don't understand it.
 
-    local cc = find_cc() & " -g -mt -xldscope=symbolic " & SunXRegs & " "
+    local cc = sun_cc & " -g -mt -xldscope=symbolic " & SunXRegs & " "
     local old = "-xarch=" & SunXArch
     local new = "-m" & WordSize
     if equal(WORD_SIZE, "32BITS") and not equal(TARGET, "I386_SOLARIS")
@@ -98,29 +150,11 @@ if equal (C_COMPILER, "SUN")
   end
 
   % SYSTEM_LD = "/usr/ccs/bin/ld"
-end
 
-if equal (C_COMPILER, "GNU")
-  proc configure_c_compiler() is
-    if defined("SYSTEM_CC")
-      return
-    end
-
-    local proc find_cc() is
-        readonly local possible = [
-            "/usr/bin/g++",
-            "/usr/bin/clang++",
-            "/usr/sfw/bin/g++",
-            ]
-        foreach a in possible
-            if FileExists(a)
-                return a
-            end
-        end
-        error("unable to find compiler among " & possible)
-    end
-
-    SYSTEM_CC = find_cc() & " -g -fPIC -pthreads -m" & WordSize
+  if equal (C_COMPILER, "GNU")
+    % -pthread and -pthreads seem the same for gcc but
+    % clang says -pthreads is ignored.
+    SYSTEM_CC = gnu_cc & " -g -fPIC -pthread -m" & WordSize
   end
 end
 
@@ -129,10 +163,19 @@ proc configure_linker() is
     return
   end
   configure_c_compiler()
+
   SYSTEM_LD = SYSTEM_CC & " -B direct -z ignore -z combreloc -z defs -z text"
-    & " -i -z now -z origin "
+    & " -z now -z origin "
     & " -R \\$ORIGIN"
     & " -R \\$ORIGIN/../lib"
+
+  if equal (C_COMPILER, "SUN")
+    SYSTEM_LD = SYSTEM_LD & " -i"
+  else
+    % This should work but it seems to get dropped.
+    SYSTEM_LD = SYSTEM_LD & " -Wl,-i"
+  end
+
 end
 
 SYSTEM_LIBS = {


### PR DESCRIPTION
SUN or GNU compiler and we'll look for both.
Remove clang++ support as it does not work.
Remove -i from gcc-as-ld invocation as it errors.
-Wl,-i should work but seems to get dropped.

Use -pthread instead of -pthreads for hypothetical clang support.