### PR TITLE
m3core: Changes in anticipation of type matching between

### DIFF
--- a/m3-libs/m3core/src/time/POSIX/DatePosixC.c
+++ b/m3-libs/m3core/src/time/POSIX/DatePosixC.c
@@ -56,7 +56,7 @@ TimePosix__ToSeconds(LONGREAL/*Time.T*/ t)
 
 void
 __cdecl
-DatePosix__FromTime(double t, INTEGER zone, m3core_DatePosix_T* date)
+DatePosix__FromTime(double t, INTEGER zone, DatePosix__T* date)
 {
     const INTEGER Local = 0;
     const INTEGER UTC = 1;
@@ -117,7 +117,7 @@ DatePosix__FromTime(double t, INTEGER zone, m3core_DatePosix_T* date)
 
 double
 __cdecl
-DatePosix__ToTime(/*const*/ m3core_DatePosix_T* date)
+DatePosix__ToTime(/*const*/ DatePosix__T* date)
 {
     struct tm tm;
     double t = 0;
@@ -169,9 +169,9 @@ Exit:
 
 void
 __cdecl
-DatePosix__TypeCheck(/*const*/ m3core_DatePosix_T* d, WORD_T sizeof_DateT)
+DatePosix__TypeCheck(/*const*/ DatePosix__T* d, INTEGER sizeof_DateT)
 {
-    assert(sizeof(m3core_DatePosix_T) == sizeof_DateT);
+    assert(sizeof(DatePosix__T) == sizeof_DateT);
     assert(d->year == 1);
     assert(d->month == 2);
     assert(d->day == 3);

--- a/m3-libs/m3core/src/unix/Common/Umman.i3
+++ b/m3-libs/m3core/src/unix/Common/Umman.i3
@@ -4,11 +4,12 @@
 
 INTERFACE Umman;
 
-FROM Ctypes IMPORT int;
+FROM Ctypes IMPORT int, void_star;
 FROM Cstddef IMPORT size_t;
 FROM Utypes IMPORT off_t;
 
-(*CONST*)
+TYPE caddr_t = ADDRESS;
+
 (* This first set very portable. *)
 <*EXTERNAL Umman__PROT_NONE*> VAR PROT_NONE: int;
 <*EXTERNAL Umman__PROT_READ*> VAR PROT_READ: int;
@@ -28,8 +29,8 @@ FROM Utypes IMPORT off_t;
 <*EXTERNAL Umman__MAP_ANON*> VAR MAP_ANON: int;
 <*EXTERNAL Umman__MAP_NOCORE*> VAR MAP_NOCORE: int;
 
-<*EXTERNAL Umman__mprotect*>PROCEDURE mprotect (addr: ADDRESS; len: size_t; prot:int): int;
-<*EXTERNAL Umman__mmap*>PROCEDURE mmap (addr: ADDRESS; len: size_t; prot, flags, fd: int; off: off_t): ADDRESS;
-<*EXTERNAL Umman__munmap*>PROCEDURE munmap (addr: ADDRESS; len: size_t): int;
+<*EXTERNAL Umman__mprotect*>PROCEDURE mprotect (addr: caddr_t; len: size_t; prot:int): int;
+<*EXTERNAL Umman__mmap*>    PROCEDURE mmap     (addr: caddr_t; len: size_t; prot, flags, fd: int; off: off_t): void_star;
+<*EXTERNAL Umman__munmap*>  PROCEDURE munmap  ( addr: caddr_t; len: size_t): int;
 
 END Umman.

--- a/m3-libs/m3core/src/unix/Common/Unix.i3
+++ b/m3-libs/m3core/src/unix/Common/Unix.i3
@@ -69,6 +69,7 @@ TYPE struct_flock = RECORD
   l_whence: INTEGER := 0;
 END;
 
+(* TODO replace this with higher level constructs *)
 <*EXTERNAL "Unix__fcntl"*>PROCEDURE fcntl (fd: int; request, arg: INTEGER): int;
 
 <*EXTERNAL "Unix__fsync"*>PROCEDURE fsync (fd: int): int;
@@ -79,8 +80,8 @@ END;
 
 <*EXTERNAL "Unix__FIONREAD"*> VAR FIONREAD: const_int;
 
-<*EXTERNAL "Unix__ioctl"*>
-PROCEDURE ioctl (d: int; request: INTEGER; argp: ADDRESS): int;
+(* TODO replace this with higher level constructs *)
+<*EXTERNAL "Unix__ioctl"*> PROCEDURE ioctl (d: int; request: INTEGER; argp: ADDRESS): int;
 
 <*EXTERNAL "Unix__lseek"*>
 PROCEDURE lseek (d: int; offset: off_t; whence: int): off_t;

--- a/m3-libs/m3core/src/win32/WinReg.m3
+++ b/m3-libs/m3core/src/win32/WinReg.m3
@@ -2,6 +2,7 @@
 (* See file COPYRIGHT-CMASS for details. *)
 
 UNSAFE MODULE WinReg;
+(* TODO Move these to .c. *)
 BEGIN
   HKEY_CLASSES_ROOT     := LOOPHOLE (16_80000000, HKEY);
   HKEY_CURRENT_USER     := LOOPHOLE (16_80000001, HKEY);


### PR DESCRIPTION
m3c output and hand written C, so that they can all be concatented.

Specifically patterns like m3core.h:

ifndef Cstddef__size_t
define Cstddef__size_t Cstddef__size_t
typedef size_t Cstddef__size_t
endif

m3c will then say:
ifndef Cstddef__size_t
define Cstddef__size_t Cstddef__size_t
typedef something-maybe-not-exactly-size_t Cstddef__size_t
endif

They will be concatented, m3core.h will come first.

And then use types like Ctypes_const_char_star
instead of const char*.
Some char* vs. void*.
Some TODO comments.