### PR TITLE
NT config/bootstrap: Compile with -Gy so linker can remove unused functions.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -645,6 +645,10 @@ proc compile_c_ms(source, object, options, optimize, debug) is
 % Don't put any default library names in .objs.
 %
         "-Zl",
+
+% Let the linker remove unused functions. Most build systems do this most of the time.
+%
+        "-Gy",
         options
     ]
 

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1227,8 +1227,8 @@ def Boot():
         # -fPIC breaks Interix and is not needed on Cygwin/Mingw.
         CCompilerFlags = {
             "I386_INTERIX"  : " -g ", # gcc -fPIC generates incorrect code on Interix
-            #"AMD64_NT"      : " -Zi -MD ",
-            "AMD64_NT"      : " -Zi ", # hack some problem with exception handling and alignment otherwise
+            #"AMD64_NT"      : " -Zi -MD -Gy ",
+            "AMD64_NT"      : " -Zi -Gy ", # hack some problem with exception handling and alignment otherwise
             }.get(Config) or " -pthread -g "
 
         #CCompilerOut = {


### PR DESCRIPTION
-Gy is ancient and good. Newer toolsets also have -Gw for unused data.
We really to do this for gcc also.