### PR TITLE
m3front:Include typenames for imported types.

### DIFF
--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -128,12 +128,12 @@ PROCEDURE Compile (t: T): BOOLEAN =
   VAR uid: INTEGER;  name: TEXT;
   BEGIN
     Type.Compile (t.value);
-    IF NOT t.imported THEN
+    (*IF NOT t.imported THEN*)
       uid  := Type.GlobalUID (t.value);
       name := Value.GlobalName (t, dots := TRUE, with_module := FALSE);
       CG.Declare_typename (uid, M3ID.Add (name));
       WebInfo.Declare_typename (uid, t);
-    END;
+    (*END;*)
     RETURN TRUE;
   END Compile;
 


### PR DESCRIPTION
A step towards m3c output being concatenable, with C, and getting same typenames.