### PR TITLE
m3-sys/cg/front/back/middle: Add QID to declare_param.

### DIFF
--- a/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
@@ -1761,7 +1761,7 @@ to check this. Perhaps the front end could supply the correct type. *)
     RETURN size;    
   END ImportedStructSize;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR

--- a/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
@@ -1854,7 +1854,7 @@ PROCEDURE declare_local
     RETURN v;
   END declare_local;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -1917,7 +1917,7 @@ PROCEDURE declare_local
     RETURN v;
   END declare_local;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4181,7 +4181,8 @@ PROCEDURE Locals_declare_param(
     typeid: TypeUID;
     <*UNUSED*>in_memory: BOOLEAN;
     up_level: BOOLEAN;
-    <*UNUSED*>frequency: Frequency): M3CG.Var =
+    <*UNUSED*>frequency: Frequency;
+    qid := M3CG.NoQID): M3CG.Var =
 BEGIN
     RETURN declare_param(
         self.self,
@@ -4190,7 +4191,8 @@ BEGIN
         alignment,
         type,
         typeid,
-        up_level);
+        up_level,
+        qid);
 END Locals_declare_param;
 
 PROCEDURE Locals_declare_local(
@@ -4281,7 +4283,8 @@ PROCEDURE Imports_declare_param(
     typeid: TypeUID;
     <*UNUSED*>in_memory: BOOLEAN;
     up_level: BOOLEAN;
-    <*UNUSED*>frequency: Frequency): M3CG.Var =
+    <*UNUSED*>frequency: Frequency;
+    qid := M3CG.NoQID): M3CG.Var =
 BEGIN
     RETURN declare_param(
         self.self,
@@ -4290,7 +4293,8 @@ BEGIN
         alignment,
         type,
         typeid,
-        up_level);
+        up_level,
+        qid);
 END Imports_declare_param;
 
 PROCEDURE Imports_import_global(
@@ -4312,8 +4316,8 @@ METHODS
 OVERRIDES
     declare_constant := GetStructSizes_declare_constant;
     declare_global := GetStructSizes_declare_global;
-    declare_local := GetStructSizes_declare_local_or_param;
-    declare_param := GetStructSizes_declare_local_or_param;
+    declare_local := GetStructSizes_declare_local;
+    declare_param := GetStructSizes_declare_param;
     declare_temp := GetStructSizes_declare_temp;
     import_global := GetStructSizes_import_global;
 END;
@@ -4443,7 +4447,7 @@ BEGIN
     RETURN self.Declare(type, byte_size, alignment);
 END GetStructSizes_declare_constant;
 
-PROCEDURE GetStructSizes_declare_local_or_param(
+PROCEDURE GetStructSizes_declare_local(
     self: GetStructSizes_t;
     <*UNUSED*>name: Name;
     byte_size: ByteSize;
@@ -4455,7 +4459,22 @@ PROCEDURE GetStructSizes_declare_local_or_param(
     <*UNUSED*>frequency: Frequency): M3CG.Var =
 BEGIN
     RETURN self.Declare(type, byte_size, alignment);
-END GetStructSizes_declare_local_or_param;
+END GetStructSizes_declare_local;
+
+PROCEDURE GetStructSizes_declare_param(
+    self: GetStructSizes_t;
+    <*UNUSED*>name: Name;
+    byte_size: ByteSize;
+    alignment: Alignment;
+    type: CGType;
+    <*UNUSED*>typeid: TypeUID;
+    <*UNUSED*>in_memory: BOOLEAN;
+    <*UNUSED*>up_level: BOOLEAN;
+    <*UNUSED*>frequency: Frequency;
+    <*UNUSED*>qid := M3CG.NoQID): M3CG.Var =
+BEGIN
+    RETURN self.Declare(type, byte_size, alignment);
+END GetStructSizes_declare_param;
 
 PROCEDURE Struct(size: INTEGER): TEXT =
 BEGIN
@@ -4634,6 +4653,7 @@ PROCEDURE last_param(self: T) =
 VAR proc := self.param_proc;
     prototype: TEXT := NIL;
     param: Var_t := NIL;
+    qid := M3CG.NoQID;
 BEGIN
     IF proc.no_return THEN
         no_return(self);
@@ -4670,7 +4690,8 @@ PROCEDURE internal_declare_param(
     cgtype: CGType;
     typeid: TypeUID;
     up_level: BOOLEAN;
-    type_text: TEXT := NIL): M3CG.Var =
+    type_text: TEXT;
+    <*UNUSED*>qid := M3CG.NoQID): M3CG.Var =
 VAR function := self.param_proc;
     var: Var_t := NIL;
     type: Type_t := NIL;
@@ -4736,7 +4757,8 @@ declare_param(
     alignment: Alignment;
     type: CGType;
     typeid: TypeUID;
-    up_level: BOOLEAN): M3CG.Var =
+    up_level: BOOLEAN;
+    qid := M3CG.NoQID): M3CG.Var =
 BEGIN
     IF self.param_proc = NIL THEN
         RETURN NIL;
@@ -4749,7 +4771,8 @@ BEGIN
         type,
         typeid,
         up_level,
-        NIL);
+        NIL,
+        qid);
 END declare_param;
 
 PROCEDURE

--- a/m3-sys/m3back/src/M3x86.m3
+++ b/m3-sys/m3back/src/M3x86.m3
@@ -876,7 +876,7 @@ PROCEDURE mangle_procname (base: M3ID.T; arg_size: INTEGER;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          type: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency): Var =
+                         f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
   VAR v := NewVar(u, type, m3t, s, 4, n);
   BEGIN
     (* Assume a = 4 and ESP is dword aligned... *)

--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -200,7 +200,7 @@ PROCEDURE Declare_local (n: Name;  s: Size;  a: Alignment;  t: Type;
 
 PROCEDURE Declare_param (n: Name;  s: Size;  a: Alignment;  t: Type;
                          m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency): Var;
+                         f: Frequency; qid := M3.NoQID): Var;
 (* declares a formal parameter.  Formals are declared in their lexical
    order immediately following the 'declare_procedure' or
    'import_procedure' that contains them.  *)

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -492,10 +492,10 @@ PROCEDURE Declare_local (n: Name;  s: Size;  a: Alignment;  t: Type;
 
 PROCEDURE Declare_param (n: Name;  s: Size;  a: Alignment;  t: Type;
                          m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency): Var =
+                         f: Frequency; qid := M3CG.NoQID): Var =
   BEGIN
     RETURN cg.declare_param (n, ToVarSize (s, a), ByteAlign (a),
-                             t, m3t, in_memory, up_level, f);
+                             t, m3t, in_memory, up_level, f, qid);
   END Declare_param;
 
 (*----------------------------------------------------------- temporaries ---*)

--- a/m3-sys/m3front/src/misc/M3.i3
+++ b/m3-sys/m3front/src/misc/M3.i3
@@ -11,12 +11,13 @@
 
 INTERFACE M3;
 
-IMPORT M3ID, M3Buf, Jmpbufs;
+IMPORT M3ID, M3Buf, Jmpbufs, M3CG;
 
 TYPE
   Flag = BITS 1 FOR BOOLEAN;
 
-  QID  = RECORD module, item: M3ID.T; END;
+  QID  = M3CG.QID; (* module qualified name *)
+  CONST NoQID = M3CG.NoQID;
 
 (*------------------------------------------------------------- AST nodes ---*)
 

--- a/m3-sys/m3front/src/types/NamedType.i3
+++ b/m3-sys/m3front/src/types/NamedType.i3
@@ -8,7 +8,7 @@
 
 INTERFACE NamedType;
 
-IMPORT M3, M3ID, Type, Value;
+IMPORT M3, M3CG, M3ID, Type, Value;
 
 PROCEDURE Parse (): Type.T;
 

--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -9,7 +9,7 @@
 MODULE NamedType;
 
 IMPORT M3, M3ID, Token, Type, TypeRep, Scanner, ObjectType;
-IMPORT Error, Scope, Brand, Value, ErrType;
+IMPORT Error, Scope, Brand, Value, ErrType, CG;
 
 TYPE
   P = Type.T BRANDED "NamedType.T" OBJECT

--- a/m3-sys/m3middle/src/M3CG.i3
+++ b/m3-sys/m3middle/src/M3CG.i3
@@ -99,6 +99,10 @@ CONST (*  A op B  ===  NOT (A NotCompare[op] B)  *)
 TYPE
   Name = M3ID.T; (* Numbering of a simple identifier. *) 
 
+  (* an optionally module qualified name *)
+  QID  = RECORD module, item: M3ID.T; END;
+  CONST NoQID = QID {M3ID.NoID, M3ID.NoID};
+
 TYPE
   Var    = BRANDED "M3CG.Var"  OBJECT END; (* represents a variable *)
   Proc   = BRANDED "M3CG.Proc" OBJECT END; (* represents a procedure *)

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -8,7 +8,7 @@
 MODULE M3CG EXPORTS M3CG, M3CG_Ops;
 
 IMPORT Text, Word; 
-IMPORT Target;
+IMPORT Target, M3CG;
 
 REVEAL
   T = Public BRANDED "M3CG.T" OBJECT OVERRIDES
@@ -401,9 +401,9 @@ PROCEDURE declare_local (xx: T;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (xx: T;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency): Var =
+                         f: Frequency; qid := M3CG.NoQID): Var =
   BEGIN
-    RETURN xx.child.declare_param (n, s, a, t, m3t, in_memory, up_level, f);
+    RETURN xx.child.declare_param (n, s, a, t, m3t, in_memory, up_level, f, qid);
   END declare_param;
 
 PROCEDURE declare_temp (xx: T;  s: ByteSize;  a: Alignment;  t: Type;

--- a/m3-sys/m3middle/src/M3CG_AssertFalse.m3
+++ b/m3-sys/m3middle/src/M3CG_AssertFalse.m3
@@ -196,7 +196,7 @@ AssertFalse();
 RETURN NIL;
 END declare_local;
 
-<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency): Var =
+<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var =
 BEGIN
 AssertFalse();
 RETURN NIL;

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -796,9 +796,10 @@ PROCEDURE declare_param (VAR s: State) =
       up_lev := Scan_bool (s);
       freq   := Scan_int (s);
       v      := Scan_int (s);
+      qid    := M3CG.NoQID; (* TODO qid but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddVar (s, v, s.cg.declare_param (name, size, align, type, m3t,
-                                      in_mem, up_lev, freq));
+                                      in_mem, up_lev, freq, qid));
   END declare_param;
 
 PROCEDURE declare_temp (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -757,7 +757,7 @@ PROCEDURE declare_local (u: U;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency): Var =
+                         f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
   VAR v := NewVar (u);
   BEGIN
     Cmd   (u, Bop.declare_param);
@@ -770,6 +770,7 @@ PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
     Bool  (u, up_level);
     Int   (u, f);
     VName (u, v);
+    (* TODO qid but it is not used downstream and can be omitted indefinitely *)
     RETURN v;
   END declare_param;
 

--- a/m3-sys/m3middle/src/M3CG_DoNothing.m3
+++ b/m3-sys/m3middle/src/M3CG_DoNothing.m3
@@ -161,7 +161,7 @@ END;
 <*NOWARN*>PROCEDURE declare_global(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; exported, inited: BOOLEAN): Var = BEGIN RETURN NIL; END declare_global;
 <*NOWARN*>PROCEDURE declare_constant(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; exported, inited: BOOLEAN): Var = BEGIN RETURN NIL; END declare_constant;
 <*NOWARN*>PROCEDURE declare_local(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency): Var = BEGIN RETURN NIL; END declare_local;
-<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency): Var = BEGIN RETURN NIL; END declare_param;
+<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var = BEGIN RETURN NIL; END declare_param;
 <*NOWARN*>PROCEDURE declare_temp(self: T; byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN): Var = BEGIN RETURN NIL; END declare_temp;
 <*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention): Proc = BEGIN RETURN NIL; END import_procedure;
 <*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc): Proc = BEGIN RETURN NIL; END declare_procedure;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -62,7 +62,7 @@ TYPE declare_segment_t = op_tag_t OBJECT name: Name; typeid: typeid_t; is_const:
 TYPE declare_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; exported, inited: BOOLEAN; OVERRIDES replay := replay_declare_global END;
 TYPE declare_constant_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; exported, inited: BOOLEAN; OVERRIDES replay := replay_declare_constant END;
 TYPE declare_local_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; OVERRIDES replay := replay_declare_local END;
-TYPE declare_param_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; OVERRIDES replay := replay_declare_param END;
+TYPE declare_param_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID; OVERRIDES replay := replay_declare_param END;
 TYPE declare_temp_t = op_tag_t OBJECT byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN; OVERRIDES replay := replay_declare_temp END;
 TYPE import_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; OVERRIDES replay := replay_import_global END;
 

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -367,10 +367,10 @@ self.Add(NEW(declare_local_t, op := Op.declare_local, name := name, byte_size :=
 RETURN var;
 END declare_local;
 
-PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency): Var =
+PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var =
 VAR var := self.refs.NewVar();
 BEGIN
-self.Add(NEW(declare_param_t, op := Op.declare_param, name := name, byte_size := byte_size, alignment := alignment, type := type, typeid := typeid, in_memory := in_memory, up_level := up_level, frequency := frequency, tag := var.tag));
+self.Add(NEW(declare_param_t, op := Op.declare_param, name := name, byte_size := byte_size, alignment := alignment, type := type, typeid := typeid, in_memory := in_memory, up_level := up_level, frequency := frequency, tag := var.tag, qid := qid));
 RETURN var;
 END declare_param;
 
@@ -1084,7 +1084,7 @@ END replay_declare_local;
 
 PROCEDURE replay_declare_param(self: declare_param_t; replay: Replay_t; cg: cg_t) =
 BEGIN
-    replay.PutRef(self.tag, cg.declare_param(self.name, self.byte_size, self.alignment, self.type, self.typeid, self.in_memory, self.up_level, self.frequency));
+    replay.PutRef(self.tag, cg.declare_param(self.name, self.byte_size, self.alignment, self.type, self.typeid, self.in_memory, self.up_level, self.frequency, self.qid));
 END replay_declare_param;
 
 PROCEDURE replay_declare_temp(self: declare_temp_t; replay: Replay_t; cg: cg_t) =

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -253,7 +253,7 @@ declare_local (n: Name;  s: ByteSize;  a: Alignment;  t: Type;
 
 declare_param (n: Name;  s: ByteSize;  a: Alignment;  t: Type;
                m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-               f: Frequency): Var;
+               f: Frequency; qid := M3CG.NoQID): Var;
 (* Declare a formal parameter, belonging to the most recent
    declare_procedure or import_procedure.  Formals are declared in
    their lexical order, relative to each other, but many other things

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -909,9 +909,10 @@ PROCEDURE declare_param (VAR s: State) =
       up_lev := Scan_bool (s);
       freq   := Scan_int (s);
       v      := Scan_varName (s);
+      qid    := M3CG.NoQID; (* TODO qid but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddVar (s, v, s.cg.declare_param (name, size, align, type, m3t,
-                                      in_mem, up_lev, freq));
+                                      in_mem, up_lev, freq, qid));
   END declare_param;
 
 PROCEDURE declare_temp (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -785,7 +785,7 @@ PROCEDURE declare_local (u: U;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency): Var =
+                         f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
   VAR v := NewVar (u);
   BEGIN
     Cmd   (u, "declare_param");
@@ -799,6 +799,7 @@ PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
     Int   (u, f);
     VName (u, v);
     NL    (u);
+    (* TODO qid but it is not used downstream and can be omitted indefinitely *)
     RETURN v;
   END declare_param;
 


### PR DESCRIPTION
This is so that m3c can generate much higher fidelity
declarations of extern functions.

This is some initial plumbing. More work is needed
to pass and consume the values. A usefully-working
prototype exists.

declare_formal ought to be handled too, but it is unlikely
to matter for the scenario in mind.