### PR TITLE
NT config: Remove the delayload support.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -222,15 +222,10 @@ proc SetupEnvironment() is
 %             ["msobj80.dll", "msobj71.dll", "msobj10.dll", "msobj10.dll", "mspdb50.dll", "mspdb41.dll", "mspdb40.dll", "dbi.dll"],
 %             MspdbDir)
 
-%         # The free Visual C++ 2003 has neither delayimp.lib nor msvcrt.lib.
-%         # Very old toolsets have no delayimp.lib.
-%         # The Quake config file checks these environment variables.
+%         # The free Visual C++ 2003 has no msvcrt.lib.
+%         # The Quake config file checks this environment variables.
 
 %         Lib = os.environ.get("LIB")
-%         if not SearchPath("delayimp.lib", Lib)
-%             os.environ["USE_DELAYLOAD"] = "0"
-%             print("set USE_DELAYLOAD=0")
-
 %         if not SearchPath("msvcrt.lib", Lib)
 %             os.environ["USE_MSVCRT"] = "0"
 %             print("set USE_MSVCRT=0")
@@ -1126,49 +1121,6 @@ m3_link_flags =
 %
 %   "-opt:icf",
 ]
-
-%
-% The environment variable USE_DELAYLOAD is 0, 1, or not defined.
-% Not defined is treated as 1. This is a safe default for
-% linker versions going back a long way, but not infinitely so.
-% sysinfo.cmd sets it based on probing the environment.
-%
-if not equal($USE_DELAYLOAD, "0")
-    if not equal($USE_DELAYLOAD, "1")
-        if not equal($USE_DELAYLOAD, "")
-            error("The environment variable USE_DELAYLOAD should be 0, 1, or not defined, but it is " & $USE_DELAYLOAD & "." & EOL)
-        end
-    end
-end
-
-if not defined("USE_DELAYLOAD")
-    if equal($USE_DELAYLOAD, "0")
-        USE_DELAYLOAD = FALSE
-    else
-        USE_DELAYLOAD = TRUE
-    end
-end
-
-if USE_DELAYLOAD
-    m3_link_flags +=
-    [
-    %
-    % The default static dependencies of Modula-3 binaries
-    % are larger than they should be. Reduce them via delayload.
-    % This requires a Visual C++ 6.0 or newer linker.
-    %
-        %"-delayload:ws2_32.dll",
-        "-delayload:wsock32.dll",
-        "-delayload:advapi32.dll",
-        "-delayload:gdi32.dll",
-        "-delayload:netapi32.dll",
-        "-delayload:user32.dll",
-        "-delayload:comctl32.dll",
-        "-delayload:rpcrt4.dll",
-        "-delayload:iphlpapid.dll",
-        "delayimp.lib",
-    ]
-end
 
 %------------------------------------------------------------------------------
 


### PR DESCRIPTION
I added it. Probably nobody noticed or cares.
It produces warnings, now that I removed the listing file stuff.
It is not a bad idea, but perhaps this is not the way.
Really the output should be factored and formed so that
cm3 does not actually import this unused stuff.
cm3 is not really CreateProcess/LoadLibrary intensive, as it runs per package
not per source, and even this we might reduce.
ws2_32.dll (commented out)
wsock32.dll advapi32.dll gdi32.dll netapi32.dll user32.dll comctl32.dll rpcrt4.dll
iphlpapid.dll (typo)
It also doesn't work on quite old no-longer-untested toolsets (Visual C++ 2003 Express and pre-Visual++5.0sp?)