### PR TITLE
m3c: Tweak how text is turned into valid types.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2359,11 +2359,10 @@ PROCEDURE TextToId (VAR t: TEXT) =
 BEGIN
   EVAL TextRemoveAtEnd (t, ".c");
   EVAL TextRemoveAtEnd (t, ".cpp");
-  t := TextUtils.Substitute (t, "_", "_un_"); (* un for underscore *)
-  EVAL TextSubstituteAtEnd (t, ".m3", "_m");
-  EVAL TextSubstituteAtEnd (t, ".i3", "_i");
-  t := TextUtils.Substitute (t, ".", "_do_"); (* do for dot *)
-  t := TextUtils.Substitute (t, "-", "_da_"); (* da for dash *)
+  EVAL TextSubstituteAtEnd (t, ".m3", "_");
+  EVAL TextSubstituteAtEnd (t, ".i3", "_");
+  t := TextUtils.Substitute (t, ".", "_");
+  t := TextUtils.Substitute (t, "__", "_");
   (* TODO more ways to turn into valid identifier prefix? Handle in m3front. *)
 END TextToId;
 


### PR DESCRIPTION
Simpler but perhaps too fragile/ambiguous. We'll see.