### PR TITLE
m3front: Missed part of naming types:

### DIFF
--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -8,7 +8,7 @@
 
 MODULE Tipe;
 
-IMPORT M3, M3ID, CG, Value, ValueRep, Scope, OpaqueType, WebInfo;
+IMPORT M3, M3ID, CG, Value, ValueRep, Scope, OpaqueType, WebInfo, TypeRep;
 IMPORT Token, Type, Decl, Scanner, NamedType, RefType, ObjectType, Module;
 FROM Scanner IMPORT GetToken, Fail, Match, MatchID, cur;
 
@@ -72,6 +72,7 @@ PROCEDURE Parse (att: Decl.Attributes) =
         ELSE
           Fail ("missing \'=\' or \'<:\'");
         END;
+        (*t.value.info.name := id;*)
         Match (Token.T.tSEMI);
       END;
     END;
@@ -94,6 +95,7 @@ PROCEDURE Define (name: TEXT;  type: Type.T;  reserved: BOOLEAN) =
   BEGIN
     t := Create (M3ID.Add (name));
     t.value := type;
+    type.info.name := t.name;
     Scope.Insert (t);
     IF (reserved) THEN Scanner.NoteReserved (t.name, t) END;
   END Define;
@@ -104,6 +106,7 @@ PROCEDURE DefineOpaque (name: TEXT;  super: Type.T): Type.T =
     t := Create (M3ID.Add (name));
     Scope.Insert (t);
     t.value := OpaqueType.New (super, t);
+    t.value.info.name := t.name;
     Scanner.NoteReserved (t.name, t);
     RETURN t.value;
   END DefineOpaque;


### PR DESCRIPTION
 commit 575063b607bed4629111dcd4b3e2254b512796cd
 Author: Jay Krell <jay.krell@cornell.edu>
 Date:   Fri May 7 20:03:35 2021 -0700

    m3front: Provide a qid to backend for non-named types. (#424)

    That is, tell backend "INTEGER" and not just int32/int64.

When I tested that, I probably had a mix of attempts
and it worked, but then I undid parts.

The commented out line here seems correct but caused problems.