### PR TITLE
m3-sys: Make lowering of types optional.

### DIFF
--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -9,7 +9,7 @@
 MODULE NamedType;
 
 IMPORT M3, M3ID, Token, Type, TypeRep, Scanner, ObjectType;
-IMPORT Error, Scope, Brand, Value, ErrType;
+IMPORT Error, Scope, Brand, Value, ErrType, Target;
 FROM M3CG IMPORT QID;
 
 TYPE
@@ -143,6 +143,7 @@ PROCEDURE Strip (t: Type.T): Type.T =
 PROCEDURE Check (p: P) =
   VAR cs := M3.OuterCheckState;  nErrs, nWarns, nErrsB: INTEGER;
       name := p.info.name;
+      type: Type.T := NIL;
   BEGIN
     Resolve (p);
     nErrs := 0;  nErrsB := 0;
@@ -153,7 +154,10 @@ PROCEDURE Check (p: P) =
     END;
     IF (nErrs = nErrsB) THEN
       (* no errors yet... *)
-      p.type := Type.CheckInfo (p.type, p.info);
+      type := Type.CheckInfo (p.type, p.info);
+      IF Target.LowerTypes THEN
+        p.type := type;
+      END;
     ELSE (* some sort of error (probably illegal recursion...) *)
       EVAL Type.CheckInfo (ErrType.T, p.info);
     END;

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -193,6 +193,7 @@ PROCEDURE Check (p: P) =
     v      : Value.T;
     formal : Formal.Info;
     cs     := M3.OuterCheckState;
+    result : Type.T := NIL;
   BEGIN
     (* look up each of the named exceptions *)
     ESet.TypeCheck (p.raises);
@@ -228,8 +229,11 @@ PROCEDURE Check (p: P) =
       Scope.TypeCheck (p.formals, cs);
       IF (p.result # NIL) THEN
         Type.Typename (p.result, p.result_typename);
-        p.result := Type.Check (p.result);
-        IF OpenArrayType.Is (p.result) THEN
+        result := Type.Check (p.result);
+        IF Target.LowerTypes THEN
+          p.result := result;
+        END;
+        IF OpenArrayType.Is (result) THEN
           Error.Msg ("procedures may not return open arrays");
         END;
       END;

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -211,13 +211,17 @@ PROCEDURE RepTypeOf (t: T): Type.T =
 PROCEDURE Check (t: T;  VAR cs: Value.CheckState) =
 (* Only checks on the formal itself. *)
   VAR info: Type.Info;
+      type: Type.T := NIL;
   BEGIN
-    t.type := Type.CheckInfo (TypeOf (t), info);
-    t.repType := Type.StripPacked (t.type);
+    type := Type.CheckInfo (TypeOf (t), info);
+    IF Target.LowerTypes THEN
+      t.type := type;
+    END;
+    t.repType := Type.StripPacked (type);
     EVAL Type.Check (t.repType);
     t.kind := info.class;
     IF (info.class = Type.Class.Packed) THEN (* Ignore BITS in setting class. *)
-      EVAL Type.CheckInfo (Type.Base (t.type), info);
+      EVAL Type.CheckInfo (Type.Base (type), info);
       t.kind := info.class;
     END;
 
@@ -250,7 +254,7 @@ PROCEDURE Check (t: T;  VAR cs: Value.CheckState) =
              both open array) passed READONLY will do call-site copying. *)
     THEN (* We need a reference type to the formal type to do open array
             copying. *)
-      t.refType := RefType.New (t.type, traced := TRUE, brand := NIL);
+      t.refType := RefType.New (type, traced := TRUE, brand := NIL);
       EVAL Type.Check (t.refType);
     END;
 

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -477,6 +477,11 @@ VAR (*CONST*)
      test for nested procedures passed as parameters must be more
      elaborate (e.g. HPPA). *)
 
+(* LowerTypes = TRUE: m3front behaves the same as historical, stripping away NamedType.
+ * LowerTypes = FALSE; m3front passes "original_type".
+ *)
+VAR LowerTypes := TRUE;
+
 (* Ideally the value 0 would be uninitialized, but it is used publically in Quake? *)
 VAR BackendMode: M3BackendMode_t;
 VAR BackendModeInitialized := FALSE;

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -143,6 +143,7 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     IF backend_mode = M3BackendMode_t.C THEN
       Setjmp := "m3_setjmp";
       Sigsetjmp := FALSE;
+      LowerTypes := FALSE;
     ELSIF Solaris() THEN
       Setjmp := "sigsetjmp";
       Sigsetjmp := TRUE;


### PR DESCRIPTION
That is, given patterns like:
procedure init:
 t.type := x
 ...

procedure 1:
 t.type := Type.Check (t.type)
 foo (t.type)

procedure 2: (* likely run after procedure 1 *)
 EVAL t.type

Change to:
procedure init: (* unchanged *)
 t.type := x
 ...

procedure 1:
 VAR type := Type.Check (t.type)
 IF Target.LowerTypes THEN
   t.type := type;
 END;
 foo (type) (* maybe *)

procedure 2: (* likely run after procedure 1 *)
 EVAL t.type

And then LowerTypes defaults to TRUE, same behavior
as before, but is FALSE when targeting C.

This is expected to help preserve typenames down the line,
without changing the IR (or only a little).

If you survey for Type.Check you will find that I skipped most of them.
This is probably ok or mostly ok, we will see.

This notably breaks pointer comparisons of types, which I have seen a few of, e.g. to Null.T.