### PR TITLE
m3c: Treat typeid = 0 like -1 in more places.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -1365,7 +1365,7 @@ END ProcType_define;
 PROCEDURE TypeidToType_Get(self: T; typeid: TypeUID): Type_t =
 VAR type: REFANY := NIL;
 BEGIN
-    IF typeid # -1 THEN
+    IF typeid # -1 AND typeid # 0 THEN
         EVAL self.typeidToType.get(typeid, type);
     END;
     IF type = NIL THEN
@@ -1386,7 +1386,7 @@ BEGIN
     typedefs[1] := TypeIDToText(type.typeid);
 
     IF type.text = NIL THEN
-        IF type.typeid = -1 THEN
+        IF type.typeid = -1 OR type.typeid = 0 THEN
             IF cgtype = CGType.Struct THEN
                 type.text := " /* Type_Init Struct */ " & Struct(type.bit_size DIV 8);
             ELSE
@@ -1396,7 +1396,7 @@ BEGIN
             type.text := TypeIDToText(type.typeid) & type.type_text_tail;
         END;
     END;
-    IF type.typeid # -1 THEN
+    IF type.typeid # -1 AND type.typeid # 0 THEN
         EVAL self.typeidToType.put(type.typeid, type);
     END;
 (*


### PR DESCRIPTION
Otherwise we were badly confusing types, but not necessary catastrophically. That is, a local struct
that is at least pointer-sized, can be used in place of a pointer, given all the casting. It is big enough.