### PR TITLE
m3core: undef M3MODULE before defining it,

### DIFF
--- a/m3-libs/m3core/src/C/Common/CsignalC.c
+++ b/m3-libs/m3core/src/C/Common/CsignalC.c
@@ -6,6 +6,7 @@
 #include "m3core.h"
 #endif
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Csignal
 
 typedef void (__cdecl*SignalHandler)(int s);

--- a/m3-libs/m3core/src/C/Common/CstdioC.c
+++ b/m3-libs/m3core/src/C/Common/CstdioC.c
@@ -6,6 +6,7 @@
 extern "C" {
 #endif
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Cstdio
 
 M3WRAP1(int, fclose, FILE*)

--- a/m3-libs/m3core/src/C/Common/CstdlibC.c
+++ b/m3-libs/m3core/src/C/Common/CstdlibC.c
@@ -10,6 +10,7 @@
 extern "C" {
 #endif
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Cstdlib
 
 typedef void (__cdecl*AtExitFunction)(void);

--- a/m3-libs/m3core/src/C/Common/CstringC.c
+++ b/m3-libs/m3core/src/C/Common/CstringC.c
@@ -6,6 +6,7 @@
 #include "m3core.h"
 #endif
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Cstring
 
 M3WRAP3(const void*, memchr, const void*, int, WORD_T)

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -16,6 +16,7 @@
 #include <mach/mach_init.h>
 #endif
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE ThreadPThread
 
 #if defined(__sparc) || defined(__ia64__)

--- a/m3-libs/m3core/src/unix/Common/UdirC.c
+++ b/m3-libs/m3core/src/unix/Common/UdirC.c
@@ -8,6 +8,7 @@
 
 #ifndef _WIN32
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Udir
 M3WRAP1(DIR*, opendir, const char*)
 M3WRAP1(void*, readdir, DIR*)

--- a/m3-libs/m3core/src/unix/Common/Uexec.c
+++ b/m3-libs/m3core/src/unix/Common/Uexec.c
@@ -5,6 +5,7 @@
 #ifndef INCLUDED_M3CORE_H
 #include "m3core.h"
 #endif
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Uexec
 
 #ifdef __cplusplus

--- a/m3-libs/m3core/src/unix/Common/Umman.c
+++ b/m3-libs/m3core/src/unix/Common/Umman.c
@@ -5,6 +5,7 @@
 #ifndef INCLUDED_M3CORE_H
 #include "m3core.h"
 #endif
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Umman
 
 #ifndef _WIN32

--- a/m3-libs/m3core/src/unix/Common/UnixC.c
+++ b/m3-libs/m3core/src/unix/Common/UnixC.c
@@ -33,6 +33,7 @@ So use these wrappers instead.
 #ifdef _WIN32
 #include <windows.h>
 #endif
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Unix
 
 #ifdef __cplusplus

--- a/m3-libs/m3core/src/unix/Common/Uprocess.c
+++ b/m3-libs/m3core/src/unix/Common/Uprocess.c
@@ -6,5 +6,6 @@
 #include "m3core.h"
 #endif
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Uprocess
 M3WRAP0_(m3_pid_t, getpid)

--- a/m3-libs/m3core/src/unix/Common/Upwd.c
+++ b/m3-libs/m3core/src/unix/Common/Upwd.c
@@ -8,6 +8,7 @@
 
 #ifndef _WIN32
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Upwd
 
 M3WRAP1(struct passwd*, getpwuid, m3_uid_t)

--- a/m3-libs/m3core/src/unix/Common/Usignal.c
+++ b/m3-libs/m3core/src/unix/Common/Usignal.c
@@ -8,6 +8,7 @@
 
 #ifndef _WIN32
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Usignal
 M3WRAP2(int, kill, m3_pid_t, int)
 

--- a/m3-libs/m3core/src/unix/Common/Usocket.c
+++ b/m3-libs/m3core/src/unix/Common/Usocket.c
@@ -325,6 +325,7 @@ Usocket__Assertions(void)
 
 /* wrap everything */
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Usocket
 M3WRAP2(int, listen, int, int)
 M3WRAP2(int, shutdown, int, int)

--- a/m3-libs/m3core/src/unix/Common/Uugid.c
+++ b/m3-libs/m3core/src/unix/Common/Uugid.c
@@ -8,6 +8,7 @@
 
 #ifndef _WIN32
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Uugid
 M3WRAP0(m3_uid_t, geteuid)
 M3WRAP2(int, setreuid, m3_uid_t, m3_uid_t)

--- a/m3-libs/m3core/src/unix/Common/Uuio.c
+++ b/m3-libs/m3core/src/unix/Common/Uuio.c
@@ -6,6 +6,7 @@
 #include "m3core.h"
 #endif
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Uuio
 M3WRAP3_(ssize_t, read, int, void*, WORD_T)
 M3WRAP3_(ssize_t, write, int, const void*, WORD_T)

--- a/m3-libs/m3core/src/unix/Common/Uutmp.c
+++ b/m3-libs/m3core/src/unix/Common/Uutmp.c
@@ -8,6 +8,7 @@
 
 #ifndef _WIN32
 
+#undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Uutmp
 M3WRAP0(char*, getlogin)
 


### PR DESCRIPTION
so that multiple .c files can be concatenated without warning/error