### PR TITLE
scripts: Remove mklib from Unix bootstraps.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1364,9 +1364,11 @@ def Boot():
           "m3middle", "m3quake", "m3objfile", "m3linker", "m3back",
           "m3front" ])
     main_packages = ["cm3"]
-    #if nt:
+
+    # TODO: mklib = TRUE, something is wrong with the Makefile and it is not really needed,
+    # unless we want the minimal bootstrap system to be capable of crossing to NT
     #if True:
-    if not vms: # TODO
+    if nt:
         main_packages += ["mklib"]
     P += main_packages
 


### PR DESCRIPTION
It should work and is slightly useful, to quickly get
a system that can cross to NT, but there is some problem
with the Makefile, seen on Solaris and BSD and not super
worth resolving for now. Eventually we should use cmake here (and carry the entire system this way)