### PR TITLE
m3core: Fix compiling Umman.c on most systems due to Solaris fix.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Umman.c
+++ b/m3-libs/m3core/src/unix/Common/Umman.c
@@ -9,9 +9,9 @@
 
 #ifndef _WIN32
 
-// char* instead of ADDRESS for default Solaris
+// char* (caddr_t) instead of void* for default Solaris
 M3WRAP3(int, mprotect, caddr_t, WORD_T, int)
-M3WRAP6(ADDRESS, mmap, caddr_t, WORD_T, int, int, int, m3_off_t)
+M3WRAP6(void*, mmap, caddr_t, WORD_T, int, int, int, m3_off_t)
 M3WRAP2(int, munmap, caddr_t, WORD_T)
 
 #endif


### PR DESCRIPTION
../src/unix/Common/Umman.c: In function cchar* Umman__mmap(caddr_t, WORD_T, int, int, int, m3_off_t):
../src/m3core.h:315:106: error: invalid conversion from void* to ADDRESS (char*)

Keep the parameters char*, which converts to void*.
But make the return void*, which converts from char*.