### PR TITLE
m3-sys: Add typename to declare_formal.

### DIFF
--- a/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
@@ -1455,7 +1455,7 @@ PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: Typ
     self.debugObj := procRef; (* keep for the formals and raises *)
   END declare_proctype;
 
-PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID) =
+PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
   (* A formal parameter of a procedure type. *) 
   VAR
     procRef : ProcTypeDebug;

--- a/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
@@ -1537,7 +1537,7 @@ PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: Typ
     self.debugObj := procRef; (* keep for the formals and raises *)
   END declare_proctype;
 
-PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID) =
+PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
   (* A formal parameter of a procedure type. *) 
   VAR
     procRef : ProcTypeDebug;

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -1600,7 +1600,7 @@ PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: Typ
     self.debugObj := procRef; (* keep for the formals and raises *)
   END declare_proctype;
 
-PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID) =
+PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
   (* A formal parameter of a procedure type. *) 
   VAR
     procRef : ProcTypeDebug;

--- a/m3-sys/m3back/src/M3C-save1.m3
+++ b/m3-sys/m3back/src/M3C-save1.m3
@@ -911,7 +911,7 @@ BEGIN
     SuppressLineDirective(this, n_formals + (ORD(n_raises >= 0) * n_raises), "declare_proctype n_formals + n_raises");
 END declare_proctype;
 
-<*NOWARN*>PROCEDURE declare_formal(this: T; name: Name; typeid: TypeUID) =
+<*NOWARN*>PROCEDURE declare_formal(this: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) =
 BEGIN
     print(this, "/* declare formal: " & M3ID.ToText(name) & " */\n");
     SuppressLineDirective(this, -1, "declare_formal");

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -3113,13 +3113,15 @@ BEGIN
     x.Type_Init(self.procType);
 END declare_proctype;
 
-PROCEDURE declare_formal(self: DeclareTypes_t; name: Name; typeid: TypeUID) =
+PROCEDURE declare_formal(self: DeclareTypes_t; name: Name; typeid: TypeUID; typename := M3CG.NoQID) =
 VAR x := self.self;
     type := self.procType;
+    qidtext := QidText(typename);
 BEGIN
   IF DebugVerbose(x) THEN
     x.comment("declare_formal name:", NameT(name),
-        " typeid:", TypeIDToText(typeid));
+              " typeid:" & TypeIDToText(typeid),
+              " typename:" & TextOrNil(qidtext));
   ELSE
     x.comment("declare_formal");
   END;

--- a/m3-sys/m3back/src/M3x86.m3
+++ b/m3-sys/m3back/src/M3x86.m3
@@ -572,12 +572,13 @@ PROCEDURE declare_proctype (u: U;  type: TypeUID;  n_formals: INTEGER;
     END
   END declare_proctype;
 
-PROCEDURE declare_formal (u: U;  n: Name;  type: TypeUID) =
+PROCEDURE declare_formal (u: U;  n: Name;  type: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
   BEGIN
     IF u.debug THEN
       u.wr.Cmd   ("declare_formal");
       u.wr.ZName (n);
       u.wr.Tipe  (type);
+      (* TODO typename *)
       u.wr.NL    ();
     END
   END declare_formal;

--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -119,7 +119,7 @@ PROCEDURE Declare_indirect (target: TypeUID): TypeUID;
 PROCEDURE Declare_proctype (t: TypeUID; n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
                             cc: CallingConvention);
-PROCEDURE Declare_formal (n: Name;  t: TypeUID);
+PROCEDURE Declare_formal (n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID);
 PROCEDURE Declare_raises (n: Name);
 
 PROCEDURE Declare_object (t, super: TypeUID;  brand: TEXT;  traced: BOOLEAN;

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -347,9 +347,9 @@ PROCEDURE Declare_proctype (t: TypeUID;  n_formals: INTEGER;
     WebInfo.Declare_proctype (t, n_formals, result, n_raises);
   END Declare_proctype;
 
-PROCEDURE Declare_formal (n: Name;  t: TypeUID) =
+PROCEDURE Declare_formal (n: Name;  t: TypeUID; typename: M3CG.QID) =
   BEGIN
-    cg.declare_formal (n, t);
+    cg.declare_formal (n, t, typename);
     WebInfo.Declare_formal (n, t);
   END Declare_formal;
 

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -308,9 +308,9 @@ PROCEDURE declare_proctype (xx: T; t: TypeUID; n_formals: INTEGER;
     xx.child.declare_proctype (t, n_formals, result, n_raises, cc);
   END declare_proctype;
 
-PROCEDURE declare_formal (xx: T;  n: Name;  t: TypeUID) =
+PROCEDURE declare_formal (xx: T;  n: Name;  t: TypeUID; typename: M3CG.QID) =
   BEGIN
-    xx.child.declare_formal (n, t);
+    xx.child.declare_formal (n, t, typename);
   END declare_formal;
 
 PROCEDURE declare_raises (xx: T;  n: Name) =

--- a/m3-sys/m3middle/src/M3CG_AssertFalse.m3
+++ b/m3-sys/m3middle/src/M3CG_AssertFalse.m3
@@ -240,7 +240,7 @@ END declare_procedure;
 <*NOWARN*>PROCEDURE declare_pointer(self: T; typeid, target_typeid: TypeUID; brand: TEXT; traced: BOOLEAN) = BEGIN AssertFalse(); END declare_pointer;
 <*NOWARN*>PROCEDURE declare_indirect(self: T; typeid, target_typeid: TypeUID) = BEGIN AssertFalse(); END declare_indirect;
 <*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention) = BEGIN AssertFalse(); END declare_proctype;
-<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID) = BEGIN AssertFalse(); END declare_formal;
+<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) = BEGIN AssertFalse(); END declare_formal;
 <*NOWARN*>PROCEDURE declare_raises(self: T; name: Name) = BEGIN AssertFalse(); END declare_raises;
 <*NOWARN*>PROCEDURE declare_object(self: T; typeid, super_typeid: TypeUID; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; field_size: BitSize) = BEGIN AssertFalse(); END declare_object;
 <*NOWARN*>PROCEDURE declare_method(self: T; name: Name; signature: TypeUID) = BEGIN AssertFalse(); END declare_method;

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -628,8 +628,9 @@ PROCEDURE declare_proctype (VAR s: State) =
 PROCEDURE declare_formal (VAR s: State) =
   VAR name := Scan_name (s);
       type := Scan_tipe (s);
+      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
-    s.cg.declare_formal (name, type);
+    s.cg.declare_formal (name, type, typename);
   END declare_formal;
 
 PROCEDURE declare_raises (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -569,11 +569,12 @@ PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
     OutB (u, cc.m3cg_id);
   END declare_proctype;
 
-PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID) =
+PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID; <*UNUSED*>typename: M3CG.QID) =
   BEGIN
     Cmd   (u, Bop.declare_formal);
     ZName (u, n);
     Tipe  (u, t);
+    (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   END declare_formal;
 
 PROCEDURE declare_raises (u: U;  n: Name) =

--- a/m3-sys/m3middle/src/M3CG_DoNothing.m3
+++ b/m3-sys/m3middle/src/M3CG_DoNothing.m3
@@ -185,7 +185,7 @@ END;
 <*NOWARN*>PROCEDURE declare_pointer(self: T; typeid, target_typeid: TypeUID; brand: TEXT; traced: BOOLEAN) = BEGIN END declare_pointer;
 <*NOWARN*>PROCEDURE declare_indirect(self: T; typeid, target_typeid: TypeUID) = BEGIN END declare_indirect;
 <*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention) = BEGIN END declare_proctype;
-<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID) = BEGIN END declare_formal;
+<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) = BEGIN END declare_formal;
 <*NOWARN*>PROCEDURE declare_raises(self: T; name: Name) = BEGIN END declare_raises;
 <*NOWARN*>PROCEDURE declare_object(self: T; typeid, super_typeid: TypeUID; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; field_size: BitSize) = BEGIN END declare_object;
 <*NOWARN*>PROCEDURE declare_method(self: T; name: Name; signature: TypeUID) = BEGIN END declare_method;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -89,7 +89,7 @@ TYPE declare_subrange_t = op_t OBJECT typeid, domain_typeid: typeid_t; min, max:
 TYPE declare_pointer_t = op_t OBJECT typeid, target_typeid: typeid_t; brand: TEXT; traced: BOOLEAN; OVERRIDES replay := replay_declare_pointer END;
 TYPE declare_indirect_t = op_t OBJECT typeid, target_typeid: typeid_t; OVERRIDES replay := replay_declare_indirect END;
 TYPE declare_proctype_t = op_t OBJECT typeid: typeid_t; n_formals: INTEGER; return_typeid: typeid_t; n_raises: INTEGER; callingConvention: CallingConvention; OVERRIDES replay := replay_declare_proctype END;
-TYPE declare_formal_t = op_t OBJECT name: Name; typeid: typeid_t; OVERRIDES replay := replay_declare_formal END;
+TYPE declare_formal_t = op_t OBJECT name: Name; typeid: typeid_t; typename := M3CG.NoQID; OVERRIDES replay := replay_declare_formal END;
 TYPE declare_raises_t = op_t OBJECT name: Name; OVERRIDES replay := replay_declare_raises END;
 TYPE declare_object_t = op_t OBJECT typeid, super_typeid: typeid_t; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; fields_bit_size: BitSize; OVERRIDES replay := replay_declare_object END;
 TYPE declare_method_t = op_t OBJECT name: Name; signature: typeid_t; OVERRIDES replay := replay_declare_method END;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -504,9 +504,9 @@ BEGIN
 self.Add(NEW(declare_proctype_t, op := Op.declare_proctype, typeid := typeid, n_formals := n_formals, return_typeid := return_typeid, n_raises := n_raises, callingConvention := callingConvention));
 END declare_proctype;
 
-PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID) =
+PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename: M3CG.QID) =
 BEGIN
-self.Add(NEW(declare_formal_t, op := Op.declare_formal, name := name, typeid := typeid));
+self.Add(NEW(declare_formal_t, op := Op.declare_formal, name := name, typeid := typeid, typename := typename));
 END declare_formal;
 
 PROCEDURE declare_raises(self: T; name: Name) =
@@ -1147,7 +1147,7 @@ PROCEDURE replay_declare_subrange(self: declare_subrange_t; <*UNUSED*>replay: Re
 PROCEDURE replay_declare_pointer(self: declare_pointer_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_pointer(self.typeid, self.target_typeid, self.brand, self.traced); END replay_declare_pointer;
 PROCEDURE replay_declare_indirect(self: declare_indirect_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_indirect(self.typeid, self.target_typeid); END replay_declare_indirect;
 PROCEDURE replay_declare_proctype(self: declare_proctype_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_proctype(self.typeid, self.n_formals, self. return_typeid, self.n_raises, self.callingConvention); END replay_declare_proctype;
-PROCEDURE replay_declare_formal(self: declare_formal_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_formal(self.name, self.typeid); END replay_declare_formal;
+PROCEDURE replay_declare_formal(self: declare_formal_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_formal(self.name, self.typeid, self.typename); END replay_declare_formal;
 PROCEDURE replay_declare_raises(self: declare_raises_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_raises(self.name); END replay_declare_raises;
 PROCEDURE replay_declare_object(self: declare_object_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_object(self.typeid, self.super_typeid, self.brand, self.traced, self.n_fields, self.n_methods, self.fields_bit_size); END replay_declare_object;
 PROCEDURE replay_declare_method(self: declare_method_t; <*UNUSED*>replay: Replay_t; cg: cg_t) = BEGIN cg.declare_method(self.name, self.signature); END replay_declare_method;

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -127,7 +127,7 @@ declare_proctype (t: TypeUID;  n_formals: INTEGER;
    These occurrences of declare_formal and declare_raises all preceed the next
    occurrence of declare_proctype.  *)
 
-declare_formal (n: Name;  t: TypeUID);
+declare_formal (n: Name;  t: TypeUID; typename := M3CG.NoQID);
 (* A formal of the most recent procedure *type*, i.e., introduced by
    declare_proctype. *) 
 

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -741,8 +741,9 @@ PROCEDURE declare_proctype (VAR s: State) =
 PROCEDURE declare_formal (VAR s: State) =
   VAR name := Scan_name (s);
       type := Scan_tipe (s);
+      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
-    s.cg.declare_formal (name, type);
+    s.cg.declare_formal (name, type, typename);
   END declare_formal;
 
 PROCEDURE declare_raises (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -583,11 +583,12 @@ PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
     NL   (u);
   END declare_proctype;
 
-PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID) =
+PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID; <*UNUSED*>typename: M3CG.QID) =
   BEGIN
     Cmd   (u, "declare_formal");
     ZName (u, n);
     Tipe  (u, t);
+    (* TODO typename but it is not used downstream and can be omitted indefinitely *)
     NL    (u);
   END declare_formal;
 


### PR DESCRIPTION
This might not be needed but it is the right thing.
In particular, this is for function pointer types only,
and if any of those occur where it matters, they can be
replaced entirely instead via their pieces at low implementation
cost, i.e. via the toplevel. We'll see.

Add printing of declare_formal's typename in M3C.
It is never currently passed from m3front.