### PR TITLE
mklib: Skip exporting what we also skip in .def file.

### DIFF
--- a/m3-sys/mklib/src/Main.m3
+++ b/m3-sys/mklib/src/Main.m3
@@ -417,6 +417,10 @@ PROCEDURE ScanExports (f: FileDesc) =
 PROCEDURE AddExport (sym: TEXT;  f: FileDesc) =
   VAR ref: REFANY; f2: FileDesc;
   BEGIN
+    IF NOT IsKeeper(CleanName(sym)) THEN
+      (* IO.Put("AddExport skipping:" & sym & "\n"); *)
+      RETURN;
+    END;
     IF (export_tbl = NIL) THEN
       export_tbl := NEW (TextRefTbl.Default).init ();
     END;


### PR DESCRIPTION
Next step is to stop writing import libraries here at all.
And try to write the .def file from cm3 instead of mklib.
This addresses warnings seen, since listing file code removed, i.e. duplicate exports of floating point constants, that we should not even export once.
