### PR TITLE
cm3: Use Unix.link instead of local Utils.link that

### DIFF
--- a/m3-sys/cm3/src/Utils.i3
+++ b/m3-sys/cm3/src/Utils.i3
@@ -52,7 +52,5 @@ PROCEDURE Execute  (program: TEXT;  args: Arg.List;
 
 PROCEDURE MakeRelative (VAR from: TEXT;  to: TEXT);
 PROCEDURE SymbolicOrHardLink (link: PROCEDURE(name1, name2: const_char_star):int; s_for_sym, from, to: TEXT);
-(*bootstrap workaround*)
-<*EXTERNAL Utils__link*> PROCEDURE link (name1, name2: const_char_star): int;
 
 END Utils.

--- a/m3-sys/cm3/src/UtilsWin32.m3
+++ b/m3-sys/cm3/src/UtilsWin32.m3
@@ -3,11 +3,11 @@
 
 UNSAFE MODULE UtilsWin32 EXPORTS Utils;
 
-IMPORT Msg, OSError, Fmt, M3File(*, Unix*)(*bootstrap workaround*);
+IMPORT Msg, OSError, Fmt, M3File, Unix;
 
 PROCEDURE HardLinkFile (from, to: TEXT) =
   BEGIN
-    SymbolicOrHardLink((*Unix.*)(*bootstrap workaround*)link, "", from, to);
+    SymbolicOrHardLink(Unix.link, "", from, to);
   END HardLinkFile;
 
 PROCEDURE SymbolicLinkFile (from, to: TEXT) =

--- a/m3-sys/cm3/src/cm3unix.c
+++ b/m3-sys/cm3/src/cm3unix.c
@@ -1,2 +1,0 @@
-#define Unix__link Utils__link
-#include "UnixLink.c"

--- a/m3-sys/cm3/src/m3makefile
+++ b/m3-sys/cm3/src/m3makefile
@@ -18,13 +18,6 @@ else
                            %(and doesn't do anything either.   
 end  
 
-
-cp_if(".." & SL & ".." & SL & ".." & SL & "m3-libs" & SL & "m3core" & SL & "src" & SL & "unix" & SL & "Common" & SL & "UnixLink.c", ".")
-cp_if(".." & SL & ".." & SL & ".." & SL & "m3-libs" & SL & "m3core" & SL & "src" & SL & "unix" & SL & "Common" & SL & "m3unix.h", ".")
-cp_if(".." & SL & ".." & SL & ".." & SL & "m3-libs" & SL & "m3core" & SL & "src" & SL & "m3core.h", ".")
-cp_if(".." & SL & "src" & SL & "cm3unix.c", ".")
-derived_c("cm3unix")
-
 import ("libm3")
 import ("m3middle")
 import ("m3linker")


### PR DESCRIPTION
was an automated copy of it.
This is an old bootstrapping hack that inhibits concating files.