### PR TITLE
m3front m3c: More verbose errors in m3front and m3c.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -5537,7 +5537,15 @@ PROCEDURE load(self: T; v: M3CG.Var; offset: ByteOffset; in_mtype: MType; out_zt
 VAR var := NARROW(v, Var_t);
     expr := Variable(self, var);
 BEGIN
-    self.comment("load");
+    IF DebugVerbose(self) THEN
+      self.comment("load var:", Var_Name(var),
+        " offset:" & IntToDec(offset),
+        " in_mtype:" & cgtypeToText[in_mtype] &
+        " out_ztype:" & cgtypeToText[out_ztype]);
+    ELSE
+      self.comment("load");
+    END;
+
     IF FALSE THEN
         IF NOT in_mtype = var.cgtype THEN
             RTIO.PutText("load in_mtype:" & cgtypeToText[in_mtype] & " var.cgtype:" & cgtypeToText[var.cgtype]);
@@ -5619,7 +5627,15 @@ PROCEDURE store_indirect(self: T; offset: ByteOffset; ztype: ZType; mtype: MType
 VAR s0 := cast(get(self, 0), ztype);
     s1 := get(self, 1);
 BEGIN
-    self.comment("store_indirect");
+    IF DebugVerbose(self) THEN
+      self.comment("store_indirect ",
+        " offset:" & IntToDec(offset),
+        " ztype:" & cgtypeToText[ztype],
+        " mtype:" & cgtypeToText[mtype]);
+    ELSE
+      self.comment("store_indirect");
+    END;
+
     pop(self, 2);
     store_helper(self, s0.CText(), ztype, s1.CText(), offset, mtype);
 END store_indirect;

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -1548,14 +1548,14 @@ PROCEDURE Load
         LoadIndirectStraddling (t, o, s);
 (* IMPROVEME: A (direct) LoadStraddling could generate better code. *) 
       ELSE
-        Err ("unaligned word-straddling load, type="& Fmt.Int (ORD (t))
+        Err ("unaligned word-straddling load, type="& Target.TypeNames[t]
             & "  size/offset/align=" & Fmt.Int (s) & "/" & Fmt.Int (o)
             & "/" & Fmt.Int (base_align));
         SimpleLoad (v, o, t, base_align, addr_align);
         ForceStacked ();  (* to connect the error message to the bad code *)
       END 
     ELSE
-      Err ("unaligned partial-word load, type="& Fmt.Int (ORD (t))
+      Err ("unaligned partial-word load, type="& Target.TypeNames[t]
           & "  size/offset/align=" & Fmt.Int (s) & "/" & Fmt.Int (o)
           & "/" & Fmt.Int (base_align));
       SimpleLoad (v, o, t, base_align, addr_align);
@@ -2030,14 +2030,14 @@ x10 := stack[SCheck(1,"Load_indirect-x10")];
         ELSIF x.addr_align MOD Target.Byte = 0 THEN
           LoadIndirectStraddling (t, addedOffset, s); 
         ELSE 
-          Err ("unaligned word-straddling load_indirect, type="& Fmt.Int (ORD (t))
+          Err ("unaligned word-straddling load_indirect, type="& Target.TypeNames[t]
               & "  s/a=" & Fmt.Int (s) & "/" & Fmt.Int (x.addr_align));
           ForceStacked ();  (* to connect the error message *)
           SimpleIndirectLoad (x, t, addr_align);
           ForceStacked ();
         END
       ELSE
-        Err ("unaligned partial-word load_indirect, type="& Fmt.Int (ORD (t))
+        Err ("unaligned partial-word load_indirect, type="& Target.TypeNames[t]
             & "  s/a=" & Fmt.Int (s) & "/" & Fmt.Int (x.addr_align));
         ForceStacked ();  (* to connect the error message *)
         SimpleIndirectLoad (x, t, addr_align);
@@ -2132,12 +2132,12 @@ PROCEDURE Store
         Swap ();
         StoreIndirectStraddling (t, o, s);
       ELSE
-        Err ("unaligned word-straddling store, type="& Fmt.Int (ORD (t))
+        Err ("unaligned word-straddling store, type="& Target.TypeNames[t]
               & "  size/offset/align=" & Fmt.Int (s) & "/" & Fmt.Int (o) & "/" & Fmt.Int(base_align));
         cg.store (v, ToBytes (o), Target.Integer.cg_type, t);
       END;
     ELSE
-      Err ("unaligned partial-word store, type="& Fmt.Int (ORD (t))
+      Err ("unaligned partial-word store, type="& Target.TypeNames[t]
             & "  size/offset/align=" & Fmt.Int (s) & "/" & Fmt.Int (o) & "/" & Fmt.Int(base_align));
       cg.store (v, ToBytes (o), Target.Integer.cg_type, t);
     END;
@@ -2375,12 +2375,12 @@ PROCEDURE Store_indirect (t: Type; addedOffset: Offset;  s: Size) =
           StoreIndirectStraddling (t, addedOffset, s);
           RETURN; (* ^This pops the operands. *)
         ELSE
-          Err ("unaligned word-straddling store_indirect, type="& Fmt.Int (ORD (t))
+          Err ("unaligned word-straddling store_indirect, type="& Target.TypeNames[t]
               & "  s/a=" & Fmt.Int (s) & "/" & Fmt.Int (x.addr_align));
           SimpleIndirectStore (x, t);
           END 
       ELSE
-        Err ("unaligned partial-word store_indirect, type="& Fmt.Int (ORD (t))
+        Err ("unaligned partial-word store_indirect, type="& Target.TypeNames[t]
             & "  s/a=" & Fmt.Int (s) & "/" & Fmt.Int (x.addr_align));
         SimpleIndirectStore (x, t);
       END;


### PR DESCRIPTION
m3front m3c: More verbose errors in m3front and m3c tracing (comments).
This is a bit unfortunate, 'cause the tracing is really verbose.
In time we might produce two files, verbose and not-verbose
and compile the not-verbose one. Or save the binary
form and write a dumper, which we really already have both.
There is a problem to be debugged here.