### PR TITLE
m3-sys: Use shortands for QID and NoQID, remove default parameters for typename:QID mostly.

### DIFF
--- a/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm3.6.1/src/M3CG_LLVM.m3
@@ -38,6 +38,7 @@ IMPORT Target;
 IMPORT TargetMap;
 IMPORT TFloat;
 IMPORT TInt;
+FROM M3CG IMPORT QID;
 
 (* Pervasive ASSUMPTION: Modula-3 NIL = C++ null pointer. *) 
 
@@ -1440,7 +1441,7 @@ PROCEDURE declare_indirect (self: U; t, target: TypeUID) =
     EVAL self.debugTable.put(t,indirectRef);
   END declare_indirect;
 
-PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
+PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: QID) =
   VAR
     procRef : ProcTypeDebug;
   BEGIN
@@ -1455,7 +1456,7 @@ PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: Typ
     self.debugObj := procRef; (* keep for the formals and raises *)
   END declare_proctype;
 
-PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
+PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename: QID) =
   (* A formal parameter of a procedure type. *) 
   VAR
     procRef : ProcTypeDebug;
@@ -1761,7 +1762,7 @@ to check this. Perhaps the front end could supply the correct type. *)
     RETURN size;    
   END ImportedStructSize;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename: QID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR
@@ -2045,7 +2046,7 @@ PROCEDURE init_float (self: U;  o: ByteOffset;  READONLY f: Target.Float) =
 
 (*------------------------------------------------------------ procedures ---*)
 
-PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; return_typename := M3CG.NoQID): Proc =
+PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; return_typename: QID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,-1,cc,FALSE,NIL);
     name : TEXT;
@@ -2082,7 +2083,7 @@ PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: 
 PROCEDURE declare_procedure (self: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
                              cc: CallingConvention; exported: BOOLEAN;
-                             parent: Proc; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                             parent: Proc; <*UNUSED*>return_typename: QID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,lev,cc,exported,parent);
   BEGIN

--- a/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm5/src/M3CG_LLVM.m3
@@ -45,6 +45,7 @@ IMPORT Target;
 IMPORT TargetMap;
 IMPORT TFloat;
 IMPORT TInt, TWord;
+FROM M3CG IMPORT QID;
 
 <*FATAL ANY*>
 
@@ -1522,7 +1523,7 @@ PROCEDURE declare_indirect (self: U; t, target: TypeUID) =
     EVAL self.debugTable.put(t,indirectRef);
   END declare_indirect;
 
-PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
+PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: QID) =
   VAR
     procRef : ProcTypeDebug;
   BEGIN
@@ -1537,7 +1538,7 @@ PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: Typ
     self.debugObj := procRef; (* keep for the formals and raises *)
   END declare_proctype;
 
-PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
+PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename: QID) =
   (* A formal parameter of a procedure type. *) 
   VAR
     procRef : ProcTypeDebug;
@@ -1854,7 +1855,7 @@ PROCEDURE declare_local
     RETURN v;
   END declare_local;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename: QID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR
@@ -2123,7 +2124,7 @@ PROCEDURE init_float (self: U;  o: ByteOffset;  READONLY f: Target.Float) =
 (*------------------------------------------------------------ procedures ---*)
 
 PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;
-                            cc: CallingConvention; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                            cc: CallingConvention; <*UNUSED*>return_typename: QID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,-1,cc,FALSE,NIL);
     name : TEXT;
@@ -2161,7 +2162,7 @@ PROCEDURE declare_procedure (
     self: U;  n: Name;  n_params: INTEGER;
     return_type: Type;  lev: INTEGER;
     cc: CallingConvention; exported: BOOLEAN;
-    parent: Proc; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+    parent: Proc; <*UNUSED*>return_typename: QID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,lev,cc,exported,parent);
   BEGIN

--- a/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm9/src/M3CG_LLVM.m3
@@ -50,6 +50,7 @@ IMPORT Target;
 IMPORT TargetMap;
 IMPORT TFloat;
 IMPORT TInt, TWord;
+FROM M3CG IMPORT QID;
 
 <*FATAL ANY*>
 
@@ -1585,7 +1586,7 @@ PROCEDURE declare_indirect (self: U; t, target: TypeUID) =
     EVAL self.debugTable.put(t,indirectRef);
   END declare_indirect;
 
-PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
+PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: TypeUID;  n_raises: INTEGER; cc: CallingConvention; <*UNUSED*>result_typename: QID) =
   VAR
     procRef : ProcTypeDebug;
   BEGIN
@@ -1600,7 +1601,7 @@ PROCEDURE declare_proctype (self: U; t: TypeUID; n_formals: INTEGER; result: Typ
     self.debugObj := procRef; (* keep for the formals and raises *)
   END declare_proctype;
 
-PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID) =
+PROCEDURE declare_formal (self: U; n: Name;  t: TypeUID; <*UNUSED*>typename: QID) =
   (* A formal parameter of a procedure type. *) 
   VAR
     procRef : ProcTypeDebug;
@@ -1917,7 +1918,7 @@ PROCEDURE declare_local
     RETURN v;
   END declare_local;
 
-PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
+PROCEDURE declare_param (self: U;  n: Name;  s: ByteSize;  a: Alignment; t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN; f: Frequency; <*UNUSED*>typename: QID): Var =
   (* A formal parameter of a procedure, not of a procedure type, (which
      is given by declare_formal). *) 
   VAR
@@ -2185,7 +2186,7 @@ PROCEDURE init_float (self: U;  o: ByteOffset;  READONLY f: Target.Float) =
 
 (*------------------------------------------------------------ procedures ---*)
 
-PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: Type;  cc: CallingConvention; <*UNUSED*>return_typename: QID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,-1,cc,FALSE,NIL);
     name : TEXT;
@@ -2228,7 +2229,7 @@ PROCEDURE import_procedure (self: U;  n: Name;  n_params: INTEGER; return_type: 
 PROCEDURE declare_procedure (self: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
                              cc: CallingConvention; exported: BOOLEAN;
-                             parent: Proc; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                             parent: Proc; <*UNUSED*>return_typename: QID): Proc =
   VAR
     p : LvProc := NewProc(self,n,n_params,return_type,lev,cc,exported,parent);
   BEGIN

--- a/m3-sys/m3back/src/M3C-save1.m3
+++ b/m3-sys/m3back/src/M3C-save1.m3
@@ -13,6 +13,7 @@ FROM M3CG IMPORT CompareOp, ConvertOp, RuntimeError, MemoryOrder, AtomicOp;
 FROM Target IMPORT CGType;
 FROM M3CG_Ops IMPORT ErrorHandler;
 IMPORT Wrx86, M3ID, TInt;
+FROM M3CG IMPORT QID;
 (*
 IMPORT Wrx86, M3ID, M3CField, M3CFieldSeq;
 IMPORT SortedIntRefTbl;
@@ -906,12 +907,12 @@ END declare_indirect;
 <*NOWARN*>PROCEDURE declare_proctype(
     this: T; typeid: TypeUID; n_formals: INTEGER;
     result: TypeUID; n_raises: INTEGER;
-    callingConvention: CallingConvention; result_typename: M3CG.QID) =
+    callingConvention: CallingConvention; result_typename: QID) =
 BEGIN
     SuppressLineDirective(this, n_formals + (ORD(n_raises >= 0) * n_raises), "declare_proctype n_formals + n_raises");
 END declare_proctype;
 
-<*NOWARN*>PROCEDURE declare_formal(this: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) =
+<*NOWARN*>PROCEDURE declare_formal(this: T; name: Name; typeid: TypeUID; typename: QID) =
 BEGIN
     print(this, "/* declare formal: " & M3ID.ToText(name) & " */\n");
     SuppressLineDirective(this, -1, "declare_formal");
@@ -1326,7 +1327,7 @@ PROCEDURE declare_procedure (this: T; name: Name; n_params: INTEGER;
                              return_type: Type; level: INTEGER;
                              callingConvention: CallingConvention;
                              exported: BOOLEAN; parent: Proc;
-                             <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                             <*UNUSED*>return_typename: QID): Proc =
 VAR proc := NEW(CProc, name := FixName(name), n_params := n_params,
                 return_type := return_type, level := level,
                 callingConvention := callingConvention, exported := exported,

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -3090,7 +3090,7 @@ BEGIN
     RETURN Target.ConventionFromID(callingConvention.m3cg_id).name;
 END CallingConventionToText;
 
-PROCEDURE declare_proctype(self: DeclareTypes_t; typeid: TypeUID; param_count: INTEGER; result: TypeUID; raise_count: INTEGER; callingConvention: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
+PROCEDURE declare_proctype(self: DeclareTypes_t; typeid: TypeUID; param_count: INTEGER; result: TypeUID; raise_count: INTEGER; callingConvention: CallingConvention; result_typename: QID) =
 VAR x := self.self;
 BEGIN
     IF DebugVerbose(x) THEN
@@ -3114,7 +3114,7 @@ BEGIN
     x.Type_Init(self.procType);
 END declare_proctype;
 
-PROCEDURE declare_formal(self: DeclareTypes_t; name: Name; typeid: TypeUID; typename := M3CG.NoQID) =
+PROCEDURE declare_formal(self: DeclareTypes_t; name: Name; typeid: TypeUID; typename: QID) =
 VAR x := self.self;
     type := self.procType;
 BEGIN
@@ -4197,7 +4197,7 @@ PROCEDURE Locals_declare_param(
     <*UNUSED*>in_memory: BOOLEAN;
     up_level: BOOLEAN;
     <*UNUSED*>frequency: Frequency;
-    typename := NoQID): M3CG.Var =
+    typename: QID): M3CG.Var =
 BEGIN
     RETURN declare_param(
         self.self,
@@ -4285,7 +4285,7 @@ PROCEDURE Imports_import_procedure(
     parameter_count: INTEGER;
     return_type: CGType;
     callingConvention: CallingConvention;
-    return_typename := NoQID): M3CG.Proc =
+    return_typename: QID): M3CG.Proc =
 BEGIN
     RETURN import_procedure(self.self, name, parameter_count, return_type, callingConvention, return_typename);
 END Imports_import_procedure;
@@ -4300,7 +4300,7 @@ PROCEDURE Imports_declare_param(
     <*UNUSED*>in_memory: BOOLEAN;
     up_level: BOOLEAN;
     <*UNUSED*>frequency: Frequency;
-    typename := NoQID): M3CG.Var =
+    typename: QID): M3CG.Var =
 BEGIN
     RETURN declare_param(
         self.self,
@@ -4487,7 +4487,7 @@ PROCEDURE GetStructSizes_declare_param(
     <*UNUSED*>in_memory: BOOLEAN;
     <*UNUSED*>up_level: BOOLEAN;
     <*UNUSED*>frequency: Frequency;
-    <*UNUSED*>typename := NoQID): M3CG.Var =
+    <*UNUSED*>typename: QID): M3CG.Var =
 BEGIN
     RETURN self.Declare(type, byte_size, alignment);
 END GetStructSizes_declare_param;
@@ -4775,7 +4775,7 @@ declare_param(
     type: CGType;
     typeid: TypeUID;
     up_level: BOOLEAN;
-    typename := NoQID): M3CG.Var =
+    typename: QID): M3CG.Var =
 BEGIN
     IF self.param_proc = NIL THEN
         RETURN NIL;
@@ -5228,7 +5228,7 @@ END Segments_init_float;
 PROCEDURE import_procedure(
     self: T; name: Name; parameter_count: INTEGER;
     return_type: CGType; callingConvention: CallingConvention;
-    return_typename := NoQID): M3CG.Proc =
+    return_typename: QID): M3CG.Proc =
 VAR proc := NEW(Proc_t, name := name, parameter_count := parameter_count,
                 return_type := return_type, imported := TRUE,
                 callingConvention := callingConvention).Init(self);
@@ -5265,7 +5265,7 @@ PROCEDURE Locals_declare_procedure(
     callingConvention: CallingConvention;
     exported: BOOLEAN;
     parent: M3CG.Proc;
-    return_typename := NoQID): M3CG.Proc =
+    return_typename: QID): M3CG.Proc =
 BEGIN
     RETURN declare_procedure(
         self.self,
@@ -5292,7 +5292,7 @@ PROCEDURE declare_procedure(
     return_type: CGType; level: INTEGER;
     callingConvention: CallingConvention;
     exported: BOOLEAN; parent: M3CG.Proc;
-    return_typename := NoQID): M3CG.Proc =
+    return_typename: QID): M3CG.Proc =
 VAR proc := NEW(Proc_t, name := name, parameter_count := parameter_count,
                 return_type := return_type, level := level,
                 callingConvention := callingConvention, exported := exported,

--- a/m3-sys/m3back/src/M3x86.m3
+++ b/m3-sys/m3back/src/M3x86.m3
@@ -17,7 +17,7 @@ FROM TargetMap IMPORT CG_Bytes;
 FROM M3CG IMPORT Name, ByteOffset, TypeUID, CallingConvention;
 FROM M3CG IMPORT BitSize, ByteSize, Alignment, Frequency;
 FROM M3CG IMPORT Var, Proc, Label, No_label, Sign, BitOffset;
-FROM M3CG IMPORT Type, ZType, AType, RType, IType, MType;
+FROM M3CG IMPORT Type, ZType, AType, RType, IType, MType, QID, NoQID;
 FROM M3CG IMPORT CompareOp, ConvertOp, RuntimeError, MemoryOrder, AtomicOp;
 
 FROM M3CG_Ops IMPORT ErrorHandler;
@@ -559,7 +559,7 @@ PROCEDURE declare_indirect (u: U;  type, target: TypeUID) =
 
 PROCEDURE declare_proctype (u: U;  type: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
+                            cc: CallingConvention; <*UNUSED*>result_typename: QID) =
   BEGIN
     IF u.debug THEN
       u.wr.Cmd  ("declare_proctype");
@@ -573,7 +573,7 @@ PROCEDURE declare_proctype (u: U;  type: TypeUID;  n_formals: INTEGER;
     END
   END declare_proctype;
 
-PROCEDURE declare_formal (u: U;  n: Name;  type: TypeUID; <*UNUSED*>typename: M3CG.QID) =
+PROCEDURE declare_formal (u: U;  n: Name;  type: TypeUID; <*UNUSED*>typename: QID) =
   BEGIN
     IF u.debug THEN
       u.wr.Cmd   ("declare_formal");
@@ -878,7 +878,7 @@ PROCEDURE mangle_procname (base: M3ID.T; arg_size: INTEGER;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          type: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
+                         f: Frequency; <*UNUSED*>typename := NoQID): Var =
   VAR v := NewVar(u, type, m3t, s, 4, n);
   BEGIN
     (* Assume a = 4 and ESP is dword aligned... *)
@@ -1281,7 +1281,7 @@ END IsAlloca;
 
 PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
                             ret_type: Type;  cc: CallingConvention;
-                            <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                            <*UNUSED*>return_typename := NoQID): Proc =
   VAR p := NewProc (u, n, n_params, ret_type, cc);
   BEGIN
     p.import := TRUE;
@@ -1317,7 +1317,7 @@ PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
 PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
                              cc: CallingConvention; exported: BOOLEAN;
-                             parent: Proc; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                             parent: Proc; <*UNUSED*>return_typename: QID): Proc =
   VAR p := NewProc (u, n, n_params, return_type, cc);
   BEGIN
     p.exported := exported;

--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -9,6 +9,7 @@
 INTERFACE CG;
 
 IMPORT Target, M3CG, M3;
+FROM M3CG IMPORT NoQID;
 
 (*
 This interface provides a single front-end specific, sometimes
@@ -118,8 +119,8 @@ PROCEDURE Declare_indirect (target: TypeUID): TypeUID;
 
 PROCEDURE Declare_proctype (t: TypeUID; n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention; <*UNUSED*>result_typename := M3CG.NoQID);
-PROCEDURE Declare_formal (n: Name;  t: TypeUID; <*UNUSED*>typename := M3CG.NoQID);
+                            cc: CallingConvention; <*UNUSED*>result_typename := NoQID);
+PROCEDURE Declare_formal (n: Name;  t: TypeUID; <*UNUSED*>typename := NoQID);
 PROCEDURE Declare_raises (n: Name);
 
 PROCEDURE Declare_object (t, super: TypeUID;  brand: TEXT;  traced: BOOLEAN;
@@ -200,7 +201,7 @@ PROCEDURE Declare_local (n: Name;  s: Size;  a: Alignment;  t: Type;
 
 PROCEDURE Declare_param (n: Name;  s: Size;  a: Alignment;  t: Type;
                          m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; typename := M3.NoQID): Var;
+                         f: Frequency; typename := NoQID): Var;
 (* declares a formal parameter.  Formals are declared in their lexical
    order immediately following the 'declare_procedure' or
    'import_procedure' that contains them.  *)
@@ -319,7 +320,7 @@ PROCEDURE EmitText (t: TEXT;  is_const: BOOLEAN): INTEGER;
 PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                             cc: CallingConvention;
                             VAR(*OUT*) new: BOOLEAN;
-                            return_typename := M3.NoQID): Proc;
+                            return_typename := NoQID): Proc;
 (* declare and import the external procedure with name 'n' and 'n_params'
    formal parameters.  It must be a top-level (=0) procedure that returns
    values of type 'ret_type'.  'cc' is the convention specified
@@ -329,7 +330,7 @@ PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
 PROCEDURE Declare_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                              lev: INTEGER;  cc: CallingConvention;
                              exported: BOOLEAN;  parent: Proc;
-                             return_typename := M3CG.NoQID): Proc;
+                             return_typename := NoQID): Proc;
 (* declare a procedure named 'n' with 'n_params' formal parameters
    at static level 'lev'.  Sets "current procedure" to this procedure.
    If the name 'n' is NIL, a new unique name will be supplied by the back-end.

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -12,6 +12,7 @@ IMPORT Text, IntIntTbl, IntRefTbl, Fmt, Word;
 IMPORT Scanner, Error, Module, RunTyme, WebInfo;
 IMPORT M3, M3CG, M3CG_Ops, M3CG_Check;
 IMPORT Host, Target, TInt, TFloat, TWord, TargetMap, M3RT (**, RTObject **);
+FROM M3CG IMPORT QID;
 
 CONST
   Max_init_chars = 256; (* max size of a single init_chars string *)
@@ -341,13 +342,13 @@ PROCEDURE Declare_indirect (target: TypeUID): TypeUID =
 
 PROCEDURE Declare_proctype (t: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention; result_typename: M3CG.QID) =
+                            cc: CallingConvention; result_typename: QID) =
   BEGIN
     cg.declare_proctype (t, n_formals, result, n_raises, cc, result_typename);
     WebInfo.Declare_proctype (t, n_formals, result, n_raises);
   END Declare_proctype;
 
-PROCEDURE Declare_formal (n: Name;  t: TypeUID; typename: M3CG.QID) =
+PROCEDURE Declare_formal (n: Name;  t: TypeUID; typename: QID) =
   BEGIN
     cg.declare_formal (n, t, typename);
     WebInfo.Declare_formal (n, t);
@@ -492,7 +493,7 @@ PROCEDURE Declare_local (n: Name;  s: Size;  a: Alignment;  t: Type;
 
 PROCEDURE Declare_param (n: Name;  s: Size;  a: Alignment;  t: Type;
                          m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; typename := M3CG.NoQID): Var =
+                         f: Frequency; typename: QID): Var =
   BEGIN
     RETURN cg.declare_param (n, ToVarSize (s, a), ByteAlign (a),
                              t, m3t, in_memory, up_level, f, typename);
@@ -1359,7 +1360,7 @@ PROCEDURE EmitText (t: TEXT;  is_const: BOOLEAN): INTEGER =
 PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                             cc: CallingConvention;
                             VAR(*OUT*) new: BOOLEAN;
-                            return_typename := M3CG.NoQID): Proc =
+                            return_typename: QID): Proc =
   VAR ref: REFANY;  p: Proc;
   BEGIN
     IF (procedures = NIL) THEN procedures := NewNameTbl() END;
@@ -1373,7 +1374,7 @@ PROCEDURE Import_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
 PROCEDURE Declare_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
                              lev: INTEGER;  cc: CallingConvention;
                              exported: BOOLEAN;  parent: Proc;
-                             return_typename := M3CG.NoQID): Proc =
+                             return_typename: QID): Proc =
   VAR p: Proc;
   BEGIN
     IF (procedures = NIL) THEN procedures := NewNameTbl() END;

--- a/m3-sys/m3front/src/misc/ESet.i3
+++ b/m3-sys/m3front/src/misc/ESet.i3
@@ -8,6 +8,7 @@
 INTERFACE ESet;
 
 IMPORT M3, Value, Scope, CG;
+FROM M3CG IMPORT QID;
 
 TYPE
   T = M3.ExSet;
@@ -24,7 +25,7 @@ PROCEDURE RaisesNone (t: T): BOOLEAN;
 
 PROCEDURE NewAny (): T;
 PROCEDURE NewEmpty (env: Scope.T): T;
-PROCEDURE Add (t: T;  READONLY name: M3.QID;   ex: Value.T);
+PROCEDURE Add (t: T;  READONLY name: QID;   ex: Value.T);
 
 PROCEDURE IsEqual (a, b: T): BOOLEAN;
 (* TRUE iff 'a' equals 'b' *)

--- a/m3-sys/m3front/src/misc/ESet.m3
+++ b/m3-sys/m3front/src/misc/ESet.m3
@@ -10,6 +10,7 @@ MODULE ESet;
 IMPORT M3, M3ID, CG, Value, Token, Scope, Scanner, M3Buf;
 IMPORT Error, Word, Exceptionz, Target, Module;
 FROM Scanner IMPORT Match, MatchID, GetToken, cur;
+FROM M3CG IMPORT QID;
 
 TYPE TList = M3.ExSetList;
 REVEAL
@@ -33,7 +34,7 @@ REVEAL
 TYPE
   Elt = BRANDED "ESet.Elt" REF RECORD
     origin : INTEGER;
-    name   : M3.QID;
+    name   : QID;
     except : Value.T;
     next   : Elt;
     used   : BOOLEAN;
@@ -248,7 +249,7 @@ PROCEDURE NewEmpty (env: Scope.T): T =
     RETURN NEW (T, env := env, origin := Scanner.offset);
   END NewEmpty;
 
-PROCEDURE Add (t: T;  READONLY name: M3.QID;   ex: Value.T) =
+PROCEDURE Add (t: T;  READONLY name: QID;   ex: Value.T) =
   VAR e: Elt;
   BEGIN
     ex := Value.Base (ex);

--- a/m3-sys/m3front/src/misc/Error.i3
+++ b/m3-sys/m3front/src/misc/Error.i3
@@ -8,13 +8,13 @@
 
 INTERFACE Error;
 
-IMPORT M3, M3ID;
+IMPORT M3ID, M3CG;
 
 (* Msg, Int, ID, QID, Txt are all implicitly level 3. *)
 PROCEDURE Msg (msg: TEXT);
 PROCEDURE Int (n: INTEGER;  msg: TEXT);
 PROCEDURE ID  (id: M3ID.T;  msg: TEXT);
-PROCEDURE QID (READONLY q: M3.QID;  msg: TEXT);
+PROCEDURE QID (READONLY q: M3CG.QID;  msg: TEXT);
 PROCEDURE Txt (str, msg: TEXT);
 
 (* Despite the names Warn and WarnId, these can be any level. *)

--- a/m3-sys/m3front/src/misc/Error.m3
+++ b/m3-sys/m3front/src/misc/Error.m3
@@ -8,7 +8,7 @@
 
 MODULE Error;
 
-IMPORT M3, Fmt, M3ID, M3Buf, Host, Scanner;
+IMPORT Fmt, M3ID, M3Buf, Host, Scanner, M3CG;
 
 TYPE
   Level = [0..3];
@@ -65,7 +65,7 @@ PROCEDURE Txt (id, msg: TEXT) =
     Trailer (wr);
   END Txt;
 
-PROCEDURE QID (READONLY q: M3.QID;  msg: TEXT) =
+PROCEDURE QID (READONLY q: M3CG.QID;  msg: TEXT) =
   VAR wr := Header ();
   BEGIN
     Out (wr, msg);

--- a/m3-sys/m3front/src/misc/M3.i3
+++ b/m3-sys/m3front/src/misc/M3.i3
@@ -11,13 +11,10 @@
 
 INTERFACE M3;
 
-IMPORT M3ID, M3Buf, Jmpbufs, M3CG;
+IMPORT M3Buf, Jmpbufs;
 
 TYPE
   Flag = BITS 1 FOR BOOLEAN;
-
-  QID  = M3CG.QID; (* module qualified name *)
-  CONST NoQID = M3CG.NoQID;
 
 (*------------------------------------------------------------- AST nodes ---*)
 

--- a/m3-sys/m3front/src/misc/RunTyme.m3
+++ b/m3-sys/m3front/src/misc/RunTyme.m3
@@ -4,8 +4,8 @@
 
 MODULE RunTyme;
 
-IMPORT M3, M3ID, Value, ValueRep, Scope, Module, Error, Procedure;
-IMPORT CG, M3RT, Target, TInt;
+IMPORT M3ID, Value, ValueRep, Scope, Module, Error, Procedure;
+IMPORT CG, M3RT, Target, TInt, M3CG;
 
 CONST
   RunTimeModuleName = "RTHooks";
@@ -94,7 +94,7 @@ PROCEDURE LookUp (name: M3ID.T): Value.T =
       ELSE v := NIL; (* probably a circular import! *)
     END;
     IF (v = NIL) THEN
-      Error.QID (M3.QID {module := hooks_name, item := name},
+      Error.QID (M3CG.QID {module := hooks_name, item := name},
                   "undefined runtime symbol !!")
     END;
 

--- a/m3-sys/m3front/src/misc/Scanner.m3
+++ b/m3-sys/m3front/src/misc/Scanner.m3
@@ -9,7 +9,7 @@ UNSAFE MODULE Scanner;
 IMPORT Text, Fmt, File, OSError, TextIntTbl, Word;
 IMPORT M3, M3ID, Error, M3String, M3WString, Token;
 IMPORT Target, TInt, TWord, TFloat, Host, M3Buf;
-IMPORT WCharr, CharSeq, CharSeqRep;
+IMPORT CharSeq, CharSeqRep;
 
 CONST
   MaxStack  = 40;

--- a/m3-sys/m3front/src/misc/Scope.i3
+++ b/m3-sys/m3front/src/misc/Scope.i3
@@ -9,6 +9,7 @@
 INTERFACE Scope;
 
 IMPORT M3, M3ID, M3Buf, Value;
+FROM M3CG IMPORT QID;
 
 TYPE
   T = M3.Scope;
@@ -29,7 +30,7 @@ PROCEDURE Top  (): T;
 PROCEDURE Insert (o: Value.T);
 
 PROCEDURE LookUp    (t: T;  name: M3ID.T;  strict: BOOLEAN): Value.T;
-PROCEDURE LookUpQID (t: T;  VAR q: M3.QID): Value.T;
+PROCEDURE LookUpQID (t: T;  VAR q: QID): Value.T;
 
 PROCEDURE ToList     (t: T): Value.T;
 PROCEDURE OuterMost  (t: T): BOOLEAN;

--- a/m3-sys/m3front/src/misc/Scope.m3
+++ b/m3-sys/m3front/src/misc/Scope.m3
@@ -10,6 +10,7 @@ MODULE Scope;
 
 IMPORT M3, M3ID, M3Buf, CG, Value, Module, Error, Procedure;
 IMPORT Scanner, ValueRep, Variable, Tracer, Convert;
+FROM M3CG IMPORT QID;
 
 CONST
   MinHashed = 30;
@@ -106,7 +107,7 @@ PROCEDURE OuterMost (t: T) : BOOLEAN =
     RETURN (t # NIL) AND (t.module);
   END OuterMost;
 
-PROCEDURE LookUpQID (t: T;  VAR q: M3.QID): Value.T =
+PROCEDURE LookUpQID (t: T;  VAR q: QID): Value.T =
   VAR v: Value.T := NIL;
   BEGIN
     IF (q.module = M3ID.NoID) THEN

--- a/m3-sys/m3front/src/stmts/RaiseStmt.m3
+++ b/m3-sys/m3front/src/stmts/RaiseStmt.m3
@@ -8,13 +8,14 @@
 
 MODULE RaiseStmt;
 
-IMPORT M3, M3ID, Expr, Token, Scanner, Stmt, StmtRep, Error, ESet;
+IMPORT M3ID, Expr, Token, Scanner, Stmt, StmtRep, Error, ESet;
 IMPORT Value, Type, Scope, Exceptionz, AssignStmt;
+FROM M3CG IMPORT QID;
 
 TYPE
   P = Stmt.T OBJECT
         scope   : Scope.T;
-        qid     : M3.QID;
+        qid     : QID;
         except  : Value.T;
         arg     : Expr.T;
       OVERRIDES

--- a/m3-sys/m3front/src/stmts/TryStmt.m3
+++ b/m3-sys/m3front/src/stmts/TryStmt.m3
@@ -8,10 +8,11 @@
 
 MODULE TryStmt;
 
-IMPORT M3, M3ID, CG, Variable, Scope, Exceptionz, Value, Error, Marker;
+IMPORT M3ID, CG, Variable, Scope, Exceptionz, Value, Error, Marker;
 IMPORT Type, Stmt, StmtRep, TryFinStmt, Token;
 IMPORT Scanner, ESet, Target, M3RT, Tracer, Jmpbufs;
 FROM Scanner IMPORT Match, MatchID, GetToken, Fail, cur;
+FROM M3CG IMPORT QID;
 
 TYPE
   P = Stmt.T OBJECT
@@ -43,7 +44,7 @@ TYPE
 TYPE
   Except = REF RECORD
              next : Except;
-             name : M3.QID;
+             name : QID;
              obj  : Value.T;
            END;
 

--- a/m3-sys/m3front/src/types/NamedType.i3
+++ b/m3-sys/m3front/src/types/NamedType.i3
@@ -8,7 +8,8 @@
 
 INTERFACE NamedType;
 
-IMPORT M3, M3ID, Type, Value;
+IMPORT M3ID, Type, Value;
+FROM M3CG IMPORT QID;
 
 PROCEDURE Parse (): Type.T;
 
@@ -16,7 +17,7 @@ PROCEDURE New (t: Type.T): Type.T;
 PROCEDURE Create (module, name: M3ID.T): Type.T;
 
 PROCEDURE Strip (t: Type.T): Type.T;
-PROCEDURE Split (t: Type.T;  VAR name: M3.QID): BOOLEAN;
+PROCEDURE Split (t: Type.T;  VAR name: QID): BOOLEAN;
 PROCEDURE SplitV (t: Type.T;  VAR v: Value.T): BOOLEAN;
 
 END NamedType.

--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -10,6 +10,7 @@ MODULE NamedType;
 
 IMPORT M3, M3ID, Token, Type, TypeRep, Scanner, ObjectType;
 IMPORT Error, Scope, Brand, Value, ErrType;
+FROM M3CG IMPORT QID;
 
 TYPE
   P = Type.T BRANDED "NamedType.T" OBJECT
@@ -88,7 +89,7 @@ PROCEDURE Reduce (t: Type.T): P =
     RETURN t;
   END Reduce;
 
-PROCEDURE Split (t: Type.T;  VAR name: M3.QID): BOOLEAN =
+PROCEDURE Split (t: Type.T;  VAR name: QID): BOOLEAN =
   VAR p := Reduce (t);
   BEGIN
     IF (p = NIL) THEN RETURN FALSE END;

--- a/m3-sys/m3front/src/types/ProcType.i3
+++ b/m3-sys/m3front/src/types/ProcType.i3
@@ -9,6 +9,7 @@
 INTERFACE ProcType;
 
 IMPORT M3, M3ID, CG, Type, Value, CallExpr;
+FROM M3CG IMPORT QID;
 
 PROCEDURE Parse          (): Type.T;
 PROCEDURE ParseSignature (name: M3ID.T;  cc: CG.CallingConvention): Type.T;
@@ -19,7 +20,7 @@ PROCEDURE Is        (t: Type.T): BOOLEAN;
 PROCEDURE NFormals  (t: Type.T): INTEGER;
 PROCEDURE Formals   (t: Type.T): Value.T (*list*);
 PROCEDURE Result    (t: Type.T): Type.T;
-PROCEDURE ResultTypename (t: Type.T): M3.QID;
+PROCEDURE ResultTypename (t: Type.T): QID;
 PROCEDURE CGResult  (t: Type.T): CG.Type;
 PROCEDURE Raises    (t: Type.T): M3.ExSet;
 PROCEDURE Methods   (t: Type.T): CallExpr.MethodList;

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -9,9 +9,10 @@
 MODULE ProcType;
 
 IMPORT M3, M3ID, CG, Expr, Type, TypeRep, Value, Scope, Target;
-IMPORT Formal, UserProc, Token, Ident, CallExpr, Word, Error, NamedType;
+IMPORT Formal, UserProc, Token, Ident, CallExpr, Word, Error;
 IMPORT ESet, TipeMap, TipeDesc, ErrType, M3Buf, Variable, OpenArrayType;
 FROM Scanner IMPORT Match, GetToken, cur;
+FROM M3CG IMPORT QID, NoQID;
 
 TYPE
   P = Type.T BRANDED "ProcType.T" OBJECT
@@ -21,7 +22,7 @@ TYPE
         result     : Type.T;
         raises     : ESet.T;
         callConv   : CG.CallingConvention;
-        result_typename := M3.NoQID;
+        result_typename := NoQID;
       OVERRIDES
         check      := Check;
         no_straddle:= TypeRep.AddrNoStraddle;
@@ -377,13 +378,13 @@ PROCEDURE Result (t: Type.T): Type.T =
     END;
   END Result;
 
-PROCEDURE ResultTypename (t: Type.T): M3.QID =
+PROCEDURE ResultTypename (t: Type.T): QID =
   VAR p := Reduce (t);
   BEGIN
     Type.Compile (t);
     IF (p # NIL)
       THEN RETURN p.result_typename;
-      ELSE RETURN M3.NoQID;
+      ELSE RETURN NoQID;
     END;
   END ResultTypename;
 

--- a/m3-sys/m3front/src/types/Type.i3
+++ b/m3-sys/m3front/src/types/Type.i3
@@ -9,6 +9,7 @@
 INTERFACE Type;
 
 IMPORT M3, CG, Target;
+FROM M3CG IMPORT QID, NoQID;
 
 TYPE
   T          = M3.Type;
@@ -35,8 +36,8 @@ TYPE
     addr_align: INTEGER := Target.Word8.align;
     (* ^When stk_type = CG.Type.Addr, the alignment of dereferenced location. *)
     hash      : INTEGER;  (* internal hash code *)
-    name      := M3.NoQID; (* usually just one M3ID.T suffices and second could be in derived NamedType,
-                            * but this form is easier *)
+    name      := NoQID;   (* usually just one M3ID.T suffices and second could be in derived NamedType,
+                           * but this form is easier *)
     stk_type  : CG.Type;  (* code generator representation on operator stack *)
     mem_type  : CG.Type;  (* code generator representation as a variable *)
     class     : Class;
@@ -103,7 +104,7 @@ PROCEDURE IsLazyAligned (t: T): BOOLEAN;
 
 PROCEDURE SetLazyAlignment (t: T; on: BOOLEAN);
 
-PROCEDURE Typename (t: T; VAR typename: M3.QID);
+PROCEDURE Typename (t: T; VAR typename: QID);
 
 (*** phase 3 ***)
 

--- a/m3-sys/m3front/src/types/Type.m3
+++ b/m3-sys/m3front/src/types/Type.m3
@@ -8,13 +8,14 @@
 
 UNSAFE MODULE Type EXPORTS Type, TypeRep;
 
-IMPORT M3, CG, Error, Token, Scanner, NamedType, Word;
+IMPORT CG, Error, Token, Scanner, NamedType, Word;
 IMPORT ArrayType, PackedType, EnumType, ObjectType, RefType;
 IMPORT ProcType, UserProc, RecordType, SetType, SubrangeType, OpaqueType;
 IMPORT Value, Module, Host, TypeFP, TypeTbl, WCharr, Brand;
 IMPORT Addr, Bool, Charr, Card, EReel, Int, LInt, LReel, Mutex, Null;
 IMPORT ObjectRef, ObjectAdr, Reel, Reff, Textt, Target, TInt, TFloat;
 IMPORT Text, M3RT, TipeMap, TipeDesc, ErrType, OpenArrayType, M3ID;
+FROM M3CG IMPORT QID;
 
 CONST
   NOT_CHECKED = -1;
@@ -190,7 +191,7 @@ PROCEDURE CheckInfo (t: T;  VAR x: Info): T =
     RETURN u;
   END CheckInfo;
 
-PROCEDURE Typename (t: T; VAR typename: M3.QID) =
+PROCEDURE Typename (t: T; VAR typename: QID) =
 BEGIN
   typename := t.info.name;
 END Typename;
@@ -478,7 +479,7 @@ PROCEDURE GetBounds (t: T;  VAR min, max: Target.Int): BOOLEAN =
   END GetBounds;
 
 PROCEDURE IllegalRecursion (t: T) =
-  VAR name: M3.QID;  v: Value.T;
+  VAR name: QID;  v: Value.T;
   BEGIN
     IF (t.errored) THEN
       (* don't reissue the error message *)

--- a/m3-sys/m3front/src/values/External.m3
+++ b/m3-sys/m3front/src/values/External.m3
@@ -7,9 +7,10 @@
 
 MODULE External;
 
-IMPORT M3, M3ID, Value, ValueRep, Token, Scope, Module, Error;
+IMPORT M3ID, Value, ValueRep, Token, Scope, Module, Error;
 IMPORT Type, Expr, Variable, Ident, Scanner, RunTyme, CG, Host;
 FROM Scanner IMPORT GetToken, Match, MatchID, cur;
+FROM M3CG IMPORT QID;
 
 TYPE TK = Token.T;
 
@@ -246,7 +247,7 @@ PROCEDURE ResolveImports (s: Set;  self: Module.T) =
           t.obj   := v;
           t.class := v.class;
         ELSE
-          Error.QID (M3.QID {module := p.name, item := t.name},
+          Error.QID (QID {module := p.name, item := t.name},
                       "symbol not exported")
         END;
       END;

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -12,6 +12,7 @@ IMPORT M3, M3ID, CG, Value, ValueRep, Type, Error, Expr, ProcType;
 IMPORT KeywordExpr, OpenArrayType, RefType, CheckExpr, PackedType;
 IMPORT ArrayType, ArrayExpr, SetType, Host, NarrowExpr, M3Buf, Tracer;
 IMPORT Variable, Procedure, UserProc, Target, M3RT, NamedType;
+FROM M3CG IMPORT NoQID;
 
 TYPE
   T = Value.T BRANDED OBJECT 
@@ -110,7 +111,7 @@ PROCEDURE EmitDeclaration (formal: Value.T;  types_only, param: BOOLEAN) =
     size     : CG.Size;
     align    : CG.Alignment;
     info     : Type.Info;
-    typename := M3.NoQID;
+    typename := NoQID;
   BEGIN
     IF (types_only) THEN
       Compile (t);

--- a/m3-sys/m3front/src/values/Procedure.m3
+++ b/m3-sys/m3front/src/values/Procedure.m3
@@ -14,6 +14,7 @@ IMPORT ProcType, Stmt, BlockStmt, Marker, Coverage, M3RT;
 IMPORT CallExpr, Token, Variable, ProcExpr, Tracer;
 IMPORT Scanner, Decl, ESet, ProcBody, Target, Expr, Formal, Jmpbufs;
 FROM Scanner IMPORT GetToken, Match, MatchID, cur;
+FROM M3CG IMPORT QID;
 
 REVEAL
   T = Value.T BRANDED OBJECT
@@ -393,7 +394,7 @@ PROCEDURE LoadStaticLink (t: T) =
  END LoadStaticLink;
 
 PROCEDURE ImportProc (p: T;  name: TEXT;  n_formals: INTEGER;
-                      cg_result: CG.Type; return_typename := M3.NoQID;
+                      cg_result: CG.Type; return_typename: QID;
                       cc: CG.CallingConvention) =
   VAR zz: Scope.T;  new: BOOLEAN;
   BEGIN

--- a/m3-sys/m3front/src/values/Revelation.m3
+++ b/m3-sys/m3front/src/values/Revelation.m3
@@ -8,17 +8,18 @@
 
 MODULE Revelation;
 
-IMPORT M3, M3ID, Value, Type, Error, OpaqueType, Scope, Decl, Host;
+IMPORT M3ID, Value, Type, Error, OpaqueType, Scope, Decl, Host;
 IMPORT ObjectType, RefType, Scanner, Token, Module, ValueRep, CG;
 IMPORT M3RT, Target, Reff;
 IMPORT PersistentRevelation, PersistentRevelationArraySort, PersistentRevelationSeq, PersistentRevelationSeqRep;
 FROM Scanner IMPORT GetToken, Fail, Match, MatchID, cur;
+FROM M3CG IMPORT QID;
 
 TYPE
   T = BRANDED "Revelation.T" REF RECORD
         home    : Value.T; (* the containing interface or module *)
         env     : Scope.T;
-        qid     : M3.QID;
+        qid     : QID;
         obj     : Value.T; (* value named by 'qid' in scope 'env' *)
         rhs     : Type.T;  (* REVEAL qid (<:|=) rhs *)
         lhs     : Type.T;  (* == type that corresponds to qid *)

--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -11,6 +11,7 @@ MODULE Tipe;
 IMPORT M3, M3ID, CG, Value, ValueRep, Scope, OpaqueType, WebInfo, TypeRep;
 IMPORT Token, Type, Decl, Scanner, NamedType, RefType, ObjectType, Module;
 FROM Scanner IMPORT GetToken, Fail, Match, MatchID, cur;
+FROM M3CG IMPORT QID;
 
 TYPE
   T = Value.T BRANDED "Tipe.T" OBJECT 
@@ -112,7 +113,7 @@ PROCEDURE DefineOpaque (name: TEXT;  super: Type.T): Type.T =
   END DefineOpaque;
 
 PROCEDURE Check (t: T;  <*UNUSED*> VAR cs: Value.CheckState) =
-  VAR info: Type.Info;  initial := t.value;  typename: M3.QID;  name: TEXT;
+  VAR info: Type.Info;  initial := t.value;  typename: QID;  name: TEXT;
   BEGIN
     t.value := Type.CheckInfo (t.value, info);
 

--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -17,6 +17,7 @@ IMPORT Decl, Null, Int, LInt, Fmt, Procedure, Tracer;
 IMPORT Expr, IntegerExpr, ArrayExpr, TextExpr, NamedExpr;
 IMPORT Type, OpenArrayType, ErrType, TipeMap;
 FROM Scanner IMPORT GetToken, Match, cur;
+FROM M3CG IMPORT NoQID;
 
 CONST
   Big_Local = 8192; (* x Target.Char.size *)
@@ -559,7 +560,7 @@ PROCEDURE Declare (t: T): BOOLEAN =
     is_struct  := Type.IsStructured (t.type);
     externName : TEXT;
     externM3ID : M3ID.T;
-    typename   := M3.NoQID;
+    typename   := NoQID;
   BEGIN
     Type.Compile (t.type);
 

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -8,7 +8,7 @@
 MODULE M3CG EXPORTS M3CG, M3CG_Ops;
 
 IMPORT Text, Word; 
-IMPORT Target, M3CG;
+IMPORT Target;
 
 REVEAL
   T = Public BRANDED "M3CG.T" OBJECT OVERRIDES
@@ -303,12 +303,12 @@ PROCEDURE declare_indirect (xx: T;  t, target: TypeUID) =
 
 PROCEDURE declare_proctype (xx: T; t: TypeUID; n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention; result_typename: M3CG.QID) =
+                            cc: CallingConvention; result_typename: QID) =
   BEGIN
     xx.child.declare_proctype (t, n_formals, result, n_raises, cc, result_typename);
   END declare_proctype;
 
-PROCEDURE declare_formal (xx: T;  n: Name;  t: TypeUID; typename: M3CG.QID) =
+PROCEDURE declare_formal (xx: T;  n: Name;  t: TypeUID; typename: QID) =
   BEGIN
     xx.child.declare_formal (n, t, typename);
   END declare_formal;
@@ -401,7 +401,7 @@ PROCEDURE declare_local (xx: T;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (xx: T;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; typename := M3CG.NoQID): Var =
+                         f: Frequency; typename: QID): Var =
   BEGIN
     RETURN xx.child.declare_param (n, s, a, t, m3t, in_memory, up_level, f, typename);
   END declare_param;
@@ -469,7 +469,7 @@ PROCEDURE init_float (xx: T;  o: ByteOffset;  READONLY f: Target.Float) =
 
 PROCEDURE import_procedure (xx: T;  n: Name;  n_params: INTEGER;
                           ret_type: Type;  cc: CallingConvention;
-                          return_typename := M3CG.NoQID): Proc =
+                          return_typename: QID): Proc =
   BEGIN
     RETURN xx.child.import_procedure (n, n_params, ret_type, cc, return_typename);
   END import_procedure;
@@ -478,7 +478,7 @@ PROCEDURE declare_procedure (xx: T;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
                              cc: CallingConvention;
                              exported: BOOLEAN;  parent: Proc;
-                             return_typename := M3CG.NoQID): Proc =
+                             return_typename: QID): Proc =
   BEGIN
     RETURN xx.child.declare_procedure (n, n_params, return_type,
                                        lev, cc, exported, parent,

--- a/m3-sys/m3middle/src/M3CG_AssertFalse.m3
+++ b/m3-sys/m3middle/src/M3CG_AssertFalse.m3
@@ -8,6 +8,7 @@ FROM M3CG IMPORT Var, Proc, Label, Sign, BitOffset;
 FROM M3CG IMPORT Type, ZType, AType, RType, IType, MType;
 FROM M3CG IMPORT CompareOp, ConvertOp, AtomicOp, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
+FROM M3CG IMPORT QID;
 
 REVEAL
 T = Public BRANDED "M3CG_AssertFalse.T" OBJECT
@@ -196,7 +197,7 @@ AssertFalse();
 RETURN NIL;
 END declare_local;
 
-<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID): Var =
+<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename: QID): Var =
 BEGIN
 AssertFalse();
 RETURN NIL;
@@ -208,13 +209,13 @@ AssertFalse();
 RETURN NIL;
 END declare_temp;
 
-<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_typename := M3CG.NoQID): Proc =
+<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_typename: QID): Proc =
 BEGIN
 AssertFalse();
 RETURN NIL;
 END import_procedure;
 
-<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_typename := M3CG.NoQID): Proc =
+<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_typename: QID): Proc =
 BEGIN
 AssertFalse();
 RETURN NIL;
@@ -239,8 +240,8 @@ END declare_procedure;
 <*NOWARN*>PROCEDURE declare_subrange(self: T; typeid, domain_typeid: TypeUID; READONLY min, max: Target.Int; bit_size: BitSize) = BEGIN AssertFalse(); END declare_subrange;
 <*NOWARN*>PROCEDURE declare_pointer(self: T; typeid, target_typeid: TypeUID; brand: TEXT; traced: BOOLEAN) = BEGIN AssertFalse(); END declare_pointer;
 <*NOWARN*>PROCEDURE declare_indirect(self: T; typeid, target_typeid: TypeUID) = BEGIN AssertFalse(); END declare_indirect;
-<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: M3CG.QID) = BEGIN AssertFalse(); END declare_proctype;
-<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) = BEGIN AssertFalse(); END declare_formal;
+<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: QID) = BEGIN AssertFalse(); END declare_proctype;
+<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename: QID) = BEGIN AssertFalse(); END declare_formal;
 <*NOWARN*>PROCEDURE declare_raises(self: T; name: Name) = BEGIN AssertFalse(); END declare_raises;
 <*NOWARN*>PROCEDURE declare_object(self: T; typeid, super_typeid: TypeUID; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; field_size: BitSize) = BEGIN AssertFalse(); END declare_object;
 <*NOWARN*>PROCEDURE declare_method(self: T; name: Name; signature: TypeUID) = BEGIN AssertFalse(); END declare_method;

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -7,6 +7,7 @@ IMPORT Fmt, Rd, Stdio, Text, Thread, Word, Wr;
 IMPORT M3ID, M3CG, M3CG_Ops, M3CG_Binary;
 IMPORT Target, TargetMap, TInt, TFloat, TWord;
 FROM M3CG IMPORT CompareOp, ConvertOp, AtomicOp, RuntimeError, MemoryOrder;
+FROM M3CG IMPORT NoQID;
 
 TYPE
   Bop = M3CG_Binary.Op;
@@ -621,7 +622,7 @@ PROCEDURE declare_proctype (VAR s: State) =
       result    := Scan_tipe (s);
       n_raises  := Scan_int (s);
       calling   := Scan_callConv (s);
-      result_typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
+      result_typename := NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     s.cg.declare_proctype (type, n_formals, result, n_raises, calling, result_typename);
   END declare_proctype;
@@ -629,7 +630,7 @@ PROCEDURE declare_proctype (VAR s: State) =
 PROCEDURE declare_formal (VAR s: State) =
   VAR name := Scan_name (s);
       type := Scan_tipe (s);
-      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
+      typename := NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     s.cg.declare_formal (name, type, typename);
   END declare_formal;
@@ -798,7 +799,7 @@ PROCEDURE declare_param (VAR s: State) =
       up_lev := Scan_bool (s);
       freq   := Scan_int (s);
       v      := Scan_int (s);
-      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
+      typename := NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddVar (s, v, s.cg.declare_param (name, size, align, type, m3t,
                                       in_mem, up_lev, freq, typename));

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -13,6 +13,7 @@ FROM M3CG IMPORT Var, Proc, Label, Sign, BitOffset;
 FROM M3CG IMPORT Type, ZType, AType, RType, IType, MType;
 FROM M3CG IMPORT CompareOp, ConvertOp, AtomicOp, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
+FROM M3CG IMPORT QID, NoQID;
 
 TYPE Bop    = M3CG_Binary.Op;
 TYPE WrVar  = Var    OBJECT tag: INTEGER END;
@@ -559,7 +560,7 @@ PROCEDURE declare_indirect (u: U;  t, target: TypeUID) =
 
 PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
+                            cc: CallingConvention; <*UNUSED*>result_typename: QID) =
   BEGIN
     Cmd  (u, Bop.declare_proctype);
     Tipe (u, t);
@@ -570,7 +571,7 @@ PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
     (* TODO result_typename but it is not used downstream *)
   END declare_proctype;
 
-PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID; <*UNUSED*>typename: M3CG.QID) =
+PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID; <*UNUSED*>typename: QID) =
   BEGIN
     Cmd   (u, Bop.declare_formal);
     ZName (u, n);
@@ -759,7 +760,7 @@ PROCEDURE declare_local (u: U;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
+                         f: Frequency; <*UNUSED*>typename := NoQID): Var =
   VAR v := NewVar (u);
   BEGIN
     Cmd   (u, Bop.declare_param);
@@ -872,7 +873,7 @@ PROCEDURE NewProc (u: U): Proc =
 
 PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
                             ret_type: Type; cc: CallingConvention;
-                            <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                            <*UNUSED*>return_typename := NoQID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, Bop.import_procedure);
@@ -887,7 +888,7 @@ PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
 PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
                              cc: CallingConvention; exported: BOOLEAN;
-                             parent: Proc; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                             parent: Proc; <*UNUSED*>return_typename := NoQID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, Bop.declare_procedure);

--- a/m3-sys/m3middle/src/M3CG_DoNothing.m3
+++ b/m3-sys/m3middle/src/M3CG_DoNothing.m3
@@ -8,6 +8,7 @@ FROM M3CG IMPORT Var, Proc, Label, Sign, BitOffset;
 FROM M3CG IMPORT Type, ZType, AType, RType, IType, MType;
 FROM M3CG IMPORT CompareOp, ConvertOp, AtomicOp, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
+FROM M3CG IMPORT QID, NoQID;
 
 REVEAL
 T = Public BRANDED "M3CG_DoNothing.T" OBJECT
@@ -161,10 +162,10 @@ END;
 <*NOWARN*>PROCEDURE declare_global(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; exported, inited: BOOLEAN): Var = BEGIN RETURN NIL; END declare_global;
 <*NOWARN*>PROCEDURE declare_constant(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; exported, inited: BOOLEAN): Var = BEGIN RETURN NIL; END declare_constant;
 <*NOWARN*>PROCEDURE declare_local(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency): Var = BEGIN RETURN NIL; END declare_local;
-<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID): Var = BEGIN RETURN NIL; END declare_param;
+<*NOWARN*>PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := NoQID): Var = BEGIN RETURN NIL; END declare_param;
 <*NOWARN*>PROCEDURE declare_temp(self: T; byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN): Var = BEGIN RETURN NIL; END declare_temp;
-<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_typename := M3CG.NoQID): Proc = BEGIN RETURN NIL; END import_procedure;
-<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_typename := M3CG.NoQID): Proc = BEGIN RETURN NIL; END declare_procedure;
+<*NOWARN*>PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; ret_type: Type; callingConvention: CallingConvention; return_typename := NoQID): Proc = BEGIN RETURN NIL; END import_procedure;
+<*NOWARN*>PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_typename := NoQID): Proc = BEGIN RETURN NIL; END declare_procedure;
 <*NOWARN*>PROCEDURE set_error_handler(self: T; p: M3CG_Ops.ErrorHandler) = BEGIN END set_error_handler;
 <*NOWARN*>PROCEDURE begin_unit(self: T; optimize: INTEGER) = BEGIN END begin_unit;
 <*NOWARN*>PROCEDURE end_unit(self: T) = BEGIN END end_unit;
@@ -184,8 +185,8 @@ END;
 <*NOWARN*>PROCEDURE declare_subrange(self: T; typeid, domain_typeid: TypeUID; READONLY min, max: Target.Int; bit_size: BitSize) = BEGIN END declare_subrange;
 <*NOWARN*>PROCEDURE declare_pointer(self: T; typeid, target_typeid: TypeUID; brand: TEXT; traced: BOOLEAN) = BEGIN END declare_pointer;
 <*NOWARN*>PROCEDURE declare_indirect(self: T; typeid, target_typeid: TypeUID) = BEGIN END declare_indirect;
-<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: M3CG.QID) = BEGIN END declare_proctype;
-<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename := M3CG.NoQID) = BEGIN END declare_formal;
+<*NOWARN*>PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; result: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: QID) = BEGIN END declare_proctype;
+<*NOWARN*>PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename := NoQID) = BEGIN END declare_formal;
 <*NOWARN*>PROCEDURE declare_raises(self: T; name: Name) = BEGIN END declare_raises;
 <*NOWARN*>PROCEDURE declare_object(self: T; typeid, super_typeid: TypeUID; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; field_size: BitSize) = BEGIN END declare_object;
 <*NOWARN*>PROCEDURE declare_method(self: T; name: Name; signature: TypeUID) = BEGIN END declare_method;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -15,6 +15,7 @@ FROM M3CG IMPORT Frequency, CallingConvention, CompareOp, ConvertOp, AtomicOp;
 FROM M3CG IMPORT BitSize, ByteSize, BitOffset, ByteOffset, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
 FROM M3CG_Binary IMPORT Op;
+FROM M3CG IMPORT QID, NoQID;
 
 TYPE cg_t = M3CG.T;
 TYPE typeid_t = M3CG.TypeUID;
@@ -54,15 +55,15 @@ TYPE op_tag_t = op_t OBJECT
 END;
 
 (* These create procs. *)
-TYPE import_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; return_typename := M3CG.NoQID; OVERRIDES replay := replay_import_procedure END;
-TYPE declare_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: INTEGER(*proc_t*); return_typename := M3CG.NoQID; OVERRIDES replay := replay_declare_procedure END;
+TYPE import_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; return_typename := NoQID; OVERRIDES replay := replay_import_procedure END;
+TYPE declare_procedure_t = op_tag_t OBJECT name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: INTEGER(*proc_t*); return_typename := NoQID; OVERRIDES replay := replay_declare_procedure END;
 
 (* These create vars. *)
 TYPE declare_segment_t = op_tag_t OBJECT name: Name; typeid: typeid_t; is_const: BOOLEAN; OVERRIDES replay := replay_declare_segment END;
 TYPE declare_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; exported, inited: BOOLEAN; OVERRIDES replay := replay_declare_global END;
 TYPE declare_constant_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; exported, inited: BOOLEAN; OVERRIDES replay := replay_declare_constant END;
 TYPE declare_local_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; OVERRIDES replay := replay_declare_local END;
-TYPE declare_param_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID; OVERRIDES replay := replay_declare_param END;
+TYPE declare_param_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := NoQID; OVERRIDES replay := replay_declare_param END;
 TYPE declare_temp_t = op_tag_t OBJECT byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN; OVERRIDES replay := replay_declare_temp END;
 TYPE import_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; OVERRIDES replay := replay_import_global END;
 
@@ -88,8 +89,8 @@ TYPE declare_set_t = op_t OBJECT typeid, domain_typeid: typeid_t; bit_size: BitS
 TYPE declare_subrange_t = op_t OBJECT typeid, domain_typeid: typeid_t; min, max: Target.Int; bit_size: BitSize; OVERRIDES replay := replay_declare_subrange END;
 TYPE declare_pointer_t = op_t OBJECT typeid, target_typeid: typeid_t; brand: TEXT; traced: BOOLEAN; OVERRIDES replay := replay_declare_pointer END;
 TYPE declare_indirect_t = op_t OBJECT typeid, target_typeid: typeid_t; OVERRIDES replay := replay_declare_indirect END;
-TYPE declare_proctype_t = op_t OBJECT typeid: typeid_t; n_formals: INTEGER; return_typeid: typeid_t; n_raises: INTEGER; callingConvention: CallingConvention; result_typename := M3CG.NoQID; OVERRIDES replay := replay_declare_proctype END;
-TYPE declare_formal_t = op_t OBJECT name: Name; typeid: typeid_t; typename := M3CG.NoQID; OVERRIDES replay := replay_declare_formal END;
+TYPE declare_proctype_t = op_t OBJECT typeid: typeid_t; n_formals: INTEGER; return_typeid: typeid_t; n_raises: INTEGER; callingConvention: CallingConvention; result_typename := NoQID; OVERRIDES replay := replay_declare_proctype END;
+TYPE declare_formal_t = op_t OBJECT name: Name; typeid: typeid_t; typename := NoQID; OVERRIDES replay := replay_declare_formal END;
 TYPE declare_raises_t = op_t OBJECT name: Name; OVERRIDES replay := replay_declare_raises END;
 TYPE declare_object_t = op_t OBJECT typeid, super_typeid: typeid_t; brand: TEXT; traced: BOOLEAN; n_fields, n_methods: INTEGER; fields_bit_size: BitSize; OVERRIDES replay := replay_declare_object END;
 TYPE declare_method_t = op_t OBJECT name: Name; signature: typeid_t; OVERRIDES replay := replay_declare_method END;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -7,6 +7,7 @@ FROM M3CG IMPORT Frequency, CallingConvention, CompareOp, ConvertOp, AtomicOp;
 FROM M3CG IMPORT BitSize, ByteSize, BitOffset, ByteOffset, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
 FROM M3CG_Binary IMPORT Op;
+FROM M3CG IMPORT QID, NoQID;
 
 TYPE var_t = Var OBJECT tag: INTEGER END;
 TYPE proc_t = Proc OBJECT tag: INTEGER END;
@@ -367,7 +368,7 @@ self.Add(NEW(declare_local_t, op := Op.declare_local, name := name, byte_size :=
 RETURN var;
 END declare_local;
 
-PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3CG.NoQID): Var =
+PROCEDURE declare_param(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := NoQID): Var =
 VAR var := self.refs.NewVar();
 BEGIN
 self.Add(NEW(declare_param_t, op := Op.declare_param, name := name, byte_size := byte_size, alignment := alignment, type := type, typeid := typeid, in_memory := in_memory, up_level := up_level, frequency := frequency, tag := var.tag, typename := typename));
@@ -381,14 +382,14 @@ self.Add(NEW(declare_temp_t, op := Op.declare_temp, byte_size := byte_size, alig
 RETURN var;
 END declare_temp;
 
-PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; return_typename := M3CG.NoQID): Proc =
+PROCEDURE import_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; callingConvention: CallingConvention; return_typename := NoQID): Proc =
 VAR proc := self.refs.NewProc();
 BEGIN
 self.Add(NEW(import_procedure_t, op := Op.import_procedure, name := name, n_params := n_params, return_type := return_type, callingConvention := callingConvention, return_typename := return_typename, tag := proc.tag));
 RETURN proc;
 END import_procedure;
 
-PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_typename := M3CG.NoQID): Proc =
+PROCEDURE declare_procedure(self: T; name: Name; n_params: INTEGER; return_type: Type; level: INTEGER; callingConvention: CallingConvention; exported: BOOLEAN; parent: Proc; return_typename := NoQID): Proc =
 VAR proc := self.refs.NewProc();
     parent_tag := 0;
 BEGIN
@@ -499,12 +500,12 @@ BEGIN
 self.Add(NEW(declare_indirect_t, op := Op.declare_indirect, typeid := typeid, target_typeid := target_typeid));
 END declare_indirect;
 
-PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; return_typeid: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: M3CG.QID) =
+PROCEDURE declare_proctype(self: T; typeid: TypeUID; n_formals: INTEGER; return_typeid: TypeUID; n_raises: INTEGER; callingConvention: CallingConvention; result_typename: QID) =
 BEGIN
 self.Add(NEW(declare_proctype_t, op := Op.declare_proctype, typeid := typeid, n_formals := n_formals, return_typeid := return_typeid, n_raises := n_raises, callingConvention := callingConvention, result_typename := result_typename));
 END declare_proctype;
 
-PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename: M3CG.QID) =
+PROCEDURE declare_formal(self: T; name: Name; typeid: TypeUID; typename: QID) =
 BEGIN
 self.Add(NEW(declare_formal_t, op := Op.declare_formal, name := name, typeid := typeid, typename := typename));
 END declare_formal;

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -19,6 +19,7 @@ FROM M3CG IMPORT Name, Var, Proc, Alignment, TypeUID, Label;
 FROM M3CG IMPORT Frequency, CallingConvention, CompareOp, ConvertOp, AtomicOp;
 FROM M3CG IMPORT BitSize, ByteSize, BitOffset, ByteOffset, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
+FROM M3CG IMPORT NoQID;
 
 TYPE
   ErrorHandler = PROCEDURE (msg: TEXT);
@@ -120,14 +121,14 @@ declare_indirect (t, target: TypeUID);
 
 declare_proctype (t: TypeUID;  n_formals: INTEGER;
                   result: TypeUID;  n_raises: INTEGER;
-                  cc: CallingConvention; result_typename := M3CG.NoQID);
+                  cc: CallingConvention; result_typename := NoQID);
 (* Procedure type.  The subsequent n_formals occurrences of declare_formal
    define the formal parameters.  The subsequent n_raises occurrences of
    declare_raises are names of raised exceptions.  n_raises < 0 => RAISES ANY.
    These occurrences of declare_formal and declare_raises all preceed the next
    occurrence of declare_proctype.  *)
 
-declare_formal (n: Name;  t: TypeUID; typename := M3CG.NoQID);
+declare_formal (n: Name;  t: TypeUID; typename := NoQID);
 (* A formal of the most recent procedure *type*, i.e., introduced by
    declare_proctype. *) 
 
@@ -253,7 +254,7 @@ declare_local (n: Name;  s: ByteSize;  a: Alignment;  t: Type;
 
 declare_param (n: Name;  s: ByteSize;  a: Alignment;  t: Type;
                m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-               f: Frequency; typename := M3CG.NoQID): Var;
+               f: Frequency; typename := NoQID): Var;
 (* Declare a formal parameter, belonging to the most recent
    declare_procedure or import_procedure.  Formals are declared in
    their lexical order, relative to each other, but many other things
@@ -344,7 +345,7 @@ init_float (o: ByteOffset;  READONLY f: Target.Float);
 *)
 
 import_procedure (n: Name;  n_params: INTEGER;  return: Type;
-                  cc: CallingConvention; return_typename := M3CG.NoQID): Proc;
+                  cc: CallingConvention; return_typename := NoQID): Proc;
 (* declare and import the external procedure with name 'n' and 'n_params'
    formal parameters.  It must be a top-level (=0) procedure that returns
    values of type 'return'.  'cc' is derived from the procedure's <*EXTERNAL*>
@@ -355,7 +356,7 @@ import_procedure (n: Name;  n_params: INTEGER;  return: Type;
 declare_procedure (n: Name;  n_params: INTEGER;  return: Type;
                    lev: INTEGER;  cc: CallingConvention;
                    exported: BOOLEAN;  parent: Proc;
-                   return_typename := M3CG.NoQID): Proc;
+                   return_typename := NoQID): Proc;
 (* Declare a procedure with simple name 'n' within the current scope,
    with 'n_params' formal parameters, at static nesting level 'lev'.
    Set the "current procedure" to this procedure.  If the name n is M3ID.NoID,

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -11,6 +11,7 @@ IMPORT Text, Rd, IntIntTbl, Thread, Convert, Wr, Stdio, Fmt;
 IMPORT M3ID, M3CG, M3CG_Ops, Target, TInt, TFloat;
 FROM M3CG IMPORT CompareOp, ConvertOp, AtomicOp, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
+FROM M3CG IMPORT NoQID;
 
 CONST
   EOF = '\000';
@@ -734,7 +735,7 @@ PROCEDURE declare_proctype (VAR s: State) =
       result    := Scan_tipe (s);
       n_raises  := Scan_int (s);
       calling   := Scan_callConv (s);
-      result_typename := M3CG.NoQID; (* TODO result_typename but it is not used downstream *)
+      result_typename := NoQID; (* TODO result_typename but it is not used downstream *)
   BEGIN
     s.cg.declare_proctype (type, n_formals, result, n_raises, calling, result_typename);
   END declare_proctype;
@@ -742,7 +743,7 @@ PROCEDURE declare_proctype (VAR s: State) =
 PROCEDURE declare_formal (VAR s: State) =
   VAR name := Scan_name (s);
       type := Scan_tipe (s);
-      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
+      typename := NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     s.cg.declare_formal (name, type, typename);
   END declare_formal;
@@ -911,7 +912,7 @@ PROCEDURE declare_param (VAR s: State) =
       up_lev := Scan_bool (s);
       freq   := Scan_int (s);
       v      := Scan_varName (s);
-      typename := M3CG.NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
+      typename := NoQID; (* TODO typename but it is not used downstream and can be omitted indefinitely *)
   BEGIN
     AddVar (s, v, s.cg.declare_param (name, size, align, type, m3t,
                                       in_mem, up_lev, freq, typename));

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -16,6 +16,7 @@ FROM M3CG IMPORT Var, Proc, Label, Sign, BitOffset, No_label;
 FROM M3CG IMPORT Type, ZType, AType, RType, IType, MType;
 FROM M3CG IMPORT CompareOp, ConvertOp, AtomicOp, RuntimeError;
 FROM M3CG IMPORT MemoryOrder;
+FROM M3CG IMPORT QID;
 
 TYPE WrVar    = Var    OBJECT tag: INTEGER END;
 TYPE WrProc   = Proc   OBJECT tag: INTEGER END;
@@ -572,7 +573,7 @@ PROCEDURE declare_indirect (u: U;  t, target: TypeUID) =
 
 PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
                             result: TypeUID;  n_raises: INTEGER;
-                            cc: CallingConvention; <*UNUSED*>result_typename: M3CG.QID) =
+                            cc: CallingConvention; <*UNUSED*>result_typename: QID) =
   BEGIN
     Cmd  (u, "declare_proctype");
     Tipe (u, t);
@@ -584,7 +585,7 @@ PROCEDURE declare_proctype (u: U;  t: TypeUID;  n_formals: INTEGER;
     NL   (u);
   END declare_proctype;
 
-PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID; <*UNUSED*>typename: M3CG.QID) =
+PROCEDURE declare_formal (u: U;  n: Name;  t: TypeUID; <*UNUSED*>typename: QID) =
   BEGIN
     Cmd   (u, "declare_formal");
     ZName (u, n);
@@ -787,7 +788,7 @@ PROCEDURE declare_local (u: U;  n: Name;  s: ByteSize;  a: Alignment;
 
 PROCEDURE declare_param (u: U;  n: Name;  s: ByteSize;  a: Alignment;
                          t: Type;  m3t: TypeUID;  in_memory, up_level: BOOLEAN;
-                         f: Frequency; <*UNUSED*>typename := M3CG.NoQID): Var =
+                         f: Frequency; <*UNUSED*>typename: QID): Var =
   VAR v := NewVar (u);
   BEGIN
     Cmd   (u, "declare_param");
@@ -912,7 +913,7 @@ PROCEDURE NewProc (u: U): Proc =
 
 PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
                             ret_type: Type;  cc: CallingConvention;
-                            <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                            <*UNUSED*>return_typename: QID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, "import_procedure");
@@ -929,7 +930,7 @@ PROCEDURE import_procedure (u: U;  n: Name;  n_params: INTEGER;
 PROCEDURE declare_procedure (u: U;  n: Name;  n_params: INTEGER;
                              return_type: Type;  lev: INTEGER;
                              cc: CallingConvention; exported: BOOLEAN;
-                             parent: Proc; <*UNUSED*>return_typename := M3CG.NoQID): Proc =
+                             parent: Proc; <*UNUSED*>return_typename: QID): Proc =
   VAR p := NewProc (u);
   BEGIN
     Cmd   (u, "declare_procedure");


### PR DESCRIPTION
i.e. FROM M3CG IMPORT QID, NoQID and then use QID, NoQID.
Except in a few cases there are other symbols named QID

Fix warning about unused NamedType and WCharr.