### PR TITLE
mklib: Remove m3core duplication.

### DIFF
--- a/m3-sys/mklib/src/Main.m3
+++ b/m3-sys/mklib/src/Main.m3
@@ -8,13 +8,11 @@ UNSAFE MODULE Main;
 IMPORT Process, IO, Rd, Wr, FileRd, FileWr, Thread, OSError, TextRefTbl;
 IMPORT Convert, CoffTime, File, FS, Text, Word, TextWr, TextSeq;
 IMPORT Fmt, Time, IntArraySort, RegularFile, Params, Pathname;
-IMPORT ASCII, Ctypes, TextLiteral;
+IMPORT ASCII, Ctypes, TextLiteral, WinNT;
 
 TYPE
   UINT8 = Ctypes.unsigned_char;
-  UINT16 = Ctypes.unsigned_short;
   UINT32 = Ctypes.unsigned_int;
-  INT16 = Ctypes.short;
 
 CONST
   (* TODO keep everything in memory *)
@@ -23,67 +21,12 @@ CONST
   ArchiveMagic = "!<arch>\n";
   EndHeader    = "`\n";
   PadChar      = '\n';
-  
-  (* m3core/winnt.i3 duplicated here for bootstrapping from older releases *)
-
-  IMAGE_FILE_BYTES_REVERSED_HI = 16_8000; (* Bytes of machine word are reversed. *)
-  IMAGE_SIZEOF_SYMBOL = 18;
-  IMAGE_SYM_CLASS_EXTERNAL               = 2;
-  IMAGE_SYM_UNDEFINED: INT16 = 0; (* Symbol is undefined or is common. *)
-  IMAGE_FILE_RELOCS_STRIPPED = 16_0001; (* Relocation info stripped from file. *)
-  IMAGE_FILE_EXECUTABLE_IMAGE = 16_0002; (* File is executable (i.e.  no unresolved externel references). *)
-  IMAGE_FILE_16BIT_MACHINE  = 16_0040; (* 16 bit word machine. *)
-  IMAGE_FILE_BYTES_REVERSED_LO = 16_0080; (* Bytes of machine word are reversed. *)
-  IMAGE_FILE_DLL           = 16_2000; (* File is a DLL. *)
-  IMAGE_FILE_MACHINE_I386    = 16_14c; (* Intel 386. *)
-  IMAGE_FILE_MACHINE_AMD64 = 16_8664;  (* AMD64 *)
 
 (* File header format. *)
 
 TYPE
 
-  PIMAGE_SYMBOL = (* UNALIGNED *) UNTRACED REF IMAGE_SYMBOL;
-  IMAGE_SYMBOL = RECORD
-    N: ARRAY [0 .. 7] OF UINT8;
-    (*
-    union {
-        UINT8    ShortName[8];
-        struct {
-            UINT32   Short;     (* if 0, use LongName *)
-            UINT32   Long;      (* offset into string table *)
-        } Name;
-        PUINT8   LongName[2];
-    } N;
-    *)
-    Value              : UINT32;
-    SectionNumber      : INT16;
-    Type               : UINT16;
-    StorageClass       : UINT8;
-    NumberOfAuxSymbols : UINT8;
-  END;
-
-  PIMAGE_FILE_HEADER = UNTRACED REF IMAGE_FILE_HEADER;
-  IMAGE_FILE_HEADER = RECORD
-    Machine             : UINT16;
-    NumberOfSections    : UINT16;
-    TimeDateStamp       : UINT32;
-    PointerToSymbolTable: UINT32;
-    NumberOfSymbols     : UINT32;
-    SizeOfOptionalHeader: UINT16;
-    Characteristics     : UINT16;
-  END;
-
-  IMAGE_ARCHIVE_MEMBER_HEADER = RECORD
-    Name     : ARRAY [0 .. 15] OF UINT8;  (* member name - `/' terminated. *)
-    Date     : ARRAY [0 .. 11] OF UINT8;  (* member date - decimal secs since 1970 *)
-    UserID   : ARRAY [0 .. 5]  OF UINT8;  (* member user id - decimal. *)
-    GroupID  : ARRAY [0 .. 5]  OF UINT8;  (* member group id - decimal. *)
-    Mode     : ARRAY [0 .. 7]  OF UINT8;  (* member mode - octal. *)
-    Size     : ARRAY [0 .. 9]  OF UINT8;  (* member size - decimal. *)
-    EndHeader: ARRAY [0 .. 1]  OF UINT8;  (* String to end header. *)
-  END;
-
-  Header = IMAGE_ARCHIVE_MEMBER_HEADER;
+  Header = WinNT.IMAGE_ARCHIVE_MEMBER_HEADER;
 
   FileDesc = REF RECORD
     next     : FileDesc := NIL;
@@ -140,9 +83,9 @@ BEGIN
              Fmt.Int(machine));
     END;
     Machine := machine;
-    IF machine = IMAGE_FILE_MACHINE_I386 THEN
+    IF machine = WinNT.IMAGE_FILE_MACHINE_I386 THEN
         trimUnderscore := TRUE;
-    ELSIF machine = IMAGE_FILE_MACHINE_AMD64 THEN
+    ELSIF machine = WinNT.IMAGE_FILE_MACHINE_AMD64 THEN
         trimUnderscore := FALSE;
     ELSE
         RETURN FALSE;
@@ -349,25 +292,25 @@ PROCEDURE ScanFile (f: FileDesc) =
 (*----------------------------------------------- Windows Object Files ---*)
 
 CONST (* we don't handle this stuff! *)
-  BadObjFlags = IMAGE_FILE_RELOCS_STRIPPED
-              + IMAGE_FILE_EXECUTABLE_IMAGE
-              + IMAGE_FILE_16BIT_MACHINE
-              + IMAGE_FILE_BYTES_REVERSED_LO
-              + IMAGE_FILE_DLL
-              + IMAGE_FILE_BYTES_REVERSED_HI;
+  BadObjFlags = WinNT.IMAGE_FILE_RELOCS_STRIPPED
+              + WinNT.IMAGE_FILE_EXECUTABLE_IMAGE
+              + WinNT.IMAGE_FILE_16BIT_MACHINE
+              + WinNT.IMAGE_FILE_BYTES_REVERSED_LO
+              + WinNT.IMAGE_FILE_DLL
+              + WinNT.IMAGE_FILE_BYTES_REVERSED_HI;
 
 TYPE
   ObjFile = RECORD
     file      : FileDesc;
     base      : ADDRESS;
     limit     : ADDRESS;
-    hdr       : PIMAGE_FILE_HEADER;
-    symtab    : PIMAGE_SYMBOL;
+    hdr       : WinNT.PIMAGE_FILE_HEADER;
+    symtab    : WinNT.PIMAGE_SYMBOL;
     stringtab : ADDRESS;
   END;
 
 PROCEDURE ScanExports (f: FileDesc) =
-  VAR o: ObjFile;  sym: PIMAGE_SYMBOL;
+  VAR o: ObjFile;  sym: WinNT.PIMAGE_SYMBOL;
   BEGIN
     o.file  := f;
     o.base  := ADR (f.contents[0]);           (* pin the contents so the collector*)
@@ -393,15 +336,15 @@ PROCEDURE ScanExports (f: FileDesc) =
     END;
 
     (* locate the string table *)
-    o.stringtab := o.symtab + o.hdr.NumberOfSymbols * IMAGE_SIZEOF_SYMBOL;
+    o.stringtab := o.symtab + o.hdr.NumberOfSymbols * WinNT.IMAGE_SIZEOF_SYMBOL;
     IF (o.symtab < o.base) OR (o.limit <= o.symtab) THEN
       Die ("cannot find string table in object file \"", f.name, "\".");
     END;
 
     sym := o.symtab;
     WHILE (sym < o.stringtab) DO
-      IF sym.StorageClass = IMAGE_SYM_CLASS_EXTERNAL THEN
-        IF sym.SectionNumber # IMAGE_SYM_UNDEFINED THEN
+      IF sym.StorageClass = WinNT.IMAGE_SYM_CLASS_EXTERNAL THEN
+        IF sym.SectionNumber # WinNT.IMAGE_SYM_UNDEFINED THEN
           V ("symbol section number: ", Fmt.Int(sym.SectionNumber));
           AddExport (GetSymbolName (o, sym), f);
         ELSIF sym.Value > 0 THEN
@@ -410,7 +353,7 @@ PROCEDURE ScanExports (f: FileDesc) =
           AddExport (GetSymbolName (o, sym), f);
         END;
       END;
-      sym := sym + IMAGE_SIZEOF_SYMBOL * (1 + sym.NumberOfAuxSymbols);
+      sym := sym + WinNT.IMAGE_SIZEOF_SYMBOL * (1 + sym.NumberOfAuxSymbols);
     END;
   END ScanExports;
 
@@ -448,7 +391,7 @@ PROCEDURE AddExport (sym: TEXT;  f: FileDesc) =
     END;
   END AddExport;
 
-PROCEDURE GetSymbolName (READONLY o: ObjFile;  sym: PIMAGE_SYMBOL): TEXT =
+PROCEDURE GetSymbolName (READONLY o: ObjFile;  sym: WinNT.PIMAGE_SYMBOL): TEXT =
   TYPE IntBytes = ARRAY [0..3] OF UINT8;
   VAR
     max_len, len: INTEGER;


### PR DESCRIPTION
m3core now provides Win32 types/constants for all systems,
allowing some cross scenarios (the .lib file format
working here should go away, just write .def files, in m3front)