### PR TITLE
m3-sys: Remove some type lowering for all systems.

### DIFF
--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -155,9 +155,6 @@ PROCEDURE Check (p: P) =
     IF (nErrs = nErrsB) THEN
       (* no errors yet... *)
       type := Type.CheckInfo (p.type, p.info);
-      IF Target.LowerTypes THEN
-        p.type := type;
-      END;
     ELSE (* some sort of error (probably illegal recursion...) *)
       EVAL Type.CheckInfo (ErrType.T, p.info);
     END;

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -230,9 +230,6 @@ PROCEDURE Check (p: P) =
       IF (p.result # NIL) THEN
         Type.Typename (p.result, p.result_typename);
         result := Type.Check (p.result);
-        IF Target.LowerTypes THEN
-          p.result := result;
-        END;
         IF OpenArrayType.Is (result) THEN
           Error.Msg ("procedures may not return open arrays");
         END;

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -214,9 +214,6 @@ PROCEDURE Check (t: T;  VAR cs: Value.CheckState) =
       type: Type.T := NIL;
   BEGIN
     type := Type.CheckInfo (TypeOf (t), info);
-    IF Target.LowerTypes THEN
-      t.type := type;
-    END;
     t.repType := Type.StripPacked (type);
     EVAL Type.Check (t.repType);
     t.kind := info.class;

--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -296,9 +296,6 @@ PROCEDURE Check (t: T;  VAR cs: Value.CheckState) =
       type: Type.T := NIL;
   BEGIN
     type := Type.CheckInfo (TypeOf (t), info);
-    IF Target.LowerTypes THEN
-      t.type := type;
-    END;
     t.repType  := Type.Check (Type.StripPacked (type));
     t.size     := info.size;
     t.align    := info.alignment;

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -477,11 +477,6 @@ VAR (*CONST*)
      test for nested procedures passed as parameters must be more
      elaborate (e.g. HPPA). *)
 
-(* LowerTypes = TRUE: m3front behaves the same as historical, stripping away NamedType.
- * LowerTypes = FALSE; m3front passes "original_type".
- *)
-VAR LowerTypes := TRUE;
-
 (* Ideally the value 0 would be uninitialized, but it is used publically in Quake? *)
 VAR BackendMode: M3BackendMode_t;
 VAR BackendModeInitialized := FALSE;

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -143,7 +143,6 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     IF backend_mode = M3BackendMode_t.C THEN
       Setjmp := "m3_setjmp";
       Sigsetjmp := FALSE;
-      LowerTypes := FALSE;
     ELSIF Solaris() THEN
       Setjmp := "sigsetjmp";
       Sigsetjmp := TRUE;


### PR DESCRIPTION
I don't think this is really needed, "just" an optimization, and loses possibly useful information.