### PR TITLE
m3-sys: Consolidate strings for CG type names.

### DIFF
--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -937,7 +937,7 @@ PROCEDURE Force_LValue (VAR x: ValRec) =
     IF x.type # Type.Addr THEN
       Error.Warn
         (2, "####### not Addr in Force_LValue, Kind = " & VKindImage (x.kind) &
-            " CGType = " & Target.TypeImage (x.type));
+            " CGType = " & Target.TypeNames [x.type]);
       x.type := Type.Addr;
     END; 
     IF (x.bits # NIL) THEN
@@ -4132,14 +4132,6 @@ PROCEDURE NewNameTbl (): IntRefTbl.T =
 
 CONST
   Bool = ARRAY BOOLEAN OF TEXT { "F ", "T "};
-CONST
-  TypeName = ARRAY Type OF TEXT {
-    "Word8  ", "Int8   ", "Word16 ", "Int16  ",
-    "Word32 ", "Int32  ", "Word64 ", "Int64  ",
-    "Reel   ", "LReel  ", "XReel  ",
-    "Addr   ", "Struct ", "Void   "
-  };
-CONST
   VName = ARRAY VKind OF TEXT {
     "Integer  ",
     "Float    ",
@@ -4158,7 +4150,7 @@ PROCEDURE SDump (tag: TEXT) =
     FOR i := tos-1 TO 0 BY -1 DO
       WITH x = stack[i] DO
         msg := VName [x.kind];
-        msg := msg & TypeName [x.type];
+        msg := msg & Target.TypeNamesFixedWidth [x.type];
         msg := msg & Bool [x.temp_base];
         msg := msg & Bool [x.temp_bits];
         msg := msg & Fmt.Int (x.old_align) & " ";

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -239,7 +239,7 @@ PROCEDURE Init () =
     FOR i := FIRST (CmdMap) TO LAST (CmdMap) DO
       EVAL cmds.put (M3ID.Add (CmdMap[i].op), i);
     END;
-    WITH z = Target.TypeNames DO
+    WITH z = Target.TypeNamesDotted DO
       types := NEW (IntIntTbl.Default).init (2 * NUMBER (z));
       FOR i := FIRST (z) TO LAST (z) DO
         EVAL types.put (M3ID.Add (z[i]), ORD (i));

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -232,7 +232,7 @@ PROCEDURE PName (u: U;  p: Proc) =
 PROCEDURE TName (u: U;  t: Type) =
   BEGIN
     OutC (u, ' ');
-    OutT (u, Target.TypeNames[t]);
+    OutT (u, Target.TypeNamesDotted[t]);
   END TName;
 
 PROCEDURE Flt (u: U;  READONLY f: Target.Float) =

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -156,10 +156,15 @@ TYPE (* machine supported types *)
     Void             (* not-a-type *)
   };
 
-PROCEDURE TypeImage (cgt: CGType ): TEXT; 
-
 CONST
-  TypeNames = ARRAY CGType OF TEXT {
+  TypeNamesFixedWidth = ARRAY CGType OF TEXT {
+    "Word8  ", "Int8   ", "Word16 ", "Int16  ",
+    "Word32 ", "Int32  ", "Word64 ", "Int64  ",
+    "Reel   ", "LReel  ", "XReel  ",
+    "Addr   ", "Struct ", "Void   "
+  };
+
+  TypeNamesDotted = ARRAY CGType OF TEXT {
     "Word.8",  "Int.8",
     "Word.16", "Int.16",
     "Word.32", "Int.32",
@@ -170,7 +175,17 @@ CONST
     "Void"
   };
 
-CONST
+  TypeNames = ARRAY CGType OF TEXT {
+    "Word8",  "Int8",
+    "Word16", "Int16",
+    "Word32", "Int32",
+    "Word64", "Int64",
+    "Reel", "LReel", "XReel",
+    "Addr",
+    "Struct",
+    "Void"
+  };
+
   SignedType = ARRAY CGType OF BOOLEAN {
      FALSE, TRUE,  FALSE, TRUE,  (* Word8 .. Int16 *)
      FALSE, TRUE,  FALSE, TRUE,  (* Word32 .. Int64 *)

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -301,26 +301,6 @@ PROCEDURE InitCallingConventions(backend_mode: M3BackendMode_t;
     DefaultCall := CCs[0];
   END InitCallingConventions;
 
-PROCEDURE TypeImage (cgt: CGType ): TEXT =
-  BEGIN
-    CASE cgt OF
-    | CGType.Word8 => RETURN "Word8";
-    | CGType.Int8 => RETURN "Int8";
-    | CGType.Word16 => RETURN "Word16";
-    | CGType.Int16 => RETURN "Int16";  
-    | CGType.Word32 => RETURN "Word32";
-    | CGType.Int32 => RETURN "Int32";
-    | CGType.Word64 => RETURN "Word64";
-    | CGType.Int64 => RETURN "Int64";
-    | CGType.Reel => RETURN "Reel";
-    | CGType.LReel => RETURN "LReel";
-    | CGType.XReel => RETURN "XReel";
-    | CGType.Addr => RETURN "Addr";
-    | CGType.Struct => RETURN "Struct";
-    | CGType.Void => RETURN "Void";
-    END;
-  END TypeImage;
-
 PROCEDURE CheckI (READONLY i: Int_type; max_align: INTEGER) =
   BEGIN
     <* ASSERT i.align = MIN (i.align, max_align) *>


### PR DESCRIPTION
 PROCEDURE Target.TypeImage() => CONST Target.TypeNames[]
 CONST CG.TypeName[] =>  CONST Target.TypeNamesFixedWidth[]
 CONST Target.TypeNames[] => CONST Target.TypeNamesDotted[]

Arguably should be VAR or PROCEDURE but the main
point is they are all Target.TypeNames. Two were
already CONST so stick with that.

Arguably do not need three forms, but the point
is consolidation not behavioral change, and exact
printed strings are behavior.

This is cleanup. Keep the duplication, but put it all near each other.