### PR TITLE
m3core: undef THOUSAND to support concat

### DIFF
--- a/m3-libs/m3core/src/thread/Common/ThreadInternal.c
+++ b/m3-libs/m3core/src/thread/Common/ThreadInternal.c
@@ -43,6 +43,7 @@ ThreadInternal__StackGrowsDown (void)
 enum {WaitResult_Ready, WaitResult_Error, WaitResult_FDError, WaitResult_Timeout};
 /* ^Must match TYPE WaitResult declared in SchedularPosix.i3. */ 
 
+#undef THOUSAND /* Support concatenating multiple .c files. */
 #define THOUSAND (1000)
 #define MILLION (1000 * 1000)
 

--- a/m3-libs/m3core/src/time/POSIX/TimePosixC.c
+++ b/m3-libs/m3core/src/time/POSIX/TimePosixC.c
@@ -19,6 +19,7 @@ We use gettimeofday() which returns seconds and microseconds.
 extern "C" {
 #endif
 
+#undef THOUSAND /* Support concatenating multiple .c files. */
 #define THOUSAND ((UINT64)1000)
 #define MILLION (THOUSAND * THOUSAND)
 #define BILLION (THOUSAND * MILLION)


### PR DESCRIPTION
This is maybe not best solution -- try to find a shared definition
or unshare the name.