### PR TITLE
scripts: Remove C from end of build_dir.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -707,11 +707,14 @@ GCC_BACKEND = not _CBackend
 #
 # TODO
 #
-_BuildDirC = ["", "c"]["c" in LowercaseArgv]
+#_BuildDirC = ["", "c"]["c" in LowercaseArgv]
 #_BuildDirC = ["", "c"]["+c" in LowercaseArgv]
 #_BuildDirC = ["", "c"]["+c" in LowercaseArgv and not TargetOnlyHasCBackend(Target)]
 #_BuildDirC = ["", "c"][_CBackend and not TargetOnlyHasCBackend(Target)]
 #_BuildDirC = ""
+
+# It is confusing as to when c is appended or not, so do it never.
+_BuildDirC = ""
 
 #-----------------------------------------------------------------------------
 #


### PR DESCRIPTION
Yes it solves a problem, but it is too confusing to track when it is appended.

The point is that C backend is not always call-compatible
with gcc backend, specifically because of how the static link
is passed. gcc backend can pass it in an ABI-defined
extra register. C backend passes it as last parameter.

We might be able to put an attribute on it to unify, in gcc/clang.
Maybe declspec(thread) on NT. Gross but quite efficient really.
Maybe some assembly for NT/x86.
But probably nothing ever really.

Eventually, we should have:

 /src/m3/libs/m3core/foo.m3
 /src/m3/libs/libm3/bar.m3
 /obj/m3/libs/m3core/foo.o
 /obj/m3/libs/libm3/bar.o

where /obj/m3 is entirely user-specified and can contain arch-os.
i.e. out of tree builds like autotools and cmake
at the multi-package level, not individual packages

  mkdir -p /obj/m3
  cd /obj/m3
  cmake /src/cm3/min -Dtarget=arch
  ninja
  ninja install
  rm -rf *
  cmake /src/cm3/rest -Dtarget=arch
  ninja
  ninja install

should be the goal.

Having merely each package build out of its own source
tree but not the overall source tree is not satisfying.

In this model, where output root is generated less often,
it is easier to manage this, if we really ever want to.