### PR TITLE
Move entire name:QID to Type instead of

### DIFF
--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -14,7 +14,6 @@ IMPORT Error, Scope, Brand, Value, ErrType;
 TYPE
   P = Type.T BRANDED "NamedType.T" OBJECT
         scope      : Scope.T := NIL;
-        module     := M3ID.NoID; (* QID along with type.info.name *)
         type       : Type.T := NIL;
         obj        : Value.T := NIL;
       OVERRIDES
@@ -44,12 +43,12 @@ PROCEDURE Parse (): Type.T =
       (* this is a non-reserved ID *)
       p := NEW (P);
       TypeRep.Init (p, Type.Class.Named);
-      p.scope      := Scope.Top ();
-      p.info.name  := Scanner.MatchID ();
+      p.scope          := Scope.Top ();
+      p.info.name.item := Scanner.MatchID ();
       IF (Scanner.cur.token = TK.tDOT) THEN
         Scanner.GetToken (); (* . *)
-        p.module     := p.info.name;
-        p.info.name  := Scanner.MatchID ();
+        p.info.name.module := p.info.name.item;
+        p.info.name.item   := Scanner.MatchID ();
       END;
       t := p;
     END;
@@ -76,9 +75,9 @@ PROCEDURE Create (module, name: M3ID.T): Type.T =
   BEGIN
     p := NEW (P);
     TypeRep.Init (p, Type.Class.Named);
-    p.scope      := Scope.Top ();
-    p.module     := module;
-    p.info.name  := name;
+    p.scope        := Scope.Top ();
+    p.info.name.module := module;
+    p.info.name.item   := name;
     RETURN p;
   END Create;
 
@@ -94,8 +93,7 @@ PROCEDURE Split (t: Type.T;  VAR name: M3.QID): BOOLEAN =
   BEGIN
     IF (p = NIL) THEN RETURN FALSE END;
     Resolve (p);
-    name.module := p.module;
-    name.item := p.info.name;
+    name := p.info.name;
     RETURN TRUE;
   END Split;
 
@@ -111,18 +109,14 @@ PROCEDURE SplitV (t: Type.T;  VAR v: Value.T): BOOLEAN =
 
 PROCEDURE Resolve (p: P) =
   VAR o: Value.T;  t: Type.T;  save: INTEGER;
-      typename := M3.NoQID;
   BEGIN
     IF (p.type = NIL) THEN
-      typename.module := p.module;
-      typename.item   := p.info.name;
-      o := Scope.LookUpQID (p.scope, typename);
-      p.module := typename.module;
+      o := Scope.LookUpQID (p.scope, p.info.name);
       p.obj := o;
       IF (o = NIL) THEN
         save := Scanner.offset;
         Scanner.offset := p.origin;
-        Error.QID (typename, "undefined");
+        Error.QID (t.info.name, "undefined");
         Scanner.offset := save;
         t := ErrType.T;
       ELSIF (Value.ClassOf (o) = Value.Class.Type) THEN
@@ -130,7 +124,7 @@ PROCEDURE Resolve (p: P) =
       ELSE
         save := Scanner.offset;
         Scanner.offset := p.origin;
-        Error.QID (typename, "name isn\'t bound to a type");
+        Error.QID (t.info.name, "name isn\'t bound to a type");
         Scanner.offset := save;
         t := ErrType.T;
       END;
@@ -208,9 +202,8 @@ PROCEDURE GenDesc (p: P) =
   END GenDesc;
 
 PROCEDURE FPrinter (p: P;  VAR x: M3.FPInfo) =
-  VAR typename := M3.QID {p.module, p.info.name};
   BEGIN
-    Error.QID (typename, "INTERNAL ERROR: fingerprint of named type");
+    Error.QID (p.info.name, "INTERNAL ERROR: fingerprint of named type");
     Resolve (p);
     IF (p.type # NIL) THEN p.type.fprint (x); END;
   END FPrinter;

--- a/m3-sys/m3front/src/types/Type.i3
+++ b/m3-sys/m3front/src/types/Type.i3
@@ -8,7 +8,7 @@
 
 INTERFACE Type;
 
-IMPORT M3, CG, Target, M3ID;
+IMPORT M3, CG, Target;
 
 TYPE
   T          = M3.Type;
@@ -35,7 +35,8 @@ TYPE
     addr_align: INTEGER := Target.Word8.align;
     (* ^When stk_type = CG.Type.Addr, the alignment of dereferenced location. *)
     hash      : INTEGER;  (* internal hash code *)
-    name      := M3ID.NoID;
+    name      := M3.NoQID; (* usually just one M3ID.T suffices and second could be in derived NamedType,
+                            * but this form is easier *)
     stk_type  : CG.Type;  (* code generator representation on operator stack *)
     mem_type  : CG.Type;  (* code generator representation as a variable *)
     class     : Class;

--- a/m3-sys/m3front/src/types/Type.m3
+++ b/m3-sys/m3front/src/types/Type.m3
@@ -192,10 +192,7 @@ PROCEDURE CheckInfo (t: T;  VAR x: Info): T =
 
 PROCEDURE Typename (t: T; VAR typename: M3.QID) =
 BEGIN
-  IF NOT NamedType.Split (t, typename) THEN
-    typename.module := M3ID.NoID;
-    typename.item := t.info.name;
-  END;
+  typename := t.info.name;
 END Typename;
 
 (************************************************************************)

--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -95,7 +95,7 @@ PROCEDURE Define (name: TEXT;  type: Type.T;  reserved: BOOLEAN) =
   BEGIN
     t := Create (M3ID.Add (name));
     t.value := type;
-    type.info.name := t.name;
+    type.info.name.item := t.name;
     Scope.Insert (t);
     IF (reserved) THEN Scanner.NoteReserved (t.name, t) END;
   END Define;
@@ -106,7 +106,7 @@ PROCEDURE DefineOpaque (name: TEXT;  super: Type.T): Type.T =
     t := Create (M3ID.Add (name));
     Scope.Insert (t);
     t.value := OpaqueType.New (super, t);
-    t.value.info.name := t.name;
+    t.value.info.name.item := t.name;
     Scanner.NoteReserved (t.name, t);
     RETURN t.value;
   END DefineOpaque;


### PR DESCRIPTION
splitting it so all types single element names but
only NamedTypes have module.name. A little wasteful but should be ok.