### PR TITLE
m3front: More type-based zeroing initializers.

### DIFF
--- a/m3-sys/m3front/src/types/ArrayType.m3
+++ b/m3-sys/m3front/src/types/ArrayType.m3
@@ -17,16 +17,16 @@ VAR MaxBitSize := LAST (INTEGER);
 
 TYPE
   P = Type.T BRANDED "ArrayType.P" OBJECT
-        indexType        : Type.T;
-        elementType      : Type.T;
-        alignment        : INTEGER;
-        n_elts           : INTEGER;
-        elt_align        : INTEGER;
-        elt_pack         : INTEGER;
-        total_size       : INTEGER;
-        fixedDepth       : INTEGER; (* # of dimensions, lazily computed. *) 
-        openCousin       : Type.T;  (* == ARRAY OF elementType *)
-        eltsBitAddressed : BOOLEAN;
+        indexType        : Type.T  := NIL;
+        elementType      : Type.T  := NIL;
+        alignment        : INTEGER := 0;
+        n_elts           : INTEGER := 0;
+        elt_align        : INTEGER := 0;
+        elt_pack         : INTEGER := 0;
+        total_size       : INTEGER := 0;
+        fixedDepth       : INTEGER := 0; (* # of dimensions, lazily computed. *) 
+        openCousin       : Type.T  := NIL;  (* == ARRAY OF elementType *)
+        eltsBitAddressed : BOOLEAN := FALSE;
         (* ^Could be FALSE even if elements are BITS n FOR, if 
             n is divisible by 8. *) 
       OVERRIDES
@@ -83,14 +83,7 @@ PROCEDURE New (index, element: Type.T): Type.T =
     TypeRep.Init (p, Type.Class.Array);
     p.indexType  := index;
     p.elementType := element;
-    p.alignment   := 0;
-    p.n_elts      := 0;
-    p.total_size  := 0;
-    p.elt_align   := 0;
-    p.elt_pack    := 0;
     p.fixedDepth  := -1; 
-    p.openCousin  := NIL;
-    p.eltsBitAddressed := FALSE;
     RETURN p;
   END New;
 

--- a/m3-sys/m3front/src/types/OpenArrayType.m3
+++ b/m3-sys/m3front/src/types/OpenArrayType.m3
@@ -13,11 +13,11 @@ IMPORT ArrayType, PackedType, RecordType, TipeMap, TipeDesc;
 
 TYPE
   P = Type.T BRANDED "OpenArrayType.P" OBJECT
-        EltType                 : Type.T;
-        NonopenEltType          : Type.T;
-        openDepth               : INTEGER;
-        NonopenEltAlign         : INTEGER;
-        NonopenEltPack          : INTEGER;
+        EltType                 : Type.T  := NIL;
+        NonopenEltType          : Type.T  := NIL;
+        openDepth               : INTEGER := 0;
+        NonopenEltAlign         : INTEGER := 0;
+        NonopenEltPack          : INTEGER := 0;
         NonopenEltsBitAddressed : BOOLEAN := FALSE;
         (* ^Could be FALSE even if elements are BITS n FOR, if 
             n is divisible by 8. *) 
@@ -41,10 +41,7 @@ PROCEDURE New (EltType: Type.T): Type.T =
     p := NEW (P);
     TypeRep.Init (p, Type.Class.OpenArray);
     p.EltType := EltType;
-    p.NonopenEltType := NIL;
     p.openDepth := -1;
-    p.NonopenEltPack := 0;
-    p.NonopenEltsBitAddressed := FALSE;
     RETURN p;
   END New;
 


### PR DESCRIPTION
Shorter and safer.