### PR TITLE
DatePosix: Remove managed types from C.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -635,20 +635,21 @@ M3toC__StoT(const char*);
  */
 typedef struct {
     INTEGER day;
+    INTEGER gmt;     // boolean
     INTEGER hour;
     INTEGER minute;
     INTEGER month;
     INTEGER offset;
     INTEGER second;
+    INTEGER unknown; // boolean
     INTEGER weekDay;
     INTEGER year;
-    TEXT    zone;
-    INTEGER zzalign;
+    const char* zone;
 } Date_t;
 
 void
 __cdecl
-DatePosix__FromTime(double t, INTEGER zone, Date_t* date, TEXT unknown, TEXT gmt);
+DatePosix__FromTime(double t, INTEGER zone, Date_t* date);
 
 double
 __cdecl

--- a/m3-libs/m3core/src/time/POSIX/DatePosix.i3
+++ b/m3-libs/m3core/src/time/POSIX/DatePosix.i3
@@ -6,27 +6,28 @@
 (*      modified on Thu Jan 28 10:00:32 PST 1993 by mjordan *)
 
 INTERFACE DatePosix;
-IMPORT Date, Time;
+IMPORT Date, Time, Ctypes;
 
 (* This MUST match m3core.h
  * The fields are ordered by size and alphabetically.
  * (They are all the same size.)
  *)
 TYPE T = RECORD
-  day:      INTEGER;
-  hour:     INTEGER;
-  minute:   INTEGER;
-  month:    INTEGER;
-  offset:   INTEGER;
-  second:   INTEGER;
-  weekDay:  INTEGER;
-  year:     INTEGER;
-  zone:     TEXT;
-  zzalign:  INTEGER := 10;
+  day:      INTEGER := 0;
+  gmt:      INTEGER := 0; (* boolean *)
+  hour:     INTEGER := 0;
+  minute:   INTEGER := 0;
+  month:    INTEGER := 0;
+  offset:   INTEGER := 0;
+  second:   INTEGER := 0;
+  unknown:  INTEGER := 0; (* boolean *)
+  weekDay:  INTEGER := 0;
+  year:     INTEGER := 0;
+  zone:     Ctypes.const_char_star := NIL;
 END;
 
 <*EXTERNAL DatePosix__FromTime*>
-PROCEDURE FromTime(time: LONGREAL; zone: INTEGER; VAR date: T; unknown, gmt: TEXT);
+PROCEDURE FromTime(time: LONGREAL; zone: INTEGER; VAR date: T);
 
 <*EXTERNAL DatePosix__ToTime*>
 PROCEDURE ToTime(READONLY d: T): Time.T;

--- a/m3-libs/m3core/src/time/POSIX/DatePosix.m3
+++ b/m3-libs/m3core/src/time/POSIX/DatePosix.m3
@@ -7,7 +7,7 @@
 (*      modified on Fri Dec  4 17:35:53 PST 1992 by mcjones *)
 
 UNSAFE MODULE DatePosix EXPORTS Date;
-IMPORT Scheduler, Time, Date, DatePosix, Utime;
+IMPORT Ctypes, M3toC, Scheduler, Time, Date, DatePosix, Utime;
 
 REVEAL TimeZone = BRANDED "Date.TimeZone" REF INTEGER;
 
@@ -17,13 +17,22 @@ CONST GMT = "GMT";
 PROCEDURE FromTime(t: Time.T; z: TimeZone := NIL): Date.T =
   VAR d: DatePosix.T;
       i: INTEGER := 0; (* default to Local *)
+      zone: TEXT := NIL;
   BEGIN
     IF z # NIL THEN
       i := z^;
     END;
     Scheduler.DisableSwitching();
-    DatePosix.FromTime(t, i, d, Unknown, GMT);
+    DatePosix.FromTime(t, i, d);
     Scheduler.EnableSwitching();
+    <* ASSERT d.gmt + d.unknown + ORD(d.zone # NIL) = 1 *>
+    IF d.gmt # 0 THEN
+      zone := GMT;
+    ELSIF d.unknown # 0 THEN
+      zone := Unknown;
+    ELSE
+      zone := M3toC.CopyStoT (d.zone);
+    END;
     RETURN Date.T{day     := d.day,
                   hour    := d.hour,
                   minute  := d.minute,
@@ -32,7 +41,7 @@ PROCEDURE FromTime(t: Time.T; z: TimeZone := NIL): Date.T =
                   second  := d.second,
                   weekDay := VAL(d.weekDay, WeekDay),
                   year    := d.year,
-                  zone    := d.zone};
+                  zone    := zone};
   END FromTime;
 
 PROCEDURE ToTime(READONLY d: T): Time.T RAISES {Error} =
@@ -47,7 +56,9 @@ PROCEDURE ToTime(READONLY d: T): Time.T RAISES {Error} =
                                       second  := d.second,
                                       weekDay := ORD(d.weekDay),
                                       year    := d.year,
-                                      zone    := d.zone});
+                                      zone    := NIL, (* not used *)
+                                      gmt     := 0,   (* not used *)
+                                      unknown := 0}); (* not used *)
     Scheduler.EnableSwitching();
     IF t = -1.0d0 THEN RAISE Error END;
     RETURN t;
@@ -59,6 +70,8 @@ BEGIN
   Scheduler.EnableSwitching();
   Local := NEW(TimeZone);  Local^ := 0;
   UTC   := NEW(TimeZone);  UTC^   := 1;
+
+  (* Fill in known values to each field and C asserts they are as expected. *)
   DatePosix.TypeCheck(DatePosix.T{year    := 1,
                                   month   := 2,
                                   day     := 3,
@@ -66,7 +79,9 @@ BEGIN
                                   minute  := 5,
                                   second  := 6,
                                   offset  := 7,
-                                  zone    := LOOPHOLE(8, TEXT),
-                                  weekDay := 9},
+                                  zone    := LOOPHOLE(8, Ctypes.char_star),
+                                  weekDay := 9,
+                                  gmt     := 10,
+                                  unknown := 11},
                       BYTESIZE(DatePosix.T));
 END DatePosix.


### PR DESCRIPTION
This is ultimately needed for precise GC with cooperative suspend
(unless, something unspecified around finding managed values
in C locals)
This work will be approximately finished when TEXT and MtoC
are removed from m3core.h, since those are the main/only infractions.