### PR TITLE
m3front: Strip in Type.AddCell.

### DIFF
--- a/m3-sys/m3front/src/types/Type.m3
+++ b/m3-sys/m3front/src/types/Type.m3
@@ -399,6 +399,7 @@ PROCEDURE InitPredefinedCells () =
 PROCEDURE AddCell (t: T) =
   VAR c := NEW (CellInfo);  size := M3RT.TC_SIZE;  u: T;
   BEGIN
+    t := Strip (t);
     IF (t.info.class = Class.Object) THEN
       size := M3RT.OTC_SIZE;
     ELSIF RefType.Split (t, u) AND OpenArrayType.Is (u) THEN


### PR DESCRIPTION
This is redundant with all callers so should not change anything.
The point being to generally explicitly allow unlowered types,
i.e. named typed (there are other unlowered forms like
packed and subrange, but my concern is named).