### PR TITLE
x-opengl: Fix calling convention of callbacks.

### DIFF
--- a/m3-ui/anim3D/src/x-opengl/X_OpenGL_Base.m3
+++ b/m3-ui/anim3D/src/x-opengl/X_OpenGL_Base.m3
@@ -1155,11 +1155,11 @@ PROCEDURE DrawPolygon (self         : T;
         <* ASSERT tess # NIL *>
 
         GLu.gluTessCallback (tess, GLu.GLU_BEGIN,
-                             LOOPHOLE (GL.glBegin, PROCEDURE ()));
+                             LOOPHOLE (GL.glBegin, GLu.GLUtessAnyProc));
         GLu.gluTessCallback (tess, GLu.GLU_VERTEX,
-                             LOOPHOLE (GL.glVertex3dv, PROCEDURE ()));
+                             LOOPHOLE (GL.glVertex3dv, GLu.GLUtessAnyProc));
         GLu.gluTessCallback (tess, GLu.GLU_END,
-                             LOOPHOLE (GL.glEnd, PROCEDURE ()));
+                             LOOPHOLE (GL.glEnd, GLu.GLUtessAnyProc));
 
         GLu.gluBeginPolygon (tess);
 


### PR DESCRIPTION
This fixes compiling x-opengl using the C backend.

Generally calling conventions, having more than one, is an anomoly.
It is only for NT/x86.

However when using the C backend, m3middle/m3front/backend deliberately
do not know this.

So for example, I386_NT is the same as ARM32_NT.

So all code needs to be written as if it is targeting NT/x86,
regarding calling conventions.

The fix is trivial and in good style.
Instead of casting to PROCEDURE(), cast to GLu.GLUtessAnyProc.