### PR TITLE
DatePosix: Remove branded pointer from C interface.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -648,7 +648,7 @@ typedef struct {
 
 void
 __cdecl
-DatePosix__FromTime(double t, /*const*/ INTEGER* zone, Date_t* date, TEXT unknown, TEXT gmt);
+DatePosix__FromTime(double t, INTEGER zone, Date_t* date, TEXT unknown, TEXT gmt);
 
 double
 __cdecl

--- a/m3-libs/m3core/src/time/POSIX/DatePosix.i3
+++ b/m3-libs/m3core/src/time/POSIX/DatePosix.i3
@@ -26,7 +26,7 @@ TYPE T = RECORD
 END;
 
 <*EXTERNAL DatePosix__FromTime*>
-PROCEDURE FromTime(time: LONGREAL; zone: Date.TimeZone; VAR date: T; unknown, gmt: TEXT);
+PROCEDURE FromTime(time: LONGREAL; zone: INTEGER; VAR date: T; unknown, gmt: TEXT);
 
 <*EXTERNAL DatePosix__ToTime*>
 PROCEDURE ToTime(READONLY d: T): Time.T;

--- a/m3-libs/m3core/src/time/POSIX/DatePosix.m3
+++ b/m3-libs/m3core/src/time/POSIX/DatePosix.m3
@@ -16,9 +16,13 @@ CONST GMT = "GMT";
 
 PROCEDURE FromTime(t: Time.T; z: TimeZone := NIL): Date.T =
   VAR d: DatePosix.T;
+      i: INTEGER := 0; (* default to Local *)
   BEGIN
+    IF z # NIL THEN
+      i := z^;
+    END;
     Scheduler.DisableSwitching();
-    DatePosix.FromTime(t, z, d, Unknown, GMT);
+    DatePosix.FromTime(t, i, d, Unknown, GMT);
     Scheduler.EnableSwitching();
     RETURN Date.T{day     := d.day,
                   hour    := d.hour,

--- a/m3-libs/m3core/src/time/POSIX/DatePosixC.c
+++ b/m3-libs/m3core/src/time/POSIX/DatePosixC.c
@@ -61,7 +61,7 @@ static time_t TimePosix__ToSeconds(LONGREAL/*Time.T*/ t)
 
 void
 __cdecl
-DatePosix__FromTime(double t, /*const*/ INTEGER* pzone, Date_t* date, TEXT unknown, TEXT gmt)
+DatePosix__FromTime(double t, INTEGER zone, Date_t* date, TEXT unknown, TEXT gmt)
 {
     struct tm* tm = 0;
 #ifdef _TIME64_T
@@ -69,7 +69,6 @@ DatePosix__FromTime(double t, /*const*/ INTEGER* pzone, Date_t* date, TEXT unkno
 #else
     time_t sec = TimePosix__ToSeconds(t);
 #endif
-    ptrdiff_t zone = (pzone ? *pzone : Local);
     ZeroMemory(date, sizeof(*date));
     assert(zone == Local || zone == UTC);
 #ifdef _TIME64_T


### PR DESCRIPTION
Out of ignorance of the representation.
It does not even need to be a pointer, make it INTEGER.