### PR TITLE
m3front: Call StripPacked unconditionally in OpenArrayType.Reduce.

### DIFF
--- a/m3-sys/m3front/src/types/OpenArrayType.m3
+++ b/m3-sys/m3front/src/types/OpenArrayType.m3
@@ -51,10 +51,8 @@ PROCEDURE New (EltType: Type.T): Type.T =
 PROCEDURE Reduce (t: Type.T): P =
   (* Strip Named and Packed.  NIL if that's not an open array type. *) 
   BEGIN
-    IF (t = NIL) THEN RETURN NIL END;
-    IF (t.info.class = Type.Class.Named) THEN t := Type.Strip (t) END;
-    IF (t.info.class = Type.Class.Packed) THEN t := Type.StripPacked (t) END;
-    IF (t.info.class # Type.Class.OpenArray) THEN RETURN NIL END;
+    t := Type.StripPacked (t);
+    IF (t = NIL) OR (t.info.class # Type.Class.OpenArray) THEN RETURN NIL END;
     RETURN t;
   END Reduce;
 


### PR DESCRIPTION
This is to reduce manual inlining, i.e. an anti-pattern except for maybe perf.