### PR TITLE
m3core: Add const_int and const_UINT32 types.

### DIFF
--- a/m3-libs/m3core/src/C/Common/Ctypes.i3
+++ b/m3-libs/m3core/src/C/Common/Ctypes.i3
@@ -14,6 +14,7 @@ TYPE
   signed_char                = BasicCtypes.signed_char;
   short_int                  = BasicCtypes.short_int;
   int                        = BasicCtypes.int;
+  const_int                  = int;
   long_int                   = BasicCtypes.long_int;
   long_long                  = BasicCtypes.long_long;
   unsigned_char              = BasicCtypes.unsigned_char;

--- a/m3-libs/m3core/src/win32/WinBaseTypes.i3
+++ b/m3-libs/m3core/src/win32/WinBaseTypes.i3
@@ -19,6 +19,7 @@ TYPE
   UINT8 = Cstdint.uint8_t;
   UINT16 = Cstdint.uint16_t;
   UINT32 = Cstdint.uint32_t;
+  const_UINT32 = UINT32;
   UINT64 = Cstdint.uint64_t;
   INT8 = Cstdint.int8_t;
   INT16 = Cstdint.int16_t;


### PR DESCRIPTION
This is a non-Modula3-type-system textual trick that should be useful shortly, as part of m3c+*.c concat.