### PR TITLE
Solaris: Sometimes mmap/mprotect/munmap expect char* not void*

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -518,9 +518,11 @@ INTEGER __cdecl Usocket__recvfrom(int s, void* buf, WORD_T len, int flags, M3Soc
 DIR* __cdecl Udir__opendir(const char* a);
 #endif
 
-int __cdecl Umman__mprotect(ADDRESS addr, WORD_T len, int prot);
-ADDRESS __cdecl Umman__mmap(ADDRESS addr, WORD_T len, int prot, int flags, int fd, m3_off_t off);
-int __cdecl Umman__munmap(ADDRESS addr, WORD_T len);
+// char* instead of ADDRESS for default Solaris
+typedef char* caddr_t;
+int __cdecl Umman__mprotect(caddr_t addr, WORD_T len, int prot);
+ADDRESS __cdecl Umman__mmap(caddr_t addr, WORD_T len, int prot, int flags, int fd, m3_off_t off);
+int __cdecl Umman__munmap(caddr_t addr, WORD_T len);
 
 typedef INT64 m3_time_t;
 

--- a/m3-libs/m3core/src/unix/Common/Umman.c
+++ b/m3-libs/m3core/src/unix/Common/Umman.c
@@ -7,8 +7,9 @@
 
 #ifndef _WIN32
 
-M3WRAP3(int, mprotect, ADDRESS, WORD_T, int)
-M3WRAP6(ADDRESS, mmap, ADDRESS, WORD_T, int, int, int, m3_off_t)
-M3WRAP2(int, munmap, ADDRESS, WORD_T)
+// char* instead of ADDRESS for default Solaris
+M3WRAP3(int, mprotect, caddr_t, WORD_T, int)
+M3WRAP6(ADDRESS, mmap, caddr_t, WORD_T, int, int, int, m3_off_t)
+M3WRAP2(int, munmap, caddr_t, WORD_T)
 
 #endif


### PR DESCRIPTION
and it fails to compile. It happened to me just now.