### PR TITLE
m3core: Remove FreeBSD 4 special case.

### DIFF
--- a/m3-libs/m3core/src/thread/m3makefile
+++ b/m3-libs/m3core/src/thread/m3makefile
@@ -6,72 +6,15 @@
 
 include_dir ("Common")
 
-if not defined("IsTargetFreeBSD4")
+% FreeBSD 4 or earlier might not have a viable pthreads,
+% in which case make a separate config file and set NOPTHREAD = TRUE or such.
+%
+% Cygwin might want to use Win32 threads.
 
-proc InternalPlatformEquivalent(a, b) is
-  if equal(a, b)
-    return TRUE
-  end
-  foreach c in [{"SPARC32_SOLARIS", "SOLgnu", "SOLsun"},
-                {"I386_FREEBSD", "FreeBSD4"},
-                {"I386_NT", "NT386"},
-                {"I386_CYGWIN", "NT386GNU"},
-                {"I386_MINGW", "NT386MINGNU"},
-                {"I386_LINUX", "LINUXLIBC6"}]
-    if (c contains a) and (c contains b)
-      return TRUE
-    end
-  end
-  return FALSE
-end
-
-proc IsHostFreeBSD4() is
-% remove this once cm3cfg.common is up to date
-  if defined("HOST")
-    if not InternalPlatformEquivalent(HOST, "I386_FREEBSD")
-      return FALSE
-    end
-  end
-  if not defined("xIsHostFreeBSD4")
-    xIsHostFreeBSD4 = equal(try_exec("@uname -sr | fgrep \"FreeBSD 4.\" > /dev/null"), 0)
-  end
-  return xIsHostFreeBSD4
-end
-
-proc InternalCheckTargetOS(x) is
-% remove this once cm3cfg.common is up to date
-  if defined("TARGET_OS")
-    return equal(TARGET_OS, x)
-  end
-  error("config file (or cm3 executable) must define TARGET_OS")
-  return FALSE
-end
-
-proc IsNativeBuild() is
-% remove this once cm3cfg.common is up to date
-  if defined("HOST") and defined("TARGET")
-    return InternalPlatformEquivalent(HOST, TARGET)
-  end
-  return FALSE
-end
-
-% remove this once cm3cfg.common is up to date
-proc IsTargetFreeBSD() is return InternalCheckTargetOS("FREEBSD") end
-
-proc IsTargetFreeBSD4() is
-% remove this once cm3cfg.common is up to date
-  % approx (doesn't work for cross builds)
-  return IsTargetFreeBSD() and IsNativeBuild() and IsHostFreeBSD4()
-end
-
-end
-
-if equal (OS_TYPE, "WIN32") or equal(TARGET, "NT386")
-    or ({"NT", "MINGW", "CYGWIN"} contains TARGET)
+if equal (OS_TYPE, "WIN32") or ({"CYGWIN"} contains TARGET_OS)
   include_dir ("WIN32")
 else
-  if (not defined("NOPTHREAD"))
-     and (not IsTargetFreeBSD4())
+  if not defined("NOPTHREAD")
     include_dir("PTHREAD")
   else
     include_dir (OS_TYPE)


### PR DESCRIPTION
Simplifiy selection of Win32 threads. Some of the conditions were redundant.
Require TARGET_OS to be set, such as to NT, CYGWIN, LINUX, DARWIN, etc.

Generally TARGET = TARGET_ARCH + "_" + TARGET_OS.

TARGET_OS is a further refinement of Posix generally (or NT vs. MINGW,
though I think MINGW is really just a toolset, not a host or target).

TARGET_ARCH isn't really interesting at all. Nothing outside of m3cc
is architecture-specific, except for GET_PC and M3_HOST, which are
optional.

The actual factors are WORD_SIZE and TARGET_ENDIAN, which
do closely correlate with TARGET_ARCH, but such decomposition
hypothetically makes for fewer (four) total combinations.
(if you consider sparc, mips, ppc alpha etc. 'cause actually there are only
a few interesting processors these days: amd64, arm64, riscv64, wasm32, wasm64,
decomposition into wordsize+endian isn't a huge help perhaps)

If FreeBSD 4 and earlier pthreads are not adequate,
this can be factored into the toplevel config.
FreeBSD 4 is out of support since early 2007, and might still work.