### PR TITLE
m3front: Pass on result_qid to import_procedure.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4283,9 +4283,9 @@ PROCEDURE Imports_import_procedure(
     parameter_count: INTEGER;
     return_type: CGType;
     callingConvention: CallingConvention;
-    <*UNUSED*>return_type_qid := M3CG.NoQID): M3CG.Proc =
+    return_type_qid := M3CG.NoQID): M3CG.Proc =
 BEGIN
-    RETURN import_procedure(self.self, name, parameter_count, return_type, callingConvention);
+    RETURN import_procedure(self.self, name, parameter_count, return_type, callingConvention, return_type_qid);
 END Imports_import_procedure;
 
 PROCEDURE Imports_declare_param(

--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -9,7 +9,7 @@
 MODULE NamedType;
 
 IMPORT M3, M3ID, Token, Type, TypeRep, Scanner, ObjectType;
-IMPORT Error, Scope, Brand, Value, ErrType, CG;
+IMPORT Error, Scope, Brand, Value, ErrType;
 
 TYPE
   P = Type.T BRANDED "NamedType.T" OBJECT

--- a/m3-sys/m3front/src/types/ProcType.i3
+++ b/m3-sys/m3front/src/types/ProcType.i3
@@ -19,6 +19,7 @@ PROCEDURE Is        (t: Type.T): BOOLEAN;
 PROCEDURE NFormals  (t: Type.T): INTEGER;
 PROCEDURE Formals   (t: Type.T): Value.T (*list*);
 PROCEDURE Result    (t: Type.T): Type.T;
+PROCEDURE ResultQid (t: Type.T): M3.QID;
 PROCEDURE CGResult  (t: Type.T): CG.Type;
 PROCEDURE Raises    (t: Type.T): M3.ExSet;
 PROCEDURE Methods   (t: Type.T): CallExpr.MethodList;

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -9,7 +9,7 @@
 MODULE ProcType;
 
 IMPORT M3, M3ID, CG, Expr, Type, TypeRep, Value, Scope, Target;
-IMPORT Formal, UserProc, Token, Ident, CallExpr, Word, Error;
+IMPORT Formal, UserProc, Token, Ident, CallExpr, Word, Error, NamedType;
 IMPORT ESet, TipeMap, TipeDesc, ErrType, M3Buf, Variable, OpenArrayType;
 FROM Scanner IMPORT Match, GetToken, cur;
 
@@ -21,6 +21,7 @@ TYPE
         result     : Type.T;
         raises     : ESet.T;
         callConv   : CG.CallingConvention;
+        result_qid := M3.NoQID;
       OVERRIDES
         check      := Check;
         no_straddle:= TypeRep.AddrNoStraddle;
@@ -65,6 +66,7 @@ PROCEDURE ParseSignature (name: M3ID.T;  cc: CG.CallingConvention): Type.T =
     IF (cur.token = TK.tCOLON) THEN
       GetToken (); (* : *)
       p.result := Type.Parse ();
+      EVAL NamedType.Split (p.result, p.result_qid);
     END;
     IF (cur.token = TK.tRAISES) THEN
       p.raises := ESet.ParseRaises ();
@@ -374,6 +376,15 @@ PROCEDURE Result (t: Type.T): Type.T =
       ELSE RETURN ErrType.T;
     END;
   END Result;
+
+PROCEDURE ResultQid (t: Type.T): M3.QID =
+  VAR p := Reduce (t);
+  BEGIN
+    IF (p # NIL)
+      THEN RETURN p.result_qid;
+      ELSE RETURN M3.NoQID;
+    END;
+  END ResultQid;
 
 PROCEDURE CGResult (t: Type.T): CG.Type =
   VAR p := Reduce (t);

--- a/m3-sys/m3front/src/values/Procedure.m3
+++ b/m3-sys/m3front/src/values/Procedure.m3
@@ -393,13 +393,14 @@ PROCEDURE LoadStaticLink (t: T) =
  END LoadStaticLink;
 
 PROCEDURE ImportProc (p: T;  name: TEXT;  n_formals: INTEGER;
-                      cg_result: CG.Type;  cc: CG.CallingConvention) =
+                      cg_result: CG.Type; return_type_qid := M3.NoQID;
+                      cc: CG.CallingConvention) =
   VAR zz: Scope.T;  new: BOOLEAN;
   BEGIN
     <*ASSERT p.cg_proc = NIL*>
     p.next_cg_proc := cg_procs;  cg_procs := p;
     p.cg_proc := CG.Import_procedure (M3ID.Add (name), n_formals,
-                                      cg_result, cc, new);
+                                      cg_result, cc, new, return_type_qid);
     IF (new) THEN
       (* declare the formals *)
       IF (p.syms # NIL) THEN
@@ -485,7 +486,7 @@ PROCEDURE Declarer (p: T): BOOLEAN =
         RETURN FALSE;
       ELSE
         (* it's an imported procedure *)
-        ImportProc (p, name, n_formals, cg_result, cconv);
+        ImportProc (p, name, n_formals, cg_result, ProcType.ResultQid (p.signature), cconv);
         RETURN TRUE;
       END;
     END;


### PR DESCRIPTION
m3front: Pass on result_qid to import_procedure.
m3c: Ditto.

This is a bit of a temporary failure.
The names are coming through with a single item, "int" instead of "Ctypes__int".
But it shows where and almost how to make the right change, once right is decided.

We will maybe want to call GlobalName in m3front like we do for
declare_typename and pass on a TEXT. (usually nil). (err, M3ID, not TEXT).
Not too expensive?

Alternatively, we can change the few we care about on the .i3 side
and have m3c only pay attention to ones with module # 0.

As well we can mechanize "what we care about" as extern-only.

There are likely more options, such as a narrow form of GlobalName,
that returns the module M3ID. Or providing more typedefs
like Uuio__int, etc.