### PR TITLE
m3-sys: Rename many qid to typename.

### DIFF
--- a/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
@@ -1761,7 +1761,7 @@ to check this. Perhaps the front end could supply the correct type. *)
     RETURN size;    
   END ImportedStructSize;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR

--- a/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
@@ -1854,7 +1854,7 @@ PROCEDURE declare_local
     RETURN v;
   END declare_local;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -1917,7 +1917,7 @@ PROCEDURE declare_local
     RETURN v;
   END declare_local;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4195,7 +4195,7 @@ PROCEDURE Locals_declare_param(
     <*UNUSED*>in_memory: BOOLEAN;
     up_level: BOOLEAN;
     <*UNUSED*>frequency: Frequency;
-    qid := NoQID): M3CG.Var =
+    typename := NoQID): M3CG.Var =
 BEGIN
     RETURN declare_param(
         self.self,
@@ -4205,7 +4205,7 @@ BEGIN
         type,
         typeid,
         up_level,
-        qid);
+        typename);
 END Locals_declare_param;
 
 PROCEDURE Locals_declare_local(
@@ -4298,7 +4298,7 @@ PROCEDURE Imports_declare_param(
     <*UNUSED*>in_memory: BOOLEAN;
     up_level: BOOLEAN;
     <*UNUSED*>frequency: Frequency;
-    qid := NoQID): M3CG.Var =
+    typename := NoQID): M3CG.Var =
 BEGIN
     RETURN declare_param(
         self.self,
@@ -4308,7 +4308,7 @@ BEGIN
         type,
         typeid,
         up_level,
-        qid);
+        typename);
 END Imports_declare_param;
 
 PROCEDURE Imports_import_global(
@@ -4485,7 +4485,7 @@ PROCEDURE GetStructSizes_declare_param(
     <*UNUSED*>in_memory: BOOLEAN;
     <*UNUSED*>up_level: BOOLEAN;
     <*UNUSED*>frequency: Frequency;
-    <*UNUSED*>qid := NoQID): M3CG.Var =
+    <*UNUSED*>typename := NoQID): M3CG.Var =
 BEGIN
     RETURN self.Declare(type, byte_size, alignment);
 END GetStructSizes_declare_param;
@@ -4704,11 +4704,11 @@ PROCEDURE internal_declare_param(
     typeid: TypeUID;
     up_level: BOOLEAN;
     type_text: TEXT;
-    qid := NoQID): M3CG.Var =
+    typename := NoQID): M3CG.Var =
 VAR function := self.param_proc;
     var: Var_t := NIL;
     type: Type_t := NIL;
-    qidtext := QidText(qid);
+    qidtext := QidText(typename);
 BEGIN
     IF DebugVerbose(self) THEN
         self.comment("internal_declare_param name:" & TextOrNIL(NameT(name))
@@ -4716,7 +4716,7 @@ BEGIN
             & " typeid:" & TypeIDToText(typeid)
             & " up_level:" & BoolToText[up_level]
             & " type_text:" & TextOrNIL(type_text)
-            & " qid:" & TextOrNil(qidtext));
+            & " typename:" & TextOrNil(qidtext));
     ELSE
         self.comment("internal_declare_param");
     END;
@@ -4773,7 +4773,7 @@ declare_param(
     type: CGType;
     typeid: TypeUID;
     up_level: BOOLEAN;
-    qid := NoQID): M3CG.Var =
+    typename := NoQID): M3CG.Var =
 BEGIN
     IF self.param_proc = NIL THEN
         RETURN NIL;
@@ -4787,7 +4787,7 @@ BEGIN
         typeid,
         up_level,
         NIL,
-        qid);
+        typename);
 END declare_param;
 
 PROCEDURE

--- a/m3-sys/m3back/src/M3x86.m3
+++ b/m3-sys/m3back/src/M3x86.m3
@@ -876,7 +876,7 @@ PROCEDURE mangle_procname (base: M3ID.T; arg_size: INTEGER;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          type: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
+                         f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
   VAR v := NewVar(u, type, m3t, s, 4, n);
   BEGIN
     (* Assume a = 4 and ESP is dword aligned... *)

--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -200,7 +200,7 @@ PROCEDURE Declare_local (n: Name;  s: Size;  a: Alignment;  t: Type;
 
 PROCEDURE Declare_param (n: Name;  s: Size;  a: Alignment;  t: Type;
                          m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; qid := M3.NoQID): Var;
+                         f: Frequency; typename := M3.NoQID): Var;
 (* declares a formal parameter.  Formals are declared in their lexical
    order immediately following the 'declare_procedure' or
    'import_procedure' that contains them.  *)

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -492,10 +492,10 @@ PROCEDURE Declare_local (n: Name;  s: Size;  a: Alignment;  t: Type;
 
 PROCEDURE Declare_param (n: Name;  s: Size;  a: Alignment;  t: Type;
                          m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; qid := M3CG.NoQID): Var =
+                         f: Frequency; typename := M3CG.NoQID): Var =
   BEGIN
     RETURN cg.declare_param (n, ToVarSize (s, a), ByteAlign (a),
-                             t, m3t, in_memory, up_level, f, qid);
+                             t, m3t, in_memory, up_level, f, typename);
   END Declare_param;
 
 (*----------------------------------------------------------- temporaries ---*)

--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -111,18 +111,18 @@ PROCEDURE SplitV (t: Type.T;  VAR v: Value.T): BOOLEAN =
 
 PROCEDURE Resolve (p: P) =
   VAR o: Value.T;  t: Type.T;  save: INTEGER;
-      qid := M3.NoQID;
+      typename := M3.NoQID;
   BEGIN
     IF (p.type = NIL) THEN
-      qid.module := p.module;
-      qid.item   := p.info.name;
-      o := Scope.LookUpQID (p.scope, qid);
-      p.module := qid.module;
+      typename.module := p.module;
+      typename.item   := p.info.name;
+      o := Scope.LookUpQID (p.scope, typename);
+      p.module := typename.module;
       p.obj := o;
       IF (o = NIL) THEN
         save := Scanner.offset;
         Scanner.offset := p.origin;
-        Error.QID (qid, "undefined");
+        Error.QID (typename, "undefined");
         Scanner.offset := save;
         t := ErrType.T;
       ELSIF (Value.ClassOf (o) = Value.Class.Type) THEN
@@ -130,7 +130,7 @@ PROCEDURE Resolve (p: P) =
       ELSE
         save := Scanner.offset;
         Scanner.offset := p.origin;
-        Error.QID (qid, "name isn\'t bound to a type");
+        Error.QID (typename, "name isn\'t bound to a type");
         Scanner.offset := save;
         t := ErrType.T;
       END;
@@ -208,9 +208,9 @@ PROCEDURE GenDesc (p: P) =
   END GenDesc;
 
 PROCEDURE FPrinter (p: P;  VAR x: M3.FPInfo) =
-  VAR qid := M3.QID {p.module, p.info.name};
+  VAR typename := M3.QID {p.module, p.info.name};
   BEGIN
-    Error.QID (qid, "INTERNAL ERROR: fingerprint of named type");
+    Error.QID (typename, "INTERNAL ERROR: fingerprint of named type");
     Resolve (p);
     IF (p.type # NIL) THEN p.type.fprint (x); END;
   END FPrinter;

--- a/m3-sys/m3front/src/types/ProcType.i3
+++ b/m3-sys/m3front/src/types/ProcType.i3
@@ -19,7 +19,7 @@ PROCEDURE Is        (t: Type.T): BOOLEAN;
 PROCEDURE NFormals  (t: Type.T): INTEGER;
 PROCEDURE Formals   (t: Type.T): Value.T (*list*);
 PROCEDURE Result    (t: Type.T): Type.T;
-PROCEDURE ResultQid (t: Type.T): M3.QID;
+PROCEDURE ResultTypename (t: Type.T): M3.QID;
 PROCEDURE CGResult  (t: Type.T): CG.Type;
 PROCEDURE Raises    (t: Type.T): M3.ExSet;
 PROCEDURE Methods   (t: Type.T): CallExpr.MethodList;

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -21,7 +21,7 @@ TYPE
         result     : Type.T;
         raises     : ESet.T;
         callConv   : CG.CallingConvention;
-        result_qid := M3.NoQID;
+        result_typename := M3.NoQID;
       OVERRIDES
         check      := Check;
         no_straddle:= TypeRep.AddrNoStraddle;
@@ -226,7 +226,7 @@ PROCEDURE Check (p: P) =
       p.checked := TRUE;
       Scope.TypeCheck (p.formals, cs);
       IF (p.result # NIL) THEN
-        Type.QID (p.result, p.result_qid);
+        Type.Typename (p.result, p.result_typename);
         p.result := Type.Check (p.result);
         IF OpenArrayType.Is (p.result) THEN
           Error.Msg ("procedures may not return open arrays");
@@ -377,14 +377,14 @@ PROCEDURE Result (t: Type.T): Type.T =
     END;
   END Result;
 
-PROCEDURE ResultQid (t: Type.T): M3.QID =
+PROCEDURE ResultTypename (t: Type.T): M3.QID =
   VAR p := Reduce (t);
   BEGIN
     IF (p # NIL)
-      THEN RETURN p.result_qid;
+      THEN RETURN p.result_typename;
       ELSE RETURN M3.NoQID;
     END;
-  END ResultQid;
+  END ResultTypename;
 
 PROCEDURE CGResult (t: Type.T): CG.Type =
   VAR p := Reduce (t);

--- a/m3-sys/m3front/src/types/Type.i3
+++ b/m3-sys/m3front/src/types/Type.i3
@@ -102,7 +102,7 @@ PROCEDURE IsLazyAligned (t: T): BOOLEAN;
 
 PROCEDURE SetLazyAlignment (t: T; on: BOOLEAN);
 
-PROCEDURE QID (t: T; VAR qid: M3.QID);
+PROCEDURE Typename (t: T; VAR typename: M3.QID);
 
 (*** phase 3 ***)
 

--- a/m3-sys/m3front/src/types/Type.m3
+++ b/m3-sys/m3front/src/types/Type.m3
@@ -190,13 +190,13 @@ PROCEDURE CheckInfo (t: T;  VAR x: Info): T =
     RETURN u;
   END CheckInfo;
 
-PROCEDURE QID (t: T; VAR qid: M3.QID) =
+PROCEDURE Typename (t: T; VAR typename: M3.QID) =
 BEGIN
-  IF NOT NamedType.Split (t, qid) THEN
-    qid.module := M3ID.NoID;
-    qid.item := t.info.name;
+  IF NOT NamedType.Split (t, typename) THEN
+    typename.module := M3ID.NoID;
+    typename.item := t.info.name;
   END;
-END QID;
+END Typename;
 
 (************************************************************************)
 

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -20,7 +20,7 @@ TYPE
         repType  : Type.T     := NIL;
         dfault   : Expr.T     := NIL;
         refType  : Type.T     := NIL; (* Needed to copy an open array. *)
-        qid                   := M3.NoQID;
+        typename              := M3.NoQID;
         tempCGVal: CG.Val     := NIL;
         cg_type  : CG.TypeUID := 0;
         mode     : Mode       := FIRST (Mode);
@@ -108,7 +108,7 @@ PROCEDURE EmitDeclaration (formal: Value.T;  types_only, param: BOOLEAN) =
     size     : CG.Size;
     align    : CG.Alignment;
     info     : Type.Info;
-    qid      := M3.NoQID;
+    typename := M3.NoQID;
   BEGIN
     IF (types_only) THEN
       Compile (t);
@@ -123,17 +123,17 @@ PROCEDURE EmitDeclaration (formal: Value.T;  types_only, param: BOOLEAN) =
         size  := Target.Address.size;
         align := Target.Address.align;
         mtype := CG.Type.Addr;
-        (* TODO qid *)
+        (* TODO typename *)
       ELSE (* lo-level pass by value. *)
         EVAL Type.CheckInfo (TypeOf (t), info);
         size  := info.size;
         align := info.alignment;
         mtype := info.mem_type;
-        qid   := t.qid;
+        typename := t.typename;
       END;
       EVAL CG.Declare_param (t.name, size, align, mtype,
                              t.cg_type, in_memory := FALSE, up_level := FALSE,
-                             f := CG.Maybe, qid := qid);
+                             f := CG.Maybe, typename := typename);
     ELSE (* This is part of debug info for a signature. *)
       CG.Declare_formal (t.name, t.cg_type);
     END;
@@ -188,8 +188,8 @@ PROCEDURE Check (t: T;  VAR cs: Value.CheckState) =
 (* Only checks on the formal itself. *)
   VAR info: Type.Info;
   BEGIN
-    (* Capture qid before type gets reduced and loses NamedType. *)
-    Type.QID (TypeOf (t), t.qid);
+    (* Capture typename before type gets reduced and loses NamedType. *)
+    Type.Typename (TypeOf (t), t.typename);
     t.type := Type.CheckInfo (TypeOf (t), info);
     t.repType := Type.StripPacked (t.type);
     EVAL Type.Check (t.repType);

--- a/m3-sys/m3front/src/values/Procedure.m3
+++ b/m3-sys/m3front/src/values/Procedure.m3
@@ -487,7 +487,7 @@ PROCEDURE Declarer (p: T): BOOLEAN =
       ELSE
         (* it's an imported procedure *)
         Type.Compile (ProcType.Result (p.signature));
-        ImportProc (p, name, n_formals, cg_result, ProcType.ResultQid (p.signature), cconv);
+        ImportProc (p, name, n_formals, cg_result, ProcType.ResultTypename (p.signature), cconv);
         RETURN TRUE;
       END;
     END;

--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -112,13 +112,13 @@ PROCEDURE DefineOpaque (name: TEXT;  super: Type.T): Type.T =
   END DefineOpaque;
 
 PROCEDURE Check (t: T;  <*UNUSED*> VAR cs: Value.CheckState) =
-  VAR info: Type.Info;  initial := t.value;  qid: M3.QID;  name: TEXT;
+  VAR info: Type.Info;  initial := t.value;  typename: M3.QID;  name: TEXT;
   BEGIN
     t.value := Type.CheckInfo (t.value, info);
 
     IF (NOT t.imported)
       AND ((info.class = Type.Class.Ref) OR (info.class = Type.Class.Object))
-      AND (NOT NamedType.Split (initial, qid)) THEN
+      AND (NOT NamedType.Split (initial, typename)) THEN
       name := Value.GlobalName (t);
       IF (info.class = Type.Class.Ref)
         THEN RefType.NoteRefName (t.value, name);

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -401,9 +401,9 @@ PROCEDURE declare_local (xx: T;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (xx: T;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; qid := M3CG.NoQID): Var =
+                         f: Frequency; typename := M3CG.NoQID): Var =
   BEGIN
-    RETURN xx.child.declare_param (n, s, a, t, m3t, in_memory, up_level, f, qid);
+    RETURN xx.child.declare_param (n, s, a, t, m3t, in_memory, up_level, f, typename);
   END declare_param;
 
 PROCEDURE declare_temp (xx: T;  s: ByteSize;  a: Alignment;  t: Type;

--- a/m3-sys/m3middle/src/M3CG_AssertFalse.m3
+++ b/m3-sys/m3middle/src/M3CG_AssertFalse.m3
@@ -196,7 +196,7 @@ AssertFalse();
 RETURN NIL;
 END declare_local;
 
-<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var =
+<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID): Var =
 BEGIN
 AssertFalse();
 RETURN NIL;

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -796,10 +796,10 @@ PROCEDURE declare_param (VAR s: State) =
       up_lev := Scan_bool (s);
       freq   := Scan_int (s);
       v      := Scan_int (s);
-      qid    := M3CG.NoQID; (* TODO qid but it is not used downstream and can be omitted indefinitely *)
+      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddVar (s, v, s.cg.declare_param (name, size, align, type, m3t,
-                                      in_mem, up_lev, freq, qid));
+                                      in_mem, up_lev, freq, typename));
   END declare_param;
 
 PROCEDURE declare_temp (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -757,7 +757,7 @@ PROCEDURE declare_local (u: U;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
+                         f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
   VAR v := NewVar (u);
   BEGIN
     Cmd   (u, Bop.declare_param);
@@ -770,7 +770,7 @@ PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
     Bool  (u, up_level);
     Int   (u, f);
     VName (u, v);
-    (* TODO qid but it is not used downstream and can be omitted indefinitely *)
+    (* TODO typename but it is not used downstream and can be omitted indefinitely *)
     RETURN v;
   END declare_param;
 

--- a/m3-sys/m3middle/src/M3CG_DoNothing.m3
+++ b/m3-sys/m3middle/src/M3CG_DoNothing.m3
@@ -161,7 +161,7 @@ END;
 <*NOWARN*>PROCEDURE declare_global(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; exported, inited: BOOLEAN): Var = BEGIN RETURN NIL; END declare_global;
 <*NOWARN*>PROCEDURE declare_constant(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; exported, inited: BOOLEAN): Var = BEGIN RETURN NIL; END declare_constant;
 <*NOWARN*>PROCEDURE declare_local(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency): Var = BEGIN RETURN NIL; END declare_local;
-<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var = BEGIN RETURN NIL; END declare_param;
+<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID): Var = BEGIN RETURN NIL; END declare_param;
 <*NOWARN*>PROCEDURE declare_temp(self: T; byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN): Var = BEGIN RETURN NIL; END declare_temp;
 <*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_type_qid := M3CG.NoQID): Proc = BEGIN RETURN NIL; END import_procedure;
 <*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_type_qid := M3CG.NoQID): Proc = BEGIN RETURN NIL; END declare_procedure;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -62,7 +62,7 @@ TYPE declare_segment_t = op_tag_t OBJECT name: Name; typeid: typeid_t; is_const:
 TYPE declare_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; exported, inited: BOOLEAN; OVERRIDES replay := replay_declare_global END;
 TYPE declare_constant_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; exported, inited: BOOLEAN; OVERRIDES replay := replay_declare_constant END;
 TYPE declare_local_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; OVERRIDES replay := replay_declare_local END;
-TYPE declare_param_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID; OVERRIDES replay := replay_declare_param END;
+TYPE declare_param_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID; OVERRIDES replay := replay_declare_param END;
 TYPE declare_temp_t = op_tag_t OBJECT byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN; OVERRIDES replay := replay_declare_temp END;
 TYPE import_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; OVERRIDES replay := replay_import_global END;
 

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -367,10 +367,10 @@ self.Add(NEW(declare_local_t, op := Op.declare_local, name := name, byte_size :=
 RETURN var;
 END declare_local;
 
-PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; qid := M3CG.NoQID): Var =
+PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID): Var =
 VAR var := self.refs.NewVar();
 BEGIN
-self.Add(NEW(declare_param_t, op := Op.declare_param, name := name, byte_size := byte_size, alignment := alignment, type := type, typeid := typeid, in_memory := in_memory, up_level := up_level, frequency := frequency, tag := var.tag, qid := qid));
+self.Add(NEW(declare_param_t, op := Op.declare_param, name := name, byte_size := byte_size, alignment := alignment, type := type, typeid := typeid, in_memory := in_memory, up_level := up_level, frequency := frequency, tag := var.tag, typename := typename));
 RETURN var;
 END declare_param;
 
@@ -1084,7 +1084,7 @@ END replay_declare_local;
 
 PROCEDURE replay_declare_param(self: declare_param_t; replay: Replay_t; cg: cg_t) =
 BEGIN
-    replay.PutRef(self.tag, cg.declare_param(self.name, self.byte_size, self.alignment, self.type, self.typeid, self.in_memory, self.up_level, self.frequency, self.qid));
+    replay.PutRef(self.tag, cg.declare_param(self.name, self.byte_size, self.alignment, self.type, self.typeid, self.in_memory, self.up_level, self.frequency, self.typename));
 END replay_declare_param;
 
 PROCEDURE replay_declare_temp(self: declare_temp_t; replay: Replay_t; cg: cg_t) =

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -253,7 +253,7 @@ declare_local (n: Name;  s: ByteSize;  a: Alignment;  t: Type;
 
 declare_param (n: Name;  s: ByteSize;  a: Alignment;  t: Type;
                m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-               f: Frequency; qid := M3CG.NoQID): Var;
+               f: Frequency; typename := M3CG.NoQID): Var;
 (* Declare a formal parameter, belonging to the most recent
    declare_procedure or import_procedure.  Formals are declared in
    their lexical order, relative to each other, but many other things

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -909,10 +909,10 @@ PROCEDURE declare_param (VAR s: State) =
       up_lev := Scan_bool (s);
       freq   := Scan_int (s);
       v      := Scan_varName (s);
-      qid    := M3CG.NoQID; (* TODO qid but it is not used downstream and can be omitted indefinitely *)
+      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddVar (s, v, s.cg.declare_param (name, size, align, type, m3t,
-                                      in_mem, up_lev, freq, qid));
+                                      in_mem, up_lev, freq, typename));
   END declare_param;
 
 PROCEDURE declare_temp (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -785,7 +785,7 @@ PROCEDURE declare_local (u: U;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; <*UNUSED*>qid := M3CG.NoQID): Var =
+                         f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
   VAR v := NewVar (u);
   BEGIN
     Cmd   (u, "declare_param");
@@ -799,7 +799,7 @@ PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
     Int   (u, f);
     VName (u, v);
     NL    (u);
-    (* TODO qid but it is not used downstream and can be omitted indefinitely *)
+    (* TODO typename but it is not used downstream and can be omitted indefinitely *)
     RETURN v;
   END declare_param;
 


### PR DESCRIPTION
Mostly my very recent introductions.
Some preexisting.
Retain type QID and constant NoQID.
Type.Name existed (uid to text) so rename
Type.QID to Type.Typename (yuck).

If there was an agreed upon format (e.g. Module__Name),
and needed by more backends, QID here could be M3.ID, but
no preexisting backend uses these, and M3C will soon.