### PR TITLE
m3front: Provide a qid to backend for non-named types.

### DIFF
--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -226,7 +226,7 @@ PROCEDURE Check (p: P) =
       p.checked := TRUE;
       Scope.TypeCheck (p.formals, cs);
       IF (p.result # NIL) THEN
-        EVAL NamedType.Split (p.result, p.result_qid);
+        Type.QID (p.result, p.result_qid);
         p.result := Type.Check (p.result);
         IF OpenArrayType.Is (p.result) THEN
           Error.Msg ("procedures may not return open arrays");

--- a/m3-sys/m3front/src/types/Type.i3
+++ b/m3-sys/m3front/src/types/Type.i3
@@ -8,7 +8,7 @@
 
 INTERFACE Type;
 
-IMPORT M3, CG, Target;
+IMPORT M3, CG, Target, M3ID;
 
 TYPE
   T          = M3.Type;
@@ -35,6 +35,7 @@ TYPE
     addr_align: INTEGER := Target.Word8.align;
     (* ^When stk_type = CG.Type.Addr, the alignment of dereferenced location. *)
     hash      : INTEGER;  (* internal hash code *)
+    name      := M3ID.NoID;
     stk_type  : CG.Type;  (* code generator representation on operator stack *)
     mem_type  : CG.Type;  (* code generator representation as a variable *)
     class     : Class;
@@ -100,6 +101,8 @@ PROCEDURE LoadScalar (t: T);
 PROCEDURE IsLazyAligned (t: T): BOOLEAN;
 
 PROCEDURE SetLazyAlignment (t: T; on: BOOLEAN);
+
+PROCEDURE QID (t: T; VAR qid: M3.QID);
 
 (*** phase 3 ***)
 

--- a/m3-sys/m3front/src/types/Type.m3
+++ b/m3-sys/m3front/src/types/Type.m3
@@ -190,6 +190,14 @@ PROCEDURE CheckInfo (t: T;  VAR x: Info): T =
     RETURN u;
   END CheckInfo;
 
+PROCEDURE QID (t: T; VAR qid: M3.QID) =
+BEGIN
+  IF NOT NamedType.Split (t, qid) THEN
+    qid.module := M3ID.NoID;
+    qid.item := t.info.name;
+  END;
+END QID;
+
 (************************************************************************)
 
 (*EXPORTED*)

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -209,7 +209,7 @@ PROCEDURE Check (t: T;  VAR cs: Value.CheckState) =
   VAR info: Type.Info;
   BEGIN
     (* Capture qid before type gets reduced and loses NamedType. *)
-    EVAL NamedType.Split (TypeOf (t), t.qid);
+    Type.QID (TypeOf (t), t.qid);
     t.tipe := Type.CheckInfo (TypeOf (t), info);
     t.repType := Type.StripPacked (t.tipe);
     EVAL Type.Check (t.repType);


### PR DESCRIPTION
That is, tell backend "INTEGER" and not just int32/int64.
Original attempt was to wrap all types in NamedType.
That still seems reasonable.
But it did not immediately work, I did not debug, and the approach here is to add M3ID name to every Type.info.
This is wasteful but probably ok. Wrapping in NamedType is quite disruptive perhaps.. or should work.

This way we can declare C code as taking/returning INTEGER and have it match m3c output (once m3c processes this data more).

Perhaps at this point we should just change qid=m3idpair to typename=m3id, really.
That is, remove the module: M3ID and have NamedType do a concat and M3ID.Add.
However that has cost, and with most backends, no benefit.