### PR TITLE
m3core: Check for _LIBCPP_ERRNO_H instead of cplusplus & clang & FreeBSD.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Uconstants.c
+++ b/m3-libs/m3core/src/unix/Common/Uconstants.c
@@ -45,7 +45,7 @@ extern "C" {
 //
 #define M3_UERROR_MAX 248
 
-#if defined(__cplusplus) && defined(__clang__) && defined(__FreeBSD__)
+#ifdef _LIBCPP_ERRNO_H // e.g. __cplusplus && __clang__ && __FreeBSD__
 #if ENODATA > 9900 && ENODATA < 9999
 #undef ENODATA
 #endif


### PR DESCRIPTION
Either way is not great, but note that the following code makes it less bad, and perhaps suffices.
i.e. checks for >9900 && <9999