### PR TITLE
m3-sys: Add result_typename to declare_proctype.

### DIFF
--- a/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
@@ -1440,7 +1440,7 @@ PROCEDURE declare_indirect (self: U; t, target: TypeUID) =
     EVAL self.debugTable.put(t,indirectRef);
   END declare_indirect;
 
-PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention) =
+PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
   VAR
     procRef : ProcTypeDebug;
   BEGIN

--- a/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
@@ -1522,7 +1522,7 @@ PROCEDURE declare_indirect (self: U; t, target: TypeUID) =
     EVAL self.debugTable.put(t,indirectRef);
   END declare_indirect;
 
-PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention) =
+PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
   VAR
     procRef : ProcTypeDebug;
   BEGIN

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -1585,7 +1585,7 @@ PROCEDURE declare_indirect (self: U; t, target: TypeUID) =
     EVAL self.debugTable.put(t,indirectRef);
   END declare_indirect;
 
-PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention) =
+PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
   VAR
     procRef : ProcTypeDebug;
   BEGIN

--- a/m3-sys/m3back/src/M3C-save1.m3
+++ b/m3-sys/m3back/src/M3C-save1.m3
@@ -906,7 +906,7 @@ END declare_indirect;
 <*NOWARN*>PROCEDURE declare_proctype(
     this: T; typeid: TypeUID; n_formals: INTEGER;
     result: TypeUID; n_raises: INTEGER;
-    callingConvention: CallingConvention) =
+    callingConvention: CallingConvention; result_typename: M3CG.QID) =
 BEGIN
     SuppressLineDirective(this, n_formals + (ORD(n_raises >= 0) * n_raises), "declare_proctype n_formals + n_raises");
 END declare_proctype;

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -3090,7 +3090,7 @@ BEGIN
     RETURN Target.ConventionFromID(callingConvention.m3cg_id).name;
 END CallingConventionToText;
 
-PROCEDURE declare_proctype(self: DeclareTypes_t; typeid: TypeUID; param_count: INTEGER; result: TypeUID; raise_count: INTEGER; callingConvention: CallingConvention) =
+PROCEDURE declare_proctype(self: DeclareTypes_t; typeid: TypeUID; param_count: INTEGER; result: TypeUID; raise_count: INTEGER; callingConvention: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
 VAR x := self.self;
 BEGIN
     IF DebugVerbose(x) THEN
@@ -3098,7 +3098,8 @@ BEGIN
             & " param_count:" & IntToDec(param_count)
             & " result:" & TypeIDToText(result)
             & " raise_count:" & IntToDec(raise_count)
-            & " callingConvention:" & CallingConventionToText(callingConvention));
+            & " callingConvention:" & CallingConventionToText(callingConvention)
+            & " result_typename:" & TextOrNil(QidText(result_typename)));
     ELSE
         x.comment("declare_proctype");
     END;
@@ -3116,12 +3117,11 @@ END declare_proctype;
 PROCEDURE declare_formal(self: DeclareTypes_t; name: Name; typeid: TypeUID; typename := M3CG.NoQID) =
 VAR x := self.self;
     type := self.procType;
-    qidtext := QidText(typename);
 BEGIN
   IF DebugVerbose(x) THEN
     x.comment("declare_formal name:", NameT(name),
               " typeid:" & TypeIDToText(typeid),
-              " typename:" & TextOrNil(qidtext));
+              " typename:" & TextOrNil(QidText(typename)));
   ELSE
     x.comment("declare_formal");
   END;

--- a/m3-sys/m3back/src/M3x86.m3
+++ b/m3-sys/m3back/src/M3x86.m3
@@ -559,7 +559,7 @@ PROCEDURE declare_indirect (u: U;  type, target: TypeUID) =
 
 PROCEDURE declare_proctype (u: U;  type: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention) =
+                            cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
   BEGIN
     IF u.debug THEN
       u.wr.Cmd  ("declare_proctype");
@@ -568,11 +568,12 @@ PROCEDURE declare_proctype (u: U;  type: TypeUID;  n_formals: INTEGER;
       u.wr.Tipe (result);
       u.wr.Int  (n_raises);
       u.wr.Txt  (cc.name);
+      (* TODO result_typename *)
       u.wr.NL   ();
     END
   END declare_proctype;
 
-PROCEDURE declare_formal (u: U;  n: Name;  type: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
+PROCEDURE declare_formal (u: U;  n: Name;  type: TypeUID; <*UNUSED*>typename: M3CG.QID) =
   BEGIN
     IF u.debug THEN
       u.wr.Cmd   ("declare_formal");

--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -118,7 +118,7 @@ PROCEDURE Declare_indirect (target: TypeUID): TypeUID;
 
 PROCEDURE Declare_proctype (t: TypeUID; n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention);
+                            cc: CallingConvention; <*UNUSED*>result_typename := M3CG.NoQID);
 PROCEDURE Declare_formal (n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID);
 PROCEDURE Declare_raises (n: Name);
 

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -341,9 +341,9 @@ PROCEDURE Declare_indirect (target: TypeUID): TypeUID =
 
 PROCEDURE Declare_proctype (t: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention) =
+                            cc: CallingConvention; result_typename: M3CG.QID) =
   BEGIN
-    cg.declare_proctype (t, n_formals, result, n_raises, cc);
+    cg.declare_proctype (t, n_formals, result, n_raises, cc, result_typename);
     WebInfo.Declare_proctype (t, n_formals, result, n_raises);
   END Declare_proctype;
 

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -254,7 +254,7 @@ PROCEDURE Compiler (p: P) =
     END;
     n_raises := ESet.EmitTypes (p.raises);
     CG.Declare_proctype (Type.GlobalUID (p), n_formals, result_id, n_raises,
-                         p.callConv);
+                         p.callConv); (* TODO result_typename *)
     v := Scope.ToList (p.formals);
     WHILE (v # NIL) DO
       Formal.EmitDeclaration (v, FALSE, FALSE);

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -303,9 +303,9 @@ PROCEDURE declare_indirect (xx: T;  t, target: TypeUID) =
 
 PROCEDURE declare_proctype (xx: T; t: TypeUID; n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention) =
+                            cc: CallingConvention; result_typename: M3CG.QID) =
   BEGIN
-    xx.child.declare_proctype (t, n_formals, result, n_raises, cc);
+    xx.child.declare_proctype (t, n_formals, result, n_raises, cc, result_typename);
   END declare_proctype;
 
 PROCEDURE declare_formal (xx: T;  n: Name;  t: TypeUID; typename: M3CG.QID) =

--- a/m3-sys/m3middle/src/M3CG_AssertFalse.m3
+++ b/m3-sys/m3middle/src/M3CG_AssertFalse.m3
@@ -239,7 +239,7 @@ END declare_procedure;
 <*NOWARN*>PROCEDURE declare_subrange(self: T; typeid, domain_typeid: TypeUID; READONLY min, max: Target.Int; bit_size: BitSize) = BEGIN AssertFalse(); END declare_subrange;
 <*NOWARN*>PROCEDURE declare_pointer(self: T; typeid, target_typeid: TypeUID; brand: TEXT; traced: BOOLEAN) = BEGIN AssertFalse(); END declare_pointer;
 <*NOWARN*>PROCEDURE declare_indirect(self: T; typeid, target_typeid: TypeUID) = BEGIN AssertFalse(); END declare_indirect;
-<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention) = BEGIN AssertFalse(); END declare_proctype;
+<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: M3CG.QID) = BEGIN AssertFalse(); END declare_proctype;
 <*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) = BEGIN AssertFalse(); END declare_formal;
 <*NOWARN*>PROCEDURE declare_raises(self: T; name: Name) = BEGIN AssertFalse(); END declare_raises;
 <*NOWARN*>PROCEDURE declare_object(self: T; typeid, super_typeid: TypeUID; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; field_size: BitSize) = BEGIN AssertFalse(); END declare_object;

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -621,8 +621,9 @@ PROCEDURE declare_proctype (VAR s: State) =
       result    := Scan_tipe (s);
       n_raises  := Scan_int (s);
       calling   := Scan_callConv (s);
+      result_typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
-    s.cg.declare_proctype (type, n_formals, result, n_raises, calling);
+    s.cg.declare_proctype (type, n_formals, result, n_raises, calling, result_typename);
   END declare_proctype;
 
 PROCEDURE declare_formal (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -559,7 +559,7 @@ PROCEDURE declare_indirect (u: U;  t, target: TypeUID) =
 
 PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention) =
+                            cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
   BEGIN
     Cmd  (u, Bop.declare_proctype);
     Tipe (u, t);
@@ -567,6 +567,7 @@ PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
     Tipe (u, result);
     Int  (u, n_raises);
     OutB (u, cc.m3cg_id);
+    (* TODO result_typename but it is not used downstream *)
   END declare_proctype;
 
 PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID; <*UNUSED*>typename: M3CG.QID) =

--- a/m3-sys/m3middle/src/M3CG_DoNothing.m3
+++ b/m3-sys/m3middle/src/M3CG_DoNothing.m3
@@ -184,7 +184,7 @@ END;
 <*NOWARN*>PROCEDURE declare_subrange(self: T; typeid, domain_typeid: TypeUID; READONLY min, max: Target.Int; bit_size: BitSize) = BEGIN END declare_subrange;
 <*NOWARN*>PROCEDURE declare_pointer(self: T; typeid, target_typeid: TypeUID; brand: TEXT; traced: BOOLEAN) = BEGIN END declare_pointer;
 <*NOWARN*>PROCEDURE declare_indirect(self: T; typeid, target_typeid: TypeUID) = BEGIN END declare_indirect;
-<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention) = BEGIN END declare_proctype;
+<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: M3CG.QID) = BEGIN END declare_proctype;
 <*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) = BEGIN END declare_formal;
 <*NOWARN*>PROCEDURE declare_raises(self: T; name: Name) = BEGIN END declare_raises;
 <*NOWARN*>PROCEDURE declare_object(self: T; typeid, super_typeid: TypeUID; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; field_size: BitSize) = BEGIN END declare_object;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -88,7 +88,7 @@ TYPE declare_set_t = op_t OBJECT typeid, domain_typeid: typeid_t; bit_size: BitS
 TYPE declare_subrange_t = op_t OBJECT typeid, domain_typeid: typeid_t; min, max: Target.Int; bit_size: BitSize; OVERRIDES replay := replay_declare_subrange END;
 TYPE declare_pointer_t = op_t OBJECT typeid, target_typeid: typeid_t; brand: TEXT; traced: BOOLEAN; OVERRIDES replay := replay_declare_pointer END;
 TYPE declare_indirect_t = op_t OBJECT typeid, target_typeid: typeid_t; OVERRIDES replay := replay_declare_indirect END;
-TYPE declare_proctype_t = op_t OBJECT typeid: typeid_t; n_formals: INTEGER; return_typeid: typeid_t; n_raises: INTEGER; callingConvention: CallingConvention; OVERRIDES replay := replay_declare_proctype END;
+TYPE declare_proctype_t = op_t OBJECT typeid: typeid_t; n_formals: INTEGER; return_typeid: typeid_t; n_raises: INTEGER; callingConvention: CallingConvention; result_typename := M3CG.NoQID; OVERRIDES replay := replay_declare_proctype END;
 TYPE declare_formal_t = op_t OBJECT name: Name; typeid: typeid_t; typename := M3CG.NoQID; OVERRIDES replay := replay_declare_formal END;
 TYPE declare_raises_t = op_t OBJECT name: Name; OVERRIDES replay := replay_declare_raises END;
 TYPE declare_object_t = op_t OBJECT typeid, super_typeid: typeid_t; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; fields_bit_size: BitSize; OVERRIDES replay := replay_declare_object END;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -499,9 +499,9 @@ BEGIN
 self.Add(NEW(declare_indirect_t, op := Op.declare_indirect, typeid := typeid, target_typeid := target_typeid));
 END declare_indirect;
 
-PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; return_typeid: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention) =
+PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; return_typeid: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: M3CG.QID) =
 BEGIN
-self.Add(NEW(declare_proctype_t, op := Op.declare_proctype, typeid := typeid, n_formals := n_formals, return_typeid := return_typeid, n_raises := n_raises, callingConvention := callingConvention));
+self.Add(NEW(declare_proctype_t, op := Op.declare_proctype, typeid := typeid, n_formals := n_formals, return_typeid := return_typeid, n_raises := n_raises, callingConvention := callingConvention, result_typename := result_typename));
 END declare_proctype;
 
 PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename: M3CG.QID) =

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -120,7 +120,7 @@ declare_indirect (t, target: TypeUID);
 
 declare_proctype (t: TypeUID;  n_formals: INTEGER;
                   result: TypeUID;  n_raises: INTEGER;
-                  cc: CallingConvention);
+                  cc: CallingConvention; result_typename := M3CG.NoQID);
 (* Procedure type.  The subsequent n_formals occurrences of declare_formal
    define the formal parameters.  The subsequent n_raises occurrences of
    declare_raises are names of raised exceptions.  n_raises < 0 => RAISES ANY.

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -734,8 +734,9 @@ PROCEDURE declare_proctype (VAR s: State) =
       result    := Scan_tipe (s);
       n_raises  := Scan_int (s);
       calling   := Scan_callConv (s);
+      result_typename := M3CG.NoQID; (* TODO result_typename but it is not used downstream *)
   BEGIN
-    s.cg.declare_proctype (type, n_formals, result, n_raises, calling);
+    s.cg.declare_proctype (type, n_formals, result, n_raises, calling, result_typename);
   END declare_proctype;
 
 PROCEDURE declare_formal (VAR s: State) =

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -572,7 +572,7 @@ PROCEDURE declare_indirect (u: U;  t, target: TypeUID) =
 
 PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention) =
+                            cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
   BEGIN
     Cmd  (u, "declare_proctype");
     Tipe (u, t);
@@ -580,6 +580,7 @@ PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
     Tipe (u, result);
     Int  (u, n_raises);
     Int  (u, cc.m3cg_id);
+    (* TODO result_typename but it is not used downstream *)
     NL   (u);
   END declare_proctype;
 


### PR DESCRIPTION
Again like declare_formal this might not be important and might not get filled in, but it is the right thing.