### PR TITLE
Add mysql to pkginfo.txt 

### DIFF
--- a/scripts/pkginfo.txt
+++ b/scripts/pkginfo.txt
@@ -66,6 +66,7 @@ rdwr devlib
 sharedobj obliq
 sharedobjgen obliq
 odbc database
+mysql database
 postgres95 database
 db database
 smalldb database


### PR DESCRIPTION
 Adding line:
mysql database
to file pkginfo.txt

Tested by Alexey Ershov ( thanks!) on OS Linux Mint 20.