### PR TITLE
m3c/m3front: Change typenames from:

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2641,8 +2641,8 @@ BEGIN
   ELSE
     self.comment("declare_typename");
   END;
-  nameText := self.unique & nameText; (* unique ends with underscore *)
-  TextToId (nameText);
+  (* nameText := self.unique & nameText; *) (* unique ends with underscore *)
+  (* TextToId (nameText); *)
   (* typename is like pointer but without the star and without a hash in the name *)
   self.Type_Init (NEW (Pointer_t,
                        text := nameText,

--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -130,7 +130,7 @@ PROCEDURE Compile (t: T): BOOLEAN =
     Type.Compile (t.value);
     (*IF NOT t.imported THEN*)
       uid  := Type.GlobalUID (t.value);
-      name := Value.GlobalName (t, dots := TRUE, with_module := FALSE);
+      name := Value.GlobalName (t, dots := FALSE, with_module := TRUE);
       CG.Declare_typename (uid, M3ID.Add (name));
       WebInfo.Declare_typename (uid, t);
     (*END;*)


### PR DESCRIPTION
e.g.
m3front passes:const_void_star,
m3c produces:m3core_Uuio_const_void_star
to m3front passes:Ctypes__const_void_star
and m3c leaves it alone.

Since types have no linkage, there is danger
of collision. We'll see.