### PR TITLE
m3front: When reference types have a user name, pass it to declare_typename.

### DIFF
--- a/m3-sys/m3front/src/types/RefType.m3
+++ b/m3-sys/m3front/src/types/RefType.m3
@@ -165,10 +165,17 @@ PROCEDURE Check (p: P) =
 
 (* Externally dispatched-to: *)
 PROCEDURE Compiler (p: P) =
+  VAR typeid: CG.TypeUID;
+      user_name: TEXT;
   BEGIN
     Type.Compile (p.target);
-    CG.Declare_pointer (Type.GlobalUID (p), Type.GlobalUID (p.target),
+    typeid := Type.GlobalUID (p);
+    CG.Declare_pointer (typeid, Type.GlobalUID (p.target),
                         Brand.ToText (p.brand), p.isTraced);
+    user_name := p.user_name;
+    IF user_name # NIL THEN
+      CG.Declare_typename (typeid, M3ID.Add (user_name));
+    END;
   END Compiler;
 
 (* EXPORTED *)


### PR DESCRIPTION
This should greatly help let m3c and C prototypes match.