### PR TITLE
mfront: Type.{IsEqual,IsSubtype} Fix my mistake in:

### DIFF
--- a/m3-sys/m3front/src/types/Type.m3
+++ b/m3-sys/m3front/src/types/Type.m3
@@ -507,8 +507,8 @@ PROCEDURE IsEqual (a, b: T;  x: Assumption): BOOLEAN =
     IF (a = NIL) OR (b = NIL) THEN RETURN FALSE END;
     IF (a = b) (*** OR (a = NIL) OR (b = NIL) ***) THEN RETURN TRUE END;
 
-    a := StripPacked (a);
-    b := StripPacked (b);
+    a := Strip (a);
+    b := Strip (b);
     ac := a.info.class;  bc := b.info.class;
     IF (a = b) THEN RETURN TRUE END;
     IF (ac = Class.Error) OR (bc = Class.Error) THEN RETURN TRUE END;
@@ -556,9 +556,11 @@ PROCEDURE IsSubtype (a, b: T): BOOLEAN =
     IF (a = NIL) OR (b = NIL) THEN RETURN FALSE END;
     IF (a = b) (*** OR (a = NIL) OR (b = NIL) ***) THEN RETURN TRUE END;
 
+    a := Strip (a);
+    b := Strip (b);
+    IF (a.info.class = Class.Error) OR (b.info.class = Class.Error) THEN RETURN TRUE END;
     a := StripPacked (a);
     b := StripPacked (b);
-    IF (a.info.class = Class.Error) OR (b.info.class = Class.Error) THEN RETURN TRUE END;
 
     (* try their id's first *)
     IF (a.uid = NO_UID) OR (b.uid = NO_UID) THEN


### PR DESCRIPTION
 commit b89d8fe4bab0bfbb8f64799127f3b0fab5863880
    m3front: Remove manual partial inlining. (#484)
    In IsEqual and IsSubtype, call StripPacked unconditionally.

There were two unintended changes there:
 - In IsEqual, call Strip, not StripPacked.
 - In IsSubtype, look at info.class after Strip, then call StripPacked.

Symptom of the problem:
 C:\s\cm3\m3-comm\serial>rd /q/s AMD64_NT & cm3

 Fatal Error: bad version stamps: SerialPort.m3

 version stamp mismatch: WeakRef.FromRef
   <c1ff6b0d2489bc38> => SerialPort.m3
   <28bbb0fb20661e30> => WeakRef.i3
 version stamp mismatch: WeakRef.T
   <da5baaeae3faad3a> => SerialPort.m3
   <74fc644f36110a26> => WeakRef.i3
 SerialPort.m3: missing imported type: _t2a11fb7d
 SerialPort.m3: missing imported type: _tfb5d45cd
 SerialPort.m3: missing imported type: _t98a5b108
 SerialPort.m3: missing imported type: _t554b42a0