### PR TITLE
version.c: Fix after 5069e5e60ef9f6b2a79074b9dc619c6829a5d49f

### DIFF
--- a/m3-sys/cm3/src/Version.c
+++ b/m3-sys/cm3/src/Version.c
@@ -1,6 +1,10 @@
 #include <assert.h>
 #include <string.h>
 
+#if !defined(_MSC_VER) && !defined(__cdecl)
+#define __cdecl /* nothing */
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
used `__cdecl` without `#include "m3core.h"`