### PR TITLE
version:Add git info.

### DIFF
--- a/m3-sys/cm3/src/Makefile.m3
+++ b/m3-sys/cm3/src/Makefile.m3
@@ -5,7 +5,7 @@ UNSAFE MODULE Makefile;
 
 IMPORT FS, M3File, M3Timers, OSError, Params, Process, Text, Thread, Wr;
 IMPORT Arg, M3Build, M3Options, M3Path, Msg, Utils, TextSeq, TextTextTbl;
-IMPORT MxConfig, Dirs, Version, M3toC;
+IMPORT MxConfig, Dirs, Version, M3toC, TextUtils;
 
 TYPE
   NK = M3Path.Kind;
@@ -624,9 +624,13 @@ PROCEDURE SetMode (VAR got_mode: BOOLEAN;  mode: MM) =
   END SetMode;
 
 PROCEDURE PrintVersion (exit: BOOLEAN) =
+  VAR gitInfo := Version.GitInfo;
   BEGIN
     IF traceQuake THEN MxConfig.EnableQuakeTrace() END;
     Msg.Out ("Critical Mass Modula-3 version ", Val("CM3_RELEASE"), Wr.EOL);
+    gitInfo := TextUtils.Substitute(Version.GitInfo, "\n", "\n           ");
+    gitInfo := TextUtils.SkipRight(gitInfo);
+    Msg.Out ("  GitInfo: ", gitInfo, Wr.EOL);
     Msg.Out ("  last updated: ", Val("CM3_CHANGED"), Wr.EOL);
     Msg.Out ("  compiled: ", Val("CM3_COMPILED"), Wr.EOL);
     Msg.Out ("  configuration: ", MxConfig.FindFile(), Wr.EOL);

--- a/m3-sys/cm3/src/version.quake
+++ b/m3-sys/cm3/src/version.quake
@@ -62,6 +62,7 @@ proc version_impl(name) is
         NOW = datetime()
     end
     include(".." & SL & ".." & SL & ".." & SL & "scripts" & SL & "version.quake")
+
     >> tempname in
         write("IMPORT Ctypes;", CR)
         write("CONST", CR)
@@ -69,10 +70,48 @@ proc version_impl(name) is
         write("  Number = \"", CM3VERSIONNUM, "\";", CR)
         write("  LastChanged = \"", CM3LASTCHANGED, "\";", CR)
 
-        % This comment serves to retain the old behavior where
-        % cm3 prints the time it built, if any of it changes.
-        % This does not end up in the C backend output.
-        write("  (* Created = \"", NOW, "\"; *)", CR)
+        nul = "/dev/null"
+        if equal($OS, "Windows_NT")
+          nul = "nul:"
+        end
+
+        % TODO: Out of tree builds.
+
+        if (equal(0, try_exec("@git rev-parse --verify HEAD >", nul))) % or git rev-list -n 1 HEAD
+          local revision = compress(q_exec_get("git rev-parse --verify HEAD")[1])
+          local branch = compress(q_exec_get("git symbolic-ref -q --short HEAD")[1])
+          local remote_name = compress(q_exec_get("git config branch." & branch & ".remote")[1])
+          local remote_url = compress(q_exec_get("git config remote." & remote_name & ".url")[1])
+
+          % Replace git@github.com:x.git with https://github.com/x
+          % First requires ssh, second is open to public.
+
+          if equal(pn_lastext(remote_url), "git")
+            if tcontains(remote_url, "git@github.com:")
+              remote_url = subst(remote_url, "git@github.com:", "https://github.com/", 1)
+              remote_url = pn_join(pn_prefix(remote_url), pn_lastbase(remote_url))
+              remote_url = subst_chars(remote_url, "\\", "/")
+            end
+          end
+
+          write(
+          "  GitInfo = \"",
+            remote_url, "/", "commit", "/", revision, "\\n",
+            remote_url, "/", "commits", "/", branch, "\\n",
+            "remote: ", remote_url, "\\n",
+            "revision: ", revision, "\\n",
+            "branch: ", branch, "\\n", "\";", CR)
+
+          % Time "built" is still available, but it is not necessarily time built.
+          % It is when Version.c last compiled.
+          % We could touch it whenever git info changes, and have it use timestamp instead of time date.
+        else
+          % This comment serves to retain the old behavior where
+          % cm3 prints the time it built, if any of it changes.
+          % This does not end up in the C backend output.
+          write("  (* Created = \"", NOW, "\"; *)", CR)
+          write("  GitInfo = \"unknown\";", CR)
+        end
 
         % When cm3 uses this data, it is describing the HOST.
         % They are reasonable defaults for the TARGET, ASSUMING a NATIVE build.
@@ -86,6 +125,7 @@ proc version_impl(name) is
 
         write("END ", name, ".", CR)
     end
+
     cp_if(tempname, filename)
     derived_interface(name, HIDDEN)
 end


### PR DESCRIPTION
Like this:

C:\s\cm3.2\m3-sys\cm3>cm3 && AMD64_NT\cm3.exe --version
--- building in AMD64_NT ---

ignoring ..\src\m3overrides

****  PARALLEL BACK-END BUILD, M3_PARALLEL_BACK = 20
Critical Mass Modula-3 version d5.11.0
  GitInfo: https://github.com/jaykrell/cm3/commit/fb4448d43a0283855fe362d1206c79726966b19a
           https://github.com/jaykrell/cm3/commits/vd
           remote:https://github.com/jaykrell/cm3
           revision:fb4448d43a0283855fe362d1206c79726966b19a
           branch:vd
  last updated: 2021-02-24
  compiled: 2021-04- 3 13:57:27
  configuration: C:\cm3\bin\cm3.cfg
  host: AMD64_NT
  target: AMD64_NT

 Several notes:
  - It can be changed.
  - If git fails, it prints "unknown", like:
        Critical Mass Modula-3 version d5.11.0
        GitInfo: unknown
        last updated: 2021-02-24
        compiled: 2021-04- 3 13:57:27
        configuration: C:\cm3\bin\cm3.cfg
        host: AMD64_NT
        target: AMD64_NT
  - The url does not necessarily work.
    The commit might only be local. That is always a problem with
    git, being distributed. A hash can feed into a binary,
    the binary distributed and the hash not.
  - I didn't know what to call the first line. It seems most important.
  - Nor the second line.
  - Hash alone is useless without a repository, so this tries to be more complete.
  - Again, it can be changed.
  - You can see above "compiled:" has a bug, space vs. 0.
  - This will not work, as written, with the eventual goal of out of tree builds.
  - The code should be moved/copied to .cmd/.py/.sh and written out somewhere,
    like next to version.quake as gitversion.quake, but then ultimately
    into the output tree as part of a configure step. Maybe. That isn't up to
    date enough. So I guess an out of tree build should still cd over to the source tree.

When git info is available, we no longer recompile and relink for every build of cm3.
Only if the git info or other inputs changes. Not time alone.