### PR TITLE
m3c: Initial qid support.

### DIFF
--- a/m3-sys/m3back/src/m3makefile
+++ b/m3-sys/m3back/src/m3makefile
@@ -10,6 +10,7 @@
 import ("libm3")
 import ("m3middle")
 import ("m3objfile")
+import ("set")
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % HACK ALERT! THE FOLLOWING TWO FILES ARE DEPRECATED


### PR DESCRIPTION
This will likely change a lot, to be instead typeid + declare_typename
support, but it is also probably close to correct, and cleans
things up, because same code is needed in a few places, i.e. parameters
and return types and hopefully globals, locals and even temporaries).

Specifically this steers m3c away from the low level
types (int32, int64, addr, etc.) and even typeids
as strings (T1234, etc.), more toward the notion
that types have arbitrary text to representing them ("int", "Foo_T", "Foo_T*",
etc.); which, granted, was already somewhat the case. This change
tries to use qid to form the text when they are provided but
possibly they will go away, and instead more declare_typename use.

Add some comments.

Introduce the ifndefs around typedefs, so that m3core.h can replace them.

Add a cast on returns, there was a problem seen; this
can probably benefit from the typeid/typename work,
i.e. returning typed pointers instead of mere ADDRESS.

This is also notably about the end of the line where I had
gotten with qids in ir, before starting to reconsider after much
progress.