### PR TITLE
config: Do not append c to BUILD_DIR for C backend.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/cm3cfg.common
+++ b/m3-sys/cminstall/src/config-no-install/cm3cfg.common
@@ -48,17 +48,6 @@ end
 
 %------------------------------------------------------------------------------
 
-if equal(M3_BACKEND_MODE, "IntegratedC")
-        or equal(M3_BACKEND_MODE, "C")
-        or USE_C_BACKEND_VIA_M3CGCAT
-    readonly BUILD_DIR_C = "c"
-    %readonly BUILD_DIR_C = ""
-else
-    readonly BUILD_DIR_C = ""
-end
-
-%------------------------------------------------------------------------------
-
 if not defined("PROFILING_P")
     if M3_PROFILING
         readonly PROFILING_P = "p"
@@ -68,7 +57,7 @@ if not defined("PROFILING_P")
 end
 
 if not defined("BUILD_DIR")
-    readonly BUILD_DIR    = TARGET & PROFILING_P & BUILD_DIR_C % directory for results
+    readonly BUILD_DIR    = TARGET & PROFILING_P % directory for results
 end
 
 %------------------------------------------------------------------------------


### PR DESCRIPTION
Like earlier, but I missed this spot.
It serves a useful purpose, but is confusing and eventually
eventually the output directory will just be the current directory,
like for normal cmake/automake out of tree builds.