### PR TITLE
m3core: Mostly cleanup Cstdio a little.

### DIFF
--- a/m3-libs/m3core/src/C/Common/Cstdio.i3
+++ b/m3-libs/m3core/src/C/Common/Cstdio.i3
@@ -1,5 +1,7 @@
 INTERFACE Cstdio;
 
+(* Nothing in this file is used. Nothing in this file is tested. *)
+
 FROM Ctypes IMPORT int, const_char_star, void_star;
 FROM Cstddef IMPORT size_t;
 

--- a/m3-libs/m3core/src/C/Common/CstdioC.c
+++ b/m3-libs/m3core/src/C/Common/CstdioC.c
@@ -1,3 +1,5 @@
+// Nothing in this file is used. Nothing in this file is tested.
+
 #ifndef INCLUDED_M3CORE_H
 #include "m3core.h"
 #endif
@@ -40,19 +42,15 @@ M3WRAP2(int, ungetc, int, FILE*)
 M3WRAP1_(int, getw, FILE*)
 M3WRAP2_(int, putw, int, FILE*)
 
-#define X(name, in, out) M3_DLL_EXPORT void __cdecl Cstdio__##name in { name out; }
-#define X1(name, a)             X(name, (a i),      (i))
-#define X2(name, a, b)          X(name, (a i, b j), (i, j))
-
-X1(clearerr, FILE*)
-X1(perror, const char*) /* print error */
-X1(rewind, FILE*)
-X2(setbuf, FILE*, char*)
+M3WRAP1_RETURN_VOID(clearerr, FILE*)
+M3WRAP1_RETURN_VOID(perror, const char*) /* print error */
+M3WRAP1_RETURN_VOID(rewind, FILE*)
+M3WRAP2_RETURN_VOID(setbuf, FILE*, char*)
 
 #undef X
 #undef X_
-#define X(a) M3_DLL_EXPORT EXTERN_CONST unsigned Cstdio__##a = a;
-#define X_(a) M3_DLL_EXPORT EXTERN_CONST unsigned Cstdio__##a = _##a;
+#define X(a) M3_DLL_EXPORT EXTERN_CONST int Cstdio__##a = a;
+#define X_(a) M3_DLL_EXPORT EXTERN_CONST int Cstdio__##a = _##a;
 
 X(BUFSIZ)
 X(FILENAME_MAX)
@@ -65,10 +63,6 @@ X(SEEK_CUR)
 X(SEEK_END)
 X(SEEK_SET)
 X(TMP_MAX)
-
-#undef X
-#define X(a) M3_DLL_EXPORT EXTERN_CONST int Cstdio__##a = a;
-
 X(EOF)
 
 #undef X

--- a/m3-libs/m3core/src/C/Common/m3makefile
+++ b/m3-libs/m3core/src/C/Common/m3makefile
@@ -13,8 +13,9 @@ c_source ("CerrnoC")
 
 Interface ("Cstring")
 c_source("CstringC")
-Interface ("Cstdio")
-c_source ("CstdioC")
+
+Interface ("Cstdio") % This is not used.
+c_source ("CstdioC") % This is not used.
 
 Interface ("Csignal") % not used by all ports
 c_source("CsignalC")


### PR DESCRIPTION
 - Use wrapper macros even for returning void.
 - m3core.h: Add the higher level wrapper macros for returning void.
   (with the token pasting hazard).
   We should consider using m3quake + cm3 builtins to write
   this stuff out to avoid that hazard thoroughly.
   What we have instead is selective based on empirical
   findings (i.e. systems with macros like __malloc).
   Or remove all the pasting.
 - Add comments that Cstdio is unused, untested, but keep it "working".
 - Change unsigned to int.
 - A few comments here and there.
   e.g. todo change m3_socklen_t to int.