### PR TITLE
m3front: Formal: Add original_type that takes the

### DIFF
--- a/m3-sys/m3front/src/values/Formal.i3
+++ b/m3-sys/m3front/src/values/Formal.i3
@@ -17,7 +17,7 @@ TYPE
     name   : M3ID.T   := M3ID.NoID;
     mode   : Mode     := FIRST (Mode);
     offset : INTEGER  := 0;
-    type   : Type.T   := NIL;
+    type   : Type.T   := NIL; (* original_type *)
     dfault : Expr.T   := NIL;
     unused : BOOLEAN  := FALSE;
     trace  : Tracer.T := NIL;


### PR DESCRIPTION
first non-nil value of type, and then is not
reduced/replaced upon calls to .Check/.CheckInfo.
i.e. it retains NamedType.

Return original_type in Formal.Info.type, so that
splitting and reforming a Formal, as is done, retains the NamedType.

This will lead to duplicate work to reduce the same
types multiple times but that should be ok, not terrible,
and ultimately required.