### PR TITLE
m3front: Fix some unused warnings.

### DIFF
--- a/m3-sys/m3front/src/exprs/QualifyExpr.m3
+++ b/m3-sys/m3front/src/exprs/QualifyExpr.m3
@@ -264,7 +264,7 @@ PROCEDURE Check (p: P;  VAR cs: Expr.CheckState) =
 
 PROCEDURE QualifyExprAlign (p: P): Type.BitAlignT =
   VAR fieldInfo: Field.Info;
-  VAR offset, obj_offset, obj_align, prefixAlign: INTEGER;
+  VAR offset: INTEGER;
   VAR objType: Type.T;
   VAR objTypeInfo: Type.Info;
   BEGIN

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -11,7 +11,7 @@ MODULE Formal;
 IMPORT M3, M3ID, CG, Value, ValueRep, Type, Error, Expr, ProcType;
 IMPORT KeywordExpr, OpenArrayType, RefType, CheckExpr, PackedType;
 IMPORT ArrayType, ArrayExpr, SetType, Host, NarrowExpr, M3Buf, Tracer;
-IMPORT Variable, Procedure, UserProc, Target, M3RT, NamedType;
+IMPORT Variable, Procedure, UserProc, Target, M3RT;
 FROM M3CG IMPORT NoQID;
 
 TYPE


### PR DESCRIPTION
NamedType, obj_offset, obj_align, prefixAlign