### PR TITLE
m3c: Uniquify segment names by package ("library or program") and module

### DIFF
--- a/m3-sys/cm3/src/Builder.m3
+++ b/m3-sys/cm3/src/Builder.m3
@@ -13,7 +13,7 @@ IMPORT Msg, Arg, Utils, M3Path, M3Backend, M3Compiler;
 IMPORT Quake, QMachine, QValue, QVal, QVSeq;
 IMPORT M3Loc, M3Unit, M3Options, MxConfig;
 IMPORT QIdent;
-IMPORT Target; 
+IMPORT Target;
 FROM M3Path IMPORT OSKind, OSKindStrings;
 IMPORT Pathname;
 IMPORT QPromise, QPromiseSeq, RefSeq;
@@ -2020,7 +2020,12 @@ PROCEDURE Pass0_InitCodeGenerator (env: Env): M3CG.T =
     env.cg     := NIL;
     env.output := Utils.OpenWriter (env.object, fatal := FALSE);
     IF (env.output # NIL) THEN
-      env.cg := M3Backend.Open (env.output, env.object, env.globals.m3backend_mode);
+      env.cg := M3Backend.Open (
+        env.globals.result_name,
+        env.source_unit.name,
+        env.output,
+        env.object,
+        env.globals.m3backend_mode);
     END;
     RETURN env.cg;
   END Pass0_InitCodeGenerator;

--- a/m3-sys/cm3/src/M3Backend.i3
+++ b/m3-sys/cm3/src/M3Backend.i3
@@ -6,10 +6,10 @@
 
 INTERFACE M3Backend;
 
-IMPORT Wr, M3CG;
+IMPORT Wr, M3CG, M3ID;
 IMPORT Target;
 
-PROCEDURE Open (target: Wr.T;  target_name: TEXT;  backend_mode: Target.M3BackendMode_t): M3CG.T;
+PROCEDURE Open (library (* or program *): TEXT; source (* lacks .m3 or .i3 *): M3ID.T; target: Wr.T; target_name: TEXT; backend_mode: Target.M3BackendMode_t): M3CG.T;
 PROCEDURE Close (cg: M3CG.T);
 
 END M3Backend.

--- a/m3-sys/cm3/src/M3Backend.m3
+++ b/m3-sys/cm3/src/M3Backend.m3
@@ -9,7 +9,7 @@ MODULE M3Backend;
 IMPORT Wr, Thread, M3C;
 IMPORT LLGen; (* Could be a dummy.  See the m3makefile. *) 
 IMPORT M3CG, Msg, Utils, NTObjFile, M3x86, M3ObjFile;
-IMPORT M3CG_BinWr;
+IMPORT M3CG_BinWr, M3CG_Ops, M3ID;
 IMPORT Target; 
 
 VAR
@@ -19,10 +19,22 @@ VAR
   log      : Wr.T        := NIL;
   log_name : TEXT        := NIL;
 
-PROCEDURE Open (target: Wr.T;  target_name: TEXT;  backend_mode: Target.M3BackendMode_t): M3CG.T =
+PROCEDURE Open (library (* or program *): TEXT; source: M3ID.T; target: Wr.T; target_name: TEXT; backend_mode: Target.M3BackendMode_t): M3CG.T =
+  VAR cg: M3CG_Ops.Public := NIL;
   BEGIN
     IF backend_mode = Target.M3BackendMode_t.C THEN
-      RETURN M3C.New (target);
+      cg := M3C.New (library, source, target, target_name);
+      (* cg.comment would not appear at the top because
+       * earlier passes ignore it
+       *)
+      Wr.PutText(target, "// library:");
+      Wr.PutText(target, library);
+      Wr.PutText(target, "\n// source:");
+      Wr.PutText(target, M3ID.ToText(source));
+      Wr.PutText(target, "\n// target_name:");
+      Wr.PutText(target, target_name);
+      Wr.PutText(target, "\n");
+      RETURN cg;
     END;
     IF backend_mode IN Target.BackendLlvmSet THEN
       IF (Msg.level >= Msg.Level.Verbose) THEN

--- a/m3-sys/m3back/src/M3C.i3
+++ b/m3-sys/m3back/src/M3C.i3
@@ -8,9 +8,10 @@
 
 INTERFACE M3C;
 
-IMPORT M3CG, Wr;
+IMPORT M3CG, Wr, M3ID;
 
-PROCEDURE New (cfile: Wr.T): M3CG.T;
+PROCEDURE New0 (cfile: Wr.T): M3CG.T;
+PROCEDURE New (library (* or program *): TEXT; source: M3ID.T; cfile: Wr.T; target_name: TEXT): M3CG.T;
 (* returns a new code generator that writes to 'cfile'. *)
 
 END M3C.

--- a/m3-sys/m3cgcat/src/Main.m3
+++ b/m3-sys/m3cgcat/src/Main.m3
@@ -38,7 +38,7 @@ PROCEDURE DoIt () RAISES {Rd.Failure, Wr.Failure, Alerted, OSError.E} =
   TYPE Inhale_t = PROCEDURE (rd: Rd.T;  cg: M3CG.T);
        OutNew_t = PROCEDURE (wr: Wr.T): M3CG.T;
   CONST Inhale = ARRAY OF Inhale_t {M3CG_BinRd.Inhale, M3CG_Rd.Inhale};
-  CONST OutNew = ARRAY OF OutNew_t {M3CG_BinWr.New, M3CG_Wr.New, M3C.New};
+  CONST OutNew = ARRAY OF OutNew_t {M3CG_BinWr.New, M3CG_Wr.New, M3C.New0};
   CONST inout_text = ARRAY OF TEXT {"-in-", "-out-"};
   CONST types_text = ARRAY OF TEXT {"binary", "ascii", "c"};
   VAR arg : TEXT;


### PR DESCRIPTION
This is an area where mfront/m3cg could use improvement.

Specifically m3cg should be directly given a unique identifier
prefix per source, that must be unique across the static link.
i.e. if appended with a recurring sequence, like empty
or 1, 2, 3, etc.

And/or specifically m3front should be producing these names,
for all backends. No nulls, no stars, no duplicates, no assumed
file level static linkage.
i.e. for segments.

For any backend, append before link should be trivial.

I'm a bit reluctant to mess with m3front though.

While this change does not change m3front, it does tunnel
through package/library/program name, and kinda source name to the backend.
There is also a notion of unit_name, but it does not differentiate
interface from module, which is perhaps unfortunate (I admit,
I don't know what all goes into interfaces; one might imagine
they have no code, but that is false).