### PR TITLE
m3cg: Add import_procedure(return_type_qid).

### DIFF
--- a/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
@@ -2045,7 +2045,7 @@ PROCEDURE init_float (self: U;  o: ByteOffset;  READONLY f: Target.Float) =
 
 (*------------------------------------------------------------ procedures ---*)
 
-PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention): Proc =
+PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; return_type_qid := M3CG.NoQID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,-1,cc,FALSE,NIL);
     name : TEXT;

--- a/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
@@ -2122,7 +2122,7 @@ PROCEDURE init_float (self: U;  o: ByteOffset;  READONLY f: Target.Float) =
 
 (*------------------------------------------------------------ procedures ---*)
 
-PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention): Proc =
+PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,-1,cc,FALSE,NIL);
     name : TEXT;

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -2185,7 +2185,7 @@ PROCEDURE init_float (self: U;  o: ByteOffset;  READONLY f: Target.Float) =
 
 (*------------------------------------------------------------ procedures ---*)
 
-PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention): Proc =
+PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,-1,cc,FALSE,NIL);
     name : TEXT;

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4269,7 +4269,8 @@ PROCEDURE Imports_import_procedure(
     name: Name;
     parameter_count: INTEGER;
     return_type: CGType;
-    callingConvention: CallingConvention): M3CG.Proc =
+    callingConvention: CallingConvention;
+    <*UNUSED*>return_type_qid := M3CG.NoQID): M3CG.Proc =
 BEGIN
     RETURN import_procedure(self.self, name, parameter_count, return_type, callingConvention);
 END Imports_import_procedure;
@@ -5219,7 +5220,8 @@ END Segments_init_float;
 
 PROCEDURE import_procedure(
     self: T; name: Name; parameter_count: INTEGER;
-    return_type: CGType; callingConvention: CallingConvention): M3CG.Proc =
+    return_type: CGType; callingConvention: CallingConvention;
+    <*UNUSED*>return_type_qid := M3CG.NoQID): M3CG.Proc =
 VAR proc := NEW(Proc_t, name := name, parameter_count := parameter_count,
                 return_type := return_type, imported := TRUE,
                 callingConvention := callingConvention).Init(self);

--- a/m3-sys/m3back/src/M3x86.m3
+++ b/m3-sys/m3back/src/M3x86.m3
@@ -1278,7 +1278,8 @@ BEGIN
 END IsAlloca;
 
 PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
-                            ret_type: Type;  cc: CallingConvention): Proc =
+                            ret_type: Type;  cc: CallingConvention;
+                            <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR p := NewProc (u, n, n_params, ret_type, cc);
   BEGIN
     p.import := TRUE;

--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -318,7 +318,8 @@ PROCEDURE EmitText (t: TEXT;  is_const: BOOLEAN): INTEGER;
 
 PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                             cc: CallingConvention;
-                            VAR(*OUT*) new: BOOLEAN): Proc;
+                            VAR(*OUT*) new: BOOLEAN;
+                            return_type_qid := M3.NoQID): Proc;
 (* declare and import the external procedure with name 'n' and 'n_params'
    formal parameters.  It must be a top-level (=0) procedure that returns
    values of type 'ret_type'.  'cc' is the convention specified

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -1358,12 +1358,13 @@ PROCEDURE EmitText (t: TEXT;  is_const: BOOLEAN): INTEGER =
 
 PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                             cc: CallingConvention;
-                            VAR(*OUT*) new: BOOLEAN): Proc =
+                            VAR(*OUT*) new: BOOLEAN;
+                            return_type_qid := M3CG.NoQID): Proc =
   VAR ref: REFANY;  p: Proc;
   BEGIN
     IF (procedures = NIL) THEN procedures := NewNameTbl() END;
     IF procedures.get (n, ref) THEN new := FALSE;  RETURN ref END;
-    p := cg.import_procedure (n, n_params, ret_type, cc);
+    p := cg.import_procedure (n, n_params, ret_type, cc, return_type_qid);
     EVAL procedures.put (n, p);
     new := TRUE;
     RETURN p;

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -468,9 +468,10 @@ PROCEDURE init_float (xx: T;  o: ByteOffset;  READONLY f: Target.Float) =
 (*------------------------------------------------------------ procedures ---*)
 
 PROCEDURE import_procedure (xx: T;  n: Name;  n_params: INTEGER;
-                          ret_type: Type;  cc: CallingConvention): Proc =
+                          ret_type: Type;  cc: CallingConvention;
+                          return_type_qid := M3CG.NoQID): Proc =
   BEGIN
-    RETURN xx.child.import_procedure (n, n_params, ret_type, cc);
+    RETURN xx.child.import_procedure (n, n_params, ret_type, cc, return_type_qid);
   END import_procedure;
 
 PROCEDURE declare_procedure (xx: T;  n: Name;  n_params: INTEGER;

--- a/m3-sys/m3middle/src/M3CG_AssertFalse.m3
+++ b/m3-sys/m3middle/src/M3CG_AssertFalse.m3
@@ -208,7 +208,7 @@ AssertFalse();
 RETURN NIL;
 END declare_temp;
 
-<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention): Proc =
+<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_type_qid := M3CG.NoQID): Proc =
 BEGIN
 AssertFalse();
 RETURN NIL;

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -904,6 +904,7 @@ PROCEDURE import_procedure (VAR s: State) =
       ret_type := Scan_type (s);
       calling  := Scan_callConv (s);
       p        := Scan_int (s);
+      (* TODO return_type_qid but nobody uses it *)
   BEGIN
     AddProc (s, p, s.cg.import_procedure (name, n_params, ret_type, calling));
   END import_procedure;

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -869,7 +869,8 @@ PROCEDURE NewProc (u: U): Proc =
   END NewProc;
 
 PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
-                          ret_type: Type;  cc: CallingConvention): Proc =
+                            ret_type: Type; cc: CallingConvention;
+                            <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, Bop.import_procedure);

--- a/m3-sys/m3middle/src/M3CG_DoNothing.m3
+++ b/m3-sys/m3middle/src/M3CG_DoNothing.m3
@@ -163,7 +163,7 @@ END;
 <*NOWARN*>PROCEDURE declare_local(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency): Var = BEGIN RETURN NIL; END declare_local;
 <*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var = BEGIN RETURN NIL; END declare_param;
 <*NOWARN*>PROCEDURE declare_temp(self: T; byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN): Var = BEGIN RETURN NIL; END declare_temp;
-<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention): Proc = BEGIN RETURN NIL; END import_procedure;
+<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_type_qid := M3CG.NoQID): Proc = BEGIN RETURN NIL; END import_procedure;
 <*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc): Proc = BEGIN RETURN NIL; END declare_procedure;
 <*NOWARN*>PROCEDURE set_error_handler(self: T; p: M3CG_Ops.ErrorHandler) = BEGIN END set_error_handler;
 <*NOWARN*>PROCEDURE begin_unit(self: T; optimize: INTEGER) = BEGIN END begin_unit;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -54,7 +54,7 @@ TYPE op_tag_t = op_t OBJECT
 END;
 
 (* These create procs. *)
-TYPE import_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; OVERRIDES replay := replay_import_procedure END;
+TYPE import_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; return_type_qid := M3CG.NoQID; OVERRIDES replay := replay_import_procedure END;
 TYPE declare_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: INTEGER(*proc_t*); OVERRIDES replay := replay_declare_procedure END;
 
 (* These create vars. *)

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -381,10 +381,10 @@ self.Add(NEW(declare_temp_t, op := Op.declare_temp, byte_size := byte_size, alig
 RETURN var;
 END declare_temp;
 
-PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention): Proc =
+PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; return_type_qid := M3CG.NoQID): Proc =
 VAR proc := self.refs.NewProc();
 BEGIN
-self.Add(NEW(import_procedure_t, op := Op.import_procedure, name := name, n_params := n_params, return_type := return_type, callingConvention := callingConvention, tag := proc.tag));
+self.Add(NEW(import_procedure_t, op := Op.import_procedure, name := name, n_params := n_params, return_type := return_type, callingConvention := callingConvention, return_type_qid := return_type_qid, tag := proc.tag));
 RETURN proc;
 END import_procedure;
 
@@ -1094,7 +1094,7 @@ END replay_declare_temp;
 
 PROCEDURE replay_import_procedure(self: import_procedure_t; replay: Replay_t; cg: cg_t) =
 BEGIN
-    replay.PutRef(self.tag, cg.import_procedure(self.name, self.n_params, self.return_type, self.callingConvention));
+    replay.PutRef(self.tag, cg.import_procedure(self.name, self.n_params, self.return_type, self.callingConvention, self.return_type_qid));
 END replay_import_procedure;
 
 PROCEDURE replay_declare_procedure(self: declare_procedure_t; replay: Replay_t; cg: cg_t) =

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -344,7 +344,7 @@ init_float (o: ByteOffset;  READONLY f: Target.Float);
 *)
 
 import_procedure (n: Name;  n_params: INTEGER;  return: Type;
-                  cc: CallingConvention): Proc;
+                  cc: CallingConvention; return_type_qid := M3CG.NoQID): Proc;
 (* declare and import the external procedure with name 'n' and 'n_params'
    formal parameters.  It must be a top-level (=0) procedure that returns
    values of type 'return'.  'cc' is derived from the procedure's <*EXTERNAL*>

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -1017,6 +1017,7 @@ PROCEDURE import_procedure (VAR s: State) =
       ret_type := Scan_type (s);
       calling  := Scan_callConv (s);
       p        := Scan_procName (s);
+      (* TODO return_type_qid but it is not used *)
   BEGIN
     AddProc (s, p, s.cg.import_procedure (name, n_params, ret_type, calling));
   END import_procedure;

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -909,7 +909,8 @@ PROCEDURE NewProc (u: U): Proc =
   END NewProc;
 
 PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
-                          ret_type: Type;  cc: CallingConvention): Proc =
+                            ret_type: Type;  cc: CallingConvention;
+                            <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, "import_procedure");
@@ -919,6 +920,7 @@ PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
     Int   (u, cc.m3cg_id);
     PName (u, p);
     NL    (u);
+    (* TODO return_type_qid but it not used *)
     RETURN p;
   END import_procedure;
 


### PR DESCRIPTION
This is so things like
INTERFACE Uuio;
`<*external*>PROCEDURE read(...):int`

can return "int" or "Ctypes__int", and not a type with a hash,
so that m3core.h and C backend output can match, and be concatenated,
and then bootstrap is from one large .c file.

This is plumbing toward that goal.

Previously I added the qid (module-qualified id) to the params. This adds it also for the return type.