### PR TITLE
Revert "I had this change around: expose if we are using user threads…

### DIFF
--- a/m3-libs/sysutils/src/POSIX/m3makefile
+++ b/m3-libs/sysutils/src/POSIX/m3makefile
@@ -32,21 +32,4 @@ else
   implementation("FSUnix_cm3")
 end
 
-> "UserThreads.i3.tmp" in
-  write("INTERFACE UserThreads;\n")
-  if defined("TARGET_OS")
-    if equal(TARGET_OS, "OPENBSD")
-      write("CONST Value = TRUE;\n")
-    else
-      write("CONST Value = FALSE;\n")
-    end
-  else
-    write("CONST Value = FALSE;\n")
-  end
-  write("END UserThreads.\n")
-end
-cp_if("UserThreads.i3.tmp", "UserThreads.i3")
-
-derived_interface("UserThreads", HIDDEN)
-
 end


### PR DESCRIPTION
…, i.e. if we are OpenBSD"

This reverts commit 5f41d677686c8f58eac0391390e50359427be3ed.

Hopefully OpenBSD pthreads work, and otherwise
we'd need multiple distributions, or, really
we should make this decision possible at runtime not just build time.

Unlikely anyone ever used this.