### PR TITLE
scripts: Switch the bootstraps generally to C++ compiler driver.

### DIFF
--- a/scripts/python/c_compiler
+++ b/scripts/python/c_compiler
@@ -3,20 +3,20 @@
 import os, sys
 
 PossibleExecutables = [
+    "/usr/bin/CC",
     "/opt/developerstudio12.6/bin/CC",
     "/opt/developerstudio12.5/bin/CC",
     "/opt/solarisstudio12.4/bin/CC",
-    #"/usr/bin/g++",     # Does not understand the Sun cc flags.
-    #"/usr/bin/clang++", # Does not understand the Sun cc flags.
-    "/usr/bin/cc",
-    "/opt/solarisstudio12.3/bin/cc",
-    "/opt/solstudio12.2/bin/cc",
-    "/opt/studio/SOS12/SUNWspro/bin/cc",
-    "/opt/studio/SOS11/SUNWspro/bin/cc",
-    "/opt/SUNWspro/bin/cc",
-    #"/opt/csw/gcc4/bin/gcc",
-    #"/usr/sfw/bin/gcc",
-    #"/opt/csw/gcc4/bin/gcc",
+    "/opt/solarisstudio12.3/bin/CC",
+    "/opt/solstudio12.2/bin/CC",
+    "/opt/studio/SOS12/SUNWspro/bin/CC",
+    "/opt/studio/SOS11/SUNWspro/bin/CC",
+    # Good idea but mind the Sun cc switches.
+    #"/usr/bin/c++",
+    #"/usr/bin/g++",
+    #"/usr/sfw/bin/g++",
+    #"/opt/csw/gcc4/bin/g++",
+    #"/usr/bin/clang++",
     ]
 
 for Executable in PossibleExecutables:

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1203,25 +1203,25 @@ def Boot():
     CCompilerOut = ""
 
     if alpha32vms:
-        CCompiler = "cc"
+        CCompiler = "c++"
         CCompilerFlags = " "
     elif alpha64vms:
-        CCompiler = "cc"
+        CCompiler = "c++"
         CCompilerFlags = "/pointer_size=64 "
     elif solaris or solsun:
-        CCompiler = "/usr/bin/cc"
+        CCompiler = "/usr/bin/c++"
         CCompilerFlags = " -g -mt -xldscope=symbolic "
         CCompiler = "./c_compiler"
         CopyFile("./c_compiler", BootDir)
     elif osf:
-        CCompiler = "/usr/bin/cc"
+        CCompiler = "/usr/bin/c++"
         CCompilerFlags = " -g -pthread "
     else:
         # gcc and other platforms
         CCompiler = {
-            "SOLgnu" : "/usr/sfw/bin/gcc",
+            "SOLgnu" : "/usr/sfw/bin/g++",
             "AMD64_NT"      : "cl",
-            }.get(Config) or "gcc"
+            }.get(Config) or "g++"
 
         CCompilerFlags = {
             "I386_INTERIX"  : " -g ", # gcc -fPIC generates incorrect code on Interix


### PR DESCRIPTION
i.e. g++, c++, C++
Favor c++ over CC to be case insensitive but Solaris installs only CC in places.
Not all platforms available for test, e.g. VMS and OSF/1.