### PR TITLE
m3front: Change several t.cg_align back to t.align.

### DIFF
--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -414,9 +414,10 @@ PROCEDURE Load (t: T) =
         CG.Load_addr_of (t.bss_var, 0, t.cg_align);
       ELSIF (t.cg_var = NIL) THEN (* => global *)
         Module.LoadGlobalAddr (Scope.ToUnit (t), t.offset, is_const := FALSE);
-        CG.Boost_addr_alignment (t.cg_align);
+        CG.Boost_addr_alignment (MAX(t.align, t.cg_align));
       ELSIF (t.indirect) THEN
         CG.Load_addr (t.cg_var, t.offset, t.cg_align);
+        CG.Boost_addr_alignment (MAX (t.align, t.cg_align));
       ELSE
         CG.Load_addr_of (t.cg_var, t.offset, CG.GCD(t.cg_align, t.offset));
       END;
@@ -430,10 +431,11 @@ PROCEDURE Load (t: T) =
         IF (t.indirect) THEN
           CG.Load_indirect (CG.Type.Addr, 0, Target.Address.size);
         END;
-        CG.Boost_addr_alignment (t.cg_align);
+        CG.Boost_addr_alignment (MAX (t.align, t.cg_align));
         CG.Load_indirect (t.stk_type, 0, t.size, type_info.addr_align);
       ELSIF (t.indirect) THEN
         CG.Load_addr (t.cg_var, t.offset, t.cg_align);
+        CG.Boost_addr_alignment (MAX (t.align, t.cg_align));
         CG.Load_indirect (t.stk_type, 0, t.size, type_info.addr_align);
       ELSE
         CG.Load
@@ -461,7 +463,7 @@ PROCEDURE LoadLValue (t: T) =
     ELSE
       CG.Load_addr_of (t.cg_var, t.offset, CG.GCD (t.cg_align, t.offset));
     END;
-    CG.Boost_addr_alignment (t.cg_align);
+    CG.Boost_addr_alignment (MAX (t.align, t.cg_align));
   END LoadLValue;
 
 (* EXPORTED *)
@@ -478,7 +480,7 @@ PROCEDURE SetLValue (t: T) =
       align := CG.Max_alignment;
     END;
     <*ASSERT t.indirect *>
-    CG.Boost_addr_alignment (t.cg_align);
+    CG.Boost_addr_alignment (MAX (t.align, t.cg_align));
     CG.Store_addr (v, t.offset);
   END SetLValue;
 


### PR DESCRIPTION
m3front: Change several t.cg_align back to t.align.

Whatever was changed here:

  commit 9343e3f917bc76672f1f9b9efda80e64ac3895ca
  Date:   Wed Aug 8 15:10:38 2018 -0500
    packedVars branch, initial commit.

I don't really understand this though.
Frontend has so many notions of alignment.

This fixes several cases of targeting 32bit targets
and working with VAR LONGREAL parameters.

See TextToFloat.m3 and Convert.m3 with otherwise failed
due to like:

INTERNAL CG ERROR *** unaligned partial-word store_indirect, type=LReel s/a=64/32

No packed types were involved, just VAR parameters, at least in the one case I looked at.