### PR TITLE
m3core: Rename m3_time_t to m3_time64_t.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -548,11 +548,11 @@ int __cdecl Umman__mprotect(caddr_t addr, WORD_T len, int prot);
 void* __cdecl Umman__mmap(caddr_t addr, WORD_T len, int prot, int flags, int fd, m3_off_t off);
 int __cdecl Umman__munmap(caddr_t addr, WORD_T len);
 
-typedef INT64 m3_time_t;
+typedef INT64 m3_time64_t;
 
 #ifndef _WIN32
-m3_time_t __cdecl Utime__time(m3_time_t* tloc);
-char* __cdecl Utime__ctime(const m3_time_t* m);
+m3_time64_t __cdecl Utime__time(m3_time64_t* tloc);
+char* __cdecl Utime__ctime(const m3_time64_t* m);
 #endif
 void __cdecl Utime__tzset(void);
 

--- a/m3-libs/m3core/src/unix/Common/UtimeC.c
+++ b/m3-libs/m3core/src/unix/Common/UtimeC.c
@@ -12,15 +12,15 @@ extern "C" {
  * ctime() needs to be replaced with a 64bit version or possibly removed.
  */
 #ifdef _TIME64_T
-M3_STATIC_ASSERT(sizeof(time64_t) <= sizeof(m3_time_t));
+M3_STATIC_ASSERT(sizeof(time64_t) <= sizeof(m3_time64_t));
 #else
-M3_STATIC_ASSERT(sizeof(time_t) <= sizeof(m3_time_t));
+M3_STATIC_ASSERT(sizeof(time_t) <= sizeof(m3_time64_t));
 #endif
 
 M3_DLL_EXPORT
-m3_time_t
+m3_time64_t
 __cdecl
-Utime__time(m3_time_t* tloc)
+Utime__time(m3_time64_t* tloc)
 {
 #ifdef _TIME64_T
     time64_t b = tloc ? (time64_t)*tloc : 0;
@@ -36,7 +36,7 @@ Utime__time(m3_time_t* tloc)
 M3_DLL_EXPORT
 char*
 __cdecl
-Utime__ctime(const m3_time_t* m)
+Utime__ctime(const m3_time64_t* m)
 {
 #ifdef _TIME64_T
     time64_t t = m ? (time64_t)*m : 0;


### PR DESCRIPTION
m3_time64_t is always 64bits.
m3_time64_t is always at least the size of time_t.
m3_time_t shall be repurposed to mean time_t or time64_t, whichever
 the C system supports. Many 32bit systems started with 32bit time_t
 and then later added 64bit time64_t or such. Sometimes both are available
 at the same time, sometimes defines silently changes time_t to time64_t,
 which is easier to program, if you do not need a mix. From the
 looks of it, this is all for OSF/1.