### PR TITLE
m3front: Variable: Add notion of original_type.

### DIFF
--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -26,6 +26,7 @@ CONST
 REVEAL
   T = Value.T BRANDED "Variable.T" OBJECT
         type        : Type.T    := NIL;
+        original_type: Type.T   := NIL;
         repType     : Type.T    := NIL;
         initExpr    : Expr.T    := NIL;
         qualName    : TEXT      := NIL;
@@ -154,6 +155,7 @@ PROCEDURE ParseDecl (READONLY att: Decl.Attributes) =
         t.unused   := att.isUnused;
         t.obsolete := att.isObsolete;
         t.type     := type;
+        t.original_type := type;
         t.repType  := NIL;
         t.initExpr := expr;
         t.no_type  := (type = NIL);
@@ -191,6 +193,7 @@ PROCEDURE NewFormal (formal: Value.T;  name: M3ID.T): T =
     Formal.Split (formal, f_info);
     t.formal   := formal;
     t.type     := f_info.type;
+    t.original_type := f_info.type;
     t.origin   := formal.origin;
     t.indirect := (f_info.mode # Formal.Mode.mVALUE);
     t.readonly := (f_info.mode = Formal.Mode.mREADONLY);
@@ -223,7 +226,9 @@ PROCEDURE BindType (t: T; type: Type.T;
 (* This gets called at parse time, so can't do any Check. *)
   BEGIN
     <* ASSERT t.type = NIL *>
+    <* ASSERT t.original_type = NIL *>
     t.type     := type;
+    t.original_type := type;
     t.repType  := NIL;
     t.readonly := readonly;
     t.indirect := indirect;
@@ -253,6 +258,7 @@ PROCEDURE HasClosure (t: T): BOOLEAN =
 (* Externally dispatched-to *)
 PROCEDURE TypeOf (t: T): Type.T =
   BEGIN
+    <* ASSERT (t.type # NIL) = (t.original_type # NIL) *>
     IF (t.type = NIL) THEN
       IF t.initExpr # NIL THEN t.type := Expr.TypeOf (t.initExpr)
       ELSIF  t.formal # NIL THEN t.type := Value.TypeOf (t.formal)
@@ -260,9 +266,17 @@ PROCEDURE TypeOf (t: T): Type.T =
       IF (t.type = NIL)
         THEN Error.ID (t.name, "Variable has no type.");  t.type := ErrType.T;
       END;
+      t.original_type := t.type;
     END;
+    <* ASSERT (t.type # NIL) AND (t.original_type # NIL) *>
     RETURN t.type;
   END TypeOf;
+
+PROCEDURE OriginalTypeOf (t: T): Type.T =
+  BEGIN
+    EVAL TypeOf (t);
+    RETURN t.original_type;
+  END OriginalTypeOf;
 
 (* Externally dispatched-to *)
 PROCEDURE RepTypeOf (t: T): Type.T =
@@ -545,6 +559,7 @@ PROCEDURE Declare (t: T): BOOLEAN =
     is_struct  := Type.IsStructured (t.type);
     externName : TEXT;
     externM3ID : M3ID.T;
+    typename   := M3.NoQID;
   BEGIN
     Type.Compile (t.type);
 
@@ -604,16 +619,17 @@ PROCEDURE Declare (t: T): BOOLEAN =
       (* formal passed by reference => param is an address *)
       t.cg_align := t.align;
       t.nextTWACGVar := TsWCGVars;  TsWCGVars := t;
+      (* TODO typename *)
       t.cg_var := CG.Declare_param (t.name, size, align, mtype, typeUID,
                                     t.need_addr, t.up_level, CG.Maybe);
-
     ELSE
       (* simple parameter *)
       (** align := FindAlignment (align, size); **)
       t.cg_align := align;
       t.nextTWACGVar := TsWCGVars;  TsWCGVars := t;
+      Type.Typename (OriginalTypeOf (t), typename);
       t.cg_var := CG.Declare_param (t.name, size, align, mtype, typeUID,
-                                    t.need_addr, t.up_level, CG.Maybe);
+                                    t.need_addr, t.up_level, CG.Maybe, typename);
     END;
 
     RETURN TRUE;


### PR DESCRIPTION
i.e. the value before Check lowers it
i.e. it remains NamedType (if it is NamedType)
and Typename "works" (not a hash).

Starting using it for parameters, though put off
handling indirect parameters briefly.

We should probably introduce TypedValue.T
as a common base of Formal.T and Variable.T, or push
more functionality up to the base Value.T.