### PR TITLE
m3c/m3core.h: ifndef guards around INTEGER and WORD_T

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -448,6 +448,9 @@ typedef ptrdiff_t INTEGER;
 typedef size_t WORD_T;
 #endif
 
+#define INTEGER INTEGER /* Support composition with m3c output. */
+#define WORD_T WORD_T   /* Support composition with m3c output. */
+
 /* LONGINT is always signed and exactly 64 bits. */
 typedef INT64 LONGINT;
 

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2013,7 +2013,7 @@ CONST Prefix = ARRAY OF TEXT {
 "typedef unsigned short UINT16;",
 "typedef int INT32;",
 "typedef unsigned int UINT32;",
-"#if defined(_MSC_VER) || defined(__DECC) || defined(__DECCXX) || defined(__int64)",
+"#if defined(_MSC_VER) || defined(__DECC) || defined(__DECCXX) || defined(__int64)", (* matches m3core.h *)
 "typedef __int64 INT64;",
 "typedef unsigned __int64 UINT64;",
 "#define  INT64_(x) x##I64",
@@ -2400,9 +2400,16 @@ BEGIN
 
     (* Builtin/base types start out as state := Type_State.CanBeDefined or Defined  *)
 
+    print(self, "#ifndef INTEGER\n"); (* m3core.h interop *)
     self.Type_Init(NEW(Integer_t, state := Type_State.CanBeDefined, cgtype := Target.Integer.cg_type, typeid := UID_INTEGER, text := "INTEGER"));
+    print(self, "#endif\n");
+
+    print(self, "#ifndef WORD_T\n"); (* m3core.h interop *)
     self.Type_Init(NEW(Integer_t, state := Type_State.CanBeDefined, cgtype := Target.Word.cg_type, typeid := UID_WORD, text := "WORD_T"));
+    print(self, "#endif\n");
+
     print(self, "typedef WORD_T CARDINAL;\n");
+
     self.Type_Init(NEW(Integer_t, state := Type_State.Defined, cgtype := Target.Int64.cg_type, typeid := UID_LONGINT, text := "INT64"));
     self.Type_Init(NEW(Integer_t, state := Type_State.Defined, cgtype := Target.Word64.cg_type, typeid := UID_LONGWORD, text := "UINT64"));
 


### PR DESCRIPTION
so m3c output can be concatented with hand written .c and .h

m3c and m3core.h do not necessarily agree on the exact type of INTEGER
and WORD_T. m3core.h pays to get ptrdiff_t/size_t defined
and uses them, except in VMS corner case.
m3c provides int32 and int64 and lets m3front/m3middle decide.
These should always end up the same size, but could be different
types, like int vs. 32bit long, or long long vs. 64bit long.