### PR TITLE
FreeBSD: The FreeBSD specific suspend/resume and/or stack scan

### DIFF
--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadFreeBSD.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadFreeBSD.c
@@ -4,17 +4,20 @@
 
 #include "m3core.h"
 
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
+
 #if M3_HAS_VISIBILITY
 #pragma GCC visibility push(hidden)
 #endif
 
 M3_EXTERNC_BEGIN
 
-#ifndef __FreeBSD__
-
 void __cdecl ThreadFreeBSD__Dummy(void) { } /* avoid empty file */
 
-#else /* FreeBSD */
+#if 0 // Seems to not work?
+#ifdef __FreeBSD__
 
 static void __cdecl
 ThreadFreeBSD__Fatal(int error, const char* message)
@@ -76,5 +79,6 @@ ThreadPThread__ProcessStopped (m3_pthread_t mt, char *bottom, char *context,
 }
 
 #endif /* FreeBSD */
+#endif // 0
 
 M3_EXTERNC_END

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -4,8 +4,8 @@
 
 #include "m3core.h"
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
-/* See ThreadApple.c, ThreadFreeBSD.c. */
+#if defined(__APPLE__)
+/* See ThreadApple.c. */
 #define M3_DIRECT_SUSPEND
 #endif
 
@@ -21,10 +21,10 @@
 #endif
 
 #ifdef M3_DIRECT_SUSPEND
-#define M3_DIRECT_SUSPEND_ASSERT_FALSE do {                     \
-    assert(0 && "MacOS X, FreeBSD should not get here."); \
-    fprintf(stderr, "MacOS X, FreeBSD should not get here.\n"); \
-    abort();                                                    \
+#define M3_DIRECT_SUSPEND_ASSERT_FALSE do {            \
+    assert(0 && "MacOS X should not get here.");       \
+    fprintf(stderr, "MacOS X should not get here.\n"); \
+    abort();                                           \
   } while(0);
 #endif
 
@@ -46,7 +46,7 @@ void __cdecl SignalHandler(int signo, siginfo_t *info, void *context);
     Solaris: 17 (at least 32bit SPARC?)
     Cygwin: 19 -- er, but maybe that's wrong
     Linux: 64
-    FreeBSD: 31 (not used)
+    FreeBSD: 31
     OpenBSD: 31
     HPUX: 44
   Look at the history of Usignal and RTMachine to find more values.  There was
@@ -551,8 +551,8 @@ InitC(int *bottom)
 #endif
 
   stack_grows_down = (bottom > &r);
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__INTERIX)
-  assert(stack_grows_down); /* See ThreadApple.c, ThreadFreeBSD.c */
+#if defined(__APPLE__) || defined(__INTERIX)
+  assert(stack_grows_down); /* See ThreadApple.c */
 #endif
 #ifndef M3_COMPILER_THREAD_LOCAL
   M3_RETRY(pthread_key_create(&activations, NULL)); assert(r == 0);

--- a/m3-libs/m3core/src/thread/PTHREAD/m3makefile
+++ b/m3-libs/m3core/src/thread/PTHREAD/m3makefile
@@ -23,13 +23,13 @@ if defined("TARGET_OS") and not defined("M3_BOOTSTRAP") and not equal(M3_BACKEND
     c_source ("ThreadApple")
   end
   if equal(TARGET_OS, "FREEBSD")
-    c_source ("ThreadFreeBSD")
+    %c_source ("ThreadFreeBSD")
   end
   if equal(TARGET_OS, "OPENBSD")
     %c_source ("ThreadOpenBSD")
   end
 else
   c_source ("ThreadApple")
-  c_source ("ThreadFreeBSD")
+  %c_source ("ThreadFreeBSD")
   %c_source ("ThreadOpenBSD")
 end


### PR DESCRIPTION
lead to crashes, for some reason. Switch to the gnarlier portable form at least "for now". It works.
Also fix the FreeBSD-specific code to compile, if enabled.