### PR TITLE
m3front: Pass fully qualified ids to backend.

### DIFF
--- a/m3-sys/m3front/src/misc/Scope.i3
+++ b/m3-sys/m3front/src/misc/Scope.i3
@@ -29,7 +29,7 @@ PROCEDURE Top  (): T;
 PROCEDURE Insert (o: Value.T);
 
 PROCEDURE LookUp    (t: T;  name: M3ID.T;  strict: BOOLEAN): Value.T;
-PROCEDURE LookUpQID (t: T;  READONLY q: M3.QID): Value.T;
+PROCEDURE LookUpQID (t: T;  VAR q: M3.QID): Value.T;
 
 PROCEDURE ToList     (t: T): Value.T;
 PROCEDURE OuterMost  (t: T): BOOLEAN;

--- a/m3-sys/m3front/src/misc/Scope.m3
+++ b/m3-sys/m3front/src/misc/Scope.m3
@@ -106,11 +106,15 @@ PROCEDURE OuterMost (t: T) : BOOLEAN =
     RETURN (t # NIL) AND (t.module);
   END OuterMost;
 
-PROCEDURE LookUpQID (t: T;  READONLY q: M3.QID): Value.T =
+PROCEDURE LookUpQID (t: T;  VAR q: M3.QID): Value.T =
   VAR v: Value.T := NIL;
   BEGIN
     IF (q.module = M3ID.NoID) THEN
       v := LookUp (t, q.item, FALSE);
+      IF v # NIL THEN
+        q.module := ModuleName (v);
+        <* ASSERT q.module # M3ID.NoID *>
+      END;
     ELSE
       TYPECASE Value.Base (LookUp (t, q.module, FALSE)) OF
       | Module.T (m) => v := LookUp (Module.ExportScope (m), q.item, TRUE);

--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -93,11 +93,13 @@ PROCEDURE Split (t: Type.T;  VAR name: M3.QID): BOOLEAN =
   VAR p := Reduce (t);
   BEGIN
     IF (p = NIL) THEN RETURN FALSE END;
+    Resolve (p);
     name := p.qid;
     RETURN TRUE;
   END Split;
 
 PROCEDURE SplitV (t: Type.T;  VAR v: Value.T): BOOLEAN =
+(* return V for Value *)
   VAR p := Reduce (t);
   BEGIN
     IF (p = NIL) THEN RETURN FALSE END;

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -66,7 +66,6 @@ PROCEDURE ParseSignature (name: M3ID.T;  cc: CG.CallingConvention): Type.T =
     IF (cur.token = TK.tCOLON) THEN
       GetToken (); (* : *)
       p.result := Type.Parse ();
-      EVAL NamedType.Split (p.result, p.result_qid);
     END;
     IF (cur.token = TK.tRAISES) THEN
       p.raises := ESet.ParseRaises ();
@@ -227,6 +226,7 @@ PROCEDURE Check (p: P) =
       p.checked := TRUE;
       Scope.TypeCheck (p.formals, cs);
       IF (p.result # NIL) THEN
+        EVAL NamedType.Split (p.result, p.result_qid);
         p.result := Type.Check (p.result);
         IF OpenArrayType.Is (p.result) THEN
           Error.Msg ("procedures may not return open arrays");

--- a/m3-sys/m3front/src/values/Procedure.m3
+++ b/m3-sys/m3front/src/values/Procedure.m3
@@ -486,6 +486,7 @@ PROCEDURE Declarer (p: T): BOOLEAN =
         RETURN FALSE;
       ELSE
         (* it's an imported procedure *)
+        Type.Compile (ProcType.Result (p.signature));
         ImportProc (p, name, n_formals, cg_result, ProcType.ResultQid (p.signature), cconv);
         RETURN TRUE;
       END;


### PR DESCRIPTION
NamedTypes occur like either:

INTERACE A;
FROM B IMPORT C;

PROCEDURE D():C;

or

INTERACE A;
IMPORT B;

PROCEDURE D():B.C;

In the first case, merely C was being passed.
Now B.C is.

This will help with concatenating all m3c output and hand
written .h/.c. Matching function declarations, without
type hashes, will be trivial, using like:

m3core.h:
 ifndef Ctypes__int
 define Ctypes__int Ctypes__int
 typedef int Ctypes__int
 endif
 Ctypes__int UnixFoo__Bar(void);

 cat m3core.h *.c cm3.c
 cc cm3.c

This change is a little invasive, in its changing READONLY
to VAR, but I think it is ok. It can be dialed back somewhat
if there is a problem, or other approaches considered.

Really I think it makes sense to canonicalize/lower
and not just pass through equivalent varying forms.