### PR TITLE
m3core: Add RTIO.PutRef(REFANY).

### DIFF
--- a/m3-libs/m3core/src/runtime/common/RTIO.i3
+++ b/m3-libs/m3core/src/runtime/common/RTIO.i3
@@ -38,6 +38,9 @@ PROCEDURE PutHex (i: INTEGER;  width := 0);
 PROCEDURE PutAddr (a: ADDRESS;  width := 0);
 (* == PutHex (LOOPHOLE (a, INTEGER), width) *)
 
+PROCEDURE PutRef (a: REFANY);
+(* == PutAddr (LOOPHOLE (a, ADDRESS)) *)
+
 (* Normally RTIO goes to stderr; however these go to stdout
    in order to be agnostic between static and dynamic Windows C runtime *)
 <* EXTERNAL RTIO__PutE *>

--- a/m3-libs/m3core/src/runtime/common/RTIO.m3
+++ b/m3-libs/m3core/src/runtime/common/RTIO.m3
@@ -65,6 +65,11 @@ PROCEDURE PutAddr (a: ADDRESS;  width: INTEGER) =
     PutHex (LOOPHOLE (a, INTEGER), width);
   END PutAddr;
 
+PROCEDURE PutRef (r: REFANY) =
+  BEGIN
+    PutAddr (LOOPHOLE (r, ADDRESS), 0);
+  END PutRef;
+
 PROCEDURE PutText (t: TEXT) =
   BEGIN
     FOR i := 0 TO Text.Length (t)-1 DO


### PR DESCRIPTION
Prior, callers had to be unsafe and loophole to address and call PutAddr.