### PR TITLE
m3front: Move NamedType.qid to Type.Info.

### DIFF
--- a/m3-sys/m3front/src/types/Type.i3
+++ b/m3-sys/m3front/src/types/Type.i3
@@ -37,6 +37,7 @@ TYPE
     hash      : INTEGER;  (* internal hash code *)
     stk_type  : CG.Type;  (* code generator representation on operator stack *)
     mem_type  : CG.Type;  (* code generator representation as a variable *)
+    qid       := M3.NoQID;
     class     : Class;
     isTraced  : M3.Flag;
     isEmpty   : M3.Flag;


### PR DESCRIPTION
This does bloat non-named types by two integers but this is likely the most elegant solution.
i.e. to get the qid to Formal.EmitDeclaration.