### PR TITLE
m3c: ifndef around struct types.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4203,6 +4203,7 @@ VAR size := 0;
     sizes: REF ARRAY OF INTEGER := NIL;
     x := self.self;
     index := 0;
+    sizestr: TEXT;
 BEGIN
 
     (* RETURN; *) (* TODO *)
@@ -4237,7 +4238,10 @@ BEGIN
             prev := size;
             FOR unit := FIRST(units) TO LAST(units) DO
                 IF (size MOD units[unit]) = 0 THEN
-                    print(x, "STRUCT" & IntToDec(units[unit]) & "(" & IntToDec(size) & ")\n");
+                    sizestr := IntToDec(size);
+                    ifndef_type(x, "struct_" & sizestr & "_t"); (* see define STRUCT *)
+                    print(x, "STRUCT" & IntToDec(units[unit]) & "(" & sizestr & ")\n");
+                    endif(x);
                     EXIT;
                 END;
             END;


### PR DESCRIPTION
This is with the goal of concatenating all the files
from a library/package, or across multiple library/packages,
for a crude form of LTCG/LTO, or easier to bootstrap
because cm3 will be just one file.