### PR TITLE
m3core: Unifity ADDRESS with m3c.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -410,7 +410,9 @@ typedef float REAL;
 typedef double LONGREAL;
 typedef double EXTENDED;
 #if defined(__cplusplus) || __STDC__
-typedef void* ADDRESS;
+//Match m3c, so all the files can be concatenated.
+//typedef void* ADDRESS;
+typedef char* ADDRESS;
 #else
 typedef char* ADDRESS;
 #endif

--- a/m3-libs/m3core/src/runtime/common/RTLinkerC.c
+++ b/m3-libs/m3core/src/runtime/common/RTLinkerC.c
@@ -1,6 +1,4 @@
-#if !defined(_MSC_VER) && !defined(__cdecl)
-#define __cdecl /* nothing */
-#endif
+#include "m3core.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,12 +9,16 @@ EnvFromMain is either char** from main, or char* GetEnvironmentStringsA from Win
 Rather than make a coordinated compiler/runtime change, we just ignore
 the compiler-provided data and make the runtime always work.
 One additional copy of the environment variables is leaked per .exe/.dll.
+
+RTLinker__GetEnvironmentStrings here matches M3C output (subject to change).
+That is why "ADDRESS" and not e.g. "void*".
 */
-void* __cdecl RTLinker__GetEnvironmentStrings (void* EnvFromMain)
+ADDRESS
+__cdecl
+RTLinker__GetEnvironmentStrings (ADDRESS EnvFromMain)
 {
 #ifdef _WIN32
-    __declspec(dllimport) char** __stdcall GetEnvironmentStringsA(void);
-    return GetEnvironmentStringsA ();
+    return (ADDRESS)GetEnvironmentStringsA ();
 #else
     return EnvFromMain;
 #endif


### PR DESCRIPTION
This is maybe unfortunate, maybe ok.
m3core.h had:
if defined(__cplusplus) || __STDC__
typedef void* ADDRESS;
else
typedef char* ADDRESS;
endif

but m3c outputs:

(* TODO ideally these are char* for K&R or ideally absent when strong
   typing and setjmp work done *)
typedef char* ADDRESS;
typedef char* STRUCT;

and the resulting code adds integers to ADDRESS.
Which is fine for char* but non-standard/illegal for void*.

The strong typing thing might happen eventually, esp. for structs,
but it also requires the offseting to be done by name/index
in m3back instead of m3front layout, so pretty far out.

If you concatenate the m3c output with the hand written C
you get approximately one error, about RTLinker__GetEnvironmen

We could alternatively rename one of them, or just have m3c
output "char*" everywhere (more tokens, fewer symbols).

However this change changes m3core.h to char* and
RTLinker__GetEnvironmentStrings to use ADDRESS instead of void*.

char* works with pre-ANSI, if that matters (we require ANSI C
currently and intend to move up to C++).
char* tends to show garbage in debuggers vs. void* shows nothing.

So maybe revisit this.