### PR TITLE
m3back: Add printing of declare_procedure(return_type_qid)

### DIFF
--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -918,6 +918,7 @@ PROCEDURE declare_procedure (VAR s: State) =
       export   := Scan_bool (s);
       parent   := Scan_proc (s);
       p        := Scan_int (s);
+      (* TODO return_type_qid but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddProc (s, p, s.cg.declare_procedure (name, n_params, ret_type,
                                            level, calling, export, parent));

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -897,6 +897,7 @@ PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
     Bool  (u, exported);
     PName (u, parent);
     PName (u, p);
+    (* TODO return_type_qid but it is not used downstream and can be omitted indefinitely *)
     RETURN p;
   END declare_procedure;
 

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -396,7 +396,7 @@ BEGIN
         parent_tag := NARROW(parent, proc_t).tag;
     END;
     self.Add(NEW(declare_procedure_t, op := Op.declare_procedure, name := name, n_params := n_params, return_type := return_type, level := level,
-                 callingConvention := callingConvention, exported := exported, parent := parent_tag, tag := proc.tag));
+                 callingConvention := callingConvention, exported := exported, parent := parent_tag, return_type_qid := return_type_qid, tag := proc.tag));
     RETURN proc;
 END declare_procedure;
 
@@ -1100,7 +1100,7 @@ END replay_import_procedure;
 PROCEDURE replay_declare_procedure(self: declare_procedure_t; replay: Replay_t; cg: cg_t) =
 BEGIN
     replay.PutRef(self.tag, cg.declare_procedure(self.name, self.n_params, self.return_type,
-        self.level, self.callingConvention, self.exported, replay.GetProc(self.parent)));
+        self.level, self.callingConvention, self.exported, replay.GetProc(self.parent), self.return_type_qid));
 END replay_declare_procedure;
 
 PROCEDURE replay_import_global(self: import_global_t; replay: Replay_t; cg: cg_t) =

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -355,7 +355,7 @@ import_procedure (n: Name;  n_params: INTEGER;  return: Type;
 declare_procedure (n: Name;  n_params: INTEGER;  return: Type;
                    lev: INTEGER;  cc: CallingConvention;
                    exported: BOOLEAN;  parent: Proc;
-                   <*UNUSED*>return_type_qid := M3CG.NoQID): Proc;
+                   return_type_qid := M3CG.NoQID): Proc;
 (* Declare a procedure with simple name 'n' within the current scope,
    with 'n_params' formal parameters, at static nesting level 'lev'.
    Set the "current procedure" to this procedure.  If the name n is M3ID.NoID,

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -1031,6 +1031,7 @@ PROCEDURE declare_procedure (VAR s: State) =
       export   := Scan_bool (s);
       parent   := Scan_proc (s);
       p        := Scan_procName (s);
+      (* TODO return_type_qid but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddProc (s, p, s.cg.declare_procedure (name, n_params, ret_type,
                                            level, calling, export, parent));

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -940,6 +940,7 @@ PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
     PName (u, parent);
     PName (u, p);
     NL    (u);
+    (* TODO return_type_qid but it is not used downstream and can be omitted indefinitely *)
     RETURN p;
   END declare_procedure;
 


### PR DESCRIPTION
Pass along declare_procedure(return_type_qid) in multipass.
Some shorthands.
Comments in m3cgrd/wr that it is not handled, since the relevant
backends do not use it and will not for long forseeable future.