### PR TITLE
Revert "m3c:Suppress warnings for Sun CC (C++) the same as Sun cc (C)…

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -1865,7 +1865,7 @@ PROCEDURE Proc_Locals(p: Proc_t; i: INTEGER): Var_t = BEGIN RETURN NARROW(p.loca
 CONST Prefix = ARRAY OF TEXT {
 (* It is unfortunate to #include anything -- slows down compilation;
    try to minimize/eliminate it. *)
-"#if defined(__SUNPRO_C) || defined(__SUNPRO_CC)", (* C or C++ *)
+"#ifdef __SUNPRO_C",
 (*"#pragma error_messages(off, E_INIT_DOES_NOT_FIT)",*)
 "#pragma error_messages(off, E_STATEMENT_NOT_REACHED)",
 "#endif",


### PR DESCRIPTION
…. (#302)"

This reverts commit 42b8f69aececff8023bf2e20cb095c1ab66ce7c4.

This only adds warnings, not reduces them.