### PR TITLE
m3-sys: Add return_type_qid to declare_procedure.

### DIFF
--- a/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
@@ -2081,8 +2081,8 @@ PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: 
 
 PROCEDURE declare_procedure (self: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
-                             cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+                             cc: CallingConvention; exported: BOOLEAN;
+                             parent: Proc; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,lev,cc,exported,parent);
   BEGIN

--- a/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
@@ -2122,7 +2122,8 @@ PROCEDURE init_float (self: U;  o: ByteOffset;  READONLY f: Target.Float) =
 
 (*------------------------------------------------------------ procedures ---*)
 
-PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
+PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;
+                            cc: CallingConvention; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,-1,cc,FALSE,NIL);
     name : TEXT;
@@ -2156,10 +2157,11 @@ PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: 
     RETURN p;
   END import_procedure;
 
-PROCEDURE declare_procedure (self: U;  n: Name;  n_params: INTEGER;
-                             return_type: Type;  lev: INTEGER;
-                             cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+PROCEDURE declare_procedure (
+    self: U;  n: Name;  n_params: INTEGER;
+    return_type: Type;  lev: INTEGER;
+    cc: CallingConvention; exported: BOOLEAN;
+    parent: Proc; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,lev,cc,exported,parent);
   BEGIN

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -2227,8 +2227,8 @@ PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: 
 
 PROCEDURE declare_procedure (self: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
-                             cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+                             cc: CallingConvention; exported: BOOLEAN;
+                             parent: Proc; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,lev,cc,exported,parent);
   BEGIN

--- a/m3-sys/m3back/src/M3C-save1.m3
+++ b/m3-sys/m3back/src/M3C-save1.m3
@@ -1325,7 +1325,8 @@ VAR proc := NEW(CProc, name := FixName(name), n_params := n_params,
 PROCEDURE declare_procedure (this: T; name: Name; n_params: INTEGER;
                              return_type: Type; level: INTEGER;
                              callingConvention: CallingConvention;
-                             exported: BOOLEAN; parent: Proc): Proc =
+                             exported: BOOLEAN; parent: Proc;
+                             <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
 VAR proc := NEW(CProc, name := FixName(name), n_params := n_params,
                 return_type := return_type, level := level,
                 callingConvention := callingConvention, exported := exported,

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -5261,7 +5261,8 @@ PROCEDURE Locals_declare_procedure(
     level: INTEGER;
     callingConvention: CallingConvention;
     exported: BOOLEAN;
-    parent: M3CG.Proc): M3CG.Proc =
+    parent: M3CG.Proc;
+    <*UNUSED*>return_type_qid := M3CG.NoQID): M3CG.Proc =
 BEGIN
     RETURN declare_procedure(
         self.self,
@@ -5286,7 +5287,8 @@ PROCEDURE declare_procedure(
     self: T; name: Name; parameter_count: INTEGER;
     return_type: CGType; level: INTEGER;
     callingConvention: CallingConvention;
-    exported: BOOLEAN; parent: M3CG.Proc): M3CG.Proc =
+    exported: BOOLEAN; parent: M3CG.Proc;
+    <*UNUSED*>return_type_qid := M3CG.NoQID): M3CG.Proc =
 VAR proc := NEW(Proc_t, name := name, parameter_count := parameter_count,
                 return_type := return_type, level := level,
                 callingConvention := callingConvention, exported := exported,

--- a/m3-sys/m3back/src/M3x86.m3
+++ b/m3-sys/m3back/src/M3x86.m3
@@ -1314,8 +1314,8 @@ PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
 
 PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
-                             cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+                             cc: CallingConvention; exported: BOOLEAN;
+                             parent: Proc; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR p := NewProc (u, n, n_params, return_type, cc);
   BEGIN
     p.exported := exported;

--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -328,7 +328,8 @@ PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
 
 PROCEDURE Declare_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                              lev: INTEGER;  cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc;
+                             exported: BOOLEAN;  parent: Proc;
+                             return_type_qid := M3CG.NoQID): Proc;
 (* declare a procedure named 'n' with 'n_params' formal parameters
    at static level 'lev'.  Sets "current procedure" to this procedure.
    If the name 'n' is NIL, a new unique name will be supplied by the back-end.

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -1372,12 +1372,14 @@ PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
 
 PROCEDURE Declare_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                              lev: INTEGER;  cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+                             exported: BOOLEAN;  parent: Proc;
+                             return_type_qid := M3CG.NoQID): Proc =
   VAR p: Proc;
   BEGIN
     IF (procedures = NIL) THEN procedures := NewNameTbl() END;
     p := cg.declare_procedure (n, n_params, ret_type,
-                                 lev, cc, exported, parent);
+                               lev, cc, exported, parent,
+                               return_type_qid);
     EVAL procedures.put (n, p);
     RETURN p;
   END Declare_procedure;

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -477,10 +477,12 @@ PROCEDURE import_procedure (xx: T;  n: Name;  n_params: INTEGER;
 PROCEDURE declare_procedure (xx: T;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
                              cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+                             exported: BOOLEAN;  parent: Proc;
+                             return_type_qid := M3CG.NoQID): Proc =
   BEGIN
     RETURN xx.child.declare_procedure (n, n_params, return_type,
-                                       lev, cc, exported, parent);
+                                       lev, cc, exported, parent,
+                                       return_type_qid);
   END declare_procedure;
 
 PROCEDURE begin_procedure (xx: T;  p: Proc) =

--- a/m3-sys/m3middle/src/M3CG_AssertFalse.m3
+++ b/m3-sys/m3middle/src/M3CG_AssertFalse.m3
@@ -214,7 +214,7 @@ AssertFalse();
 RETURN NIL;
 END import_procedure;
 
-<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc): Proc =
+<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_type_qid := M3CG.NoQID): Proc =
 BEGIN
 AssertFalse();
 RETURN NIL;

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -884,8 +884,8 @@ PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
 
 PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
-                             cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+                             cc: CallingConvention; exported: BOOLEAN;
+                             parent: Proc; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, Bop.declare_procedure);

--- a/m3-sys/m3middle/src/M3CG_DoNothing.m3
+++ b/m3-sys/m3middle/src/M3CG_DoNothing.m3
@@ -164,7 +164,7 @@ END;
 <*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var = BEGIN RETURN NIL; END declare_param;
 <*NOWARN*>PROCEDURE declare_temp(self: T; byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN): Var = BEGIN RETURN NIL; END declare_temp;
 <*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_type_qid := M3CG.NoQID): Proc = BEGIN RETURN NIL; END import_procedure;
-<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc): Proc = BEGIN RETURN NIL; END declare_procedure;
+<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_type_qid := M3CG.NoQID): Proc = BEGIN RETURN NIL; END declare_procedure;
 <*NOWARN*>PROCEDURE set_error_handler(self: T; p: M3CG_Ops.ErrorHandler) = BEGIN END set_error_handler;
 <*NOWARN*>PROCEDURE begin_unit(self: T; optimize: INTEGER) = BEGIN END begin_unit;
 <*NOWARN*>PROCEDURE end_unit(self: T) = BEGIN END end_unit;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -55,7 +55,7 @@ END;
 
 (* These create procs. *)
 TYPE import_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; return_type_qid := M3CG.NoQID; OVERRIDES replay := replay_import_procedure END;
-TYPE declare_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: INTEGER(*proc_t*); OVERRIDES replay := replay_declare_procedure END;
+TYPE declare_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: INTEGER(*proc_t*); return_type_qid := M3CG.NoQID; OVERRIDES replay := replay_declare_procedure END;
 
 (* These create vars. *)
 TYPE declare_segment_t = op_tag_t OBJECT name: Name; typeid: typeid_t; is_const: BOOLEAN; OVERRIDES replay := replay_declare_segment END;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -388,7 +388,7 @@ self.Add(NEW(import_procedure_t, op := Op.import_procedure, name := name, n_para
 RETURN proc;
 END import_procedure;
 
-PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc): Proc =
+PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_type_qid := M3CG.NoQID): Proc =
 VAR proc := self.refs.NewProc();
     parent_tag := 0;
 BEGIN

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -354,7 +354,8 @@ import_procedure (n: Name;  n_params: INTEGER;  return: Type;
 
 declare_procedure (n: Name;  n_params: INTEGER;  return: Type;
                    lev: INTEGER;  cc: CallingConvention;
-                   exported: BOOLEAN;  parent: Proc): Proc;
+                   exported: BOOLEAN;  parent: Proc;
+                   <*UNUSED*>return_type_qid := M3CG.NoQID): Proc;
 (* Declare a procedure with simple name 'n' within the current scope,
    with 'n_params' formal parameters, at static nesting level 'lev'.
    Set the "current procedure" to this procedure.  If the name n is M3ID.NoID,

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -926,8 +926,8 @@ PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
 
 PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
-                             cc: CallingConvention;
-                             exported: BOOLEAN;  parent: Proc): Proc =
+                             cc: CallingConvention; exported: BOOLEAN;
+                             parent: Proc; <*UNUSED*>return_type_qid := M3CG.NoQID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, "declare_procedure");


### PR DESCRIPTION
Ultimately and soon, imports and declares "need" to match (for concat of m3c output and hand written *.c, and not a bad idea anyway). This is not yet used, and parameters are not handled yet, but both should change soon.