### PR TITLE
m3front: If Record F() is lowered to void F(Record*)

### DIFF
--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -382,7 +382,8 @@ PROCEDURE ResultTypename (t: Type.T): QID =
   VAR p := Reduce (t);
   BEGIN
     Type.Compile (t);
-    IF (p # NIL)
+    (* If LargeResult AND standard_structs turned into void, return no type here. *)
+    IF p # NIL AND CGResult (p) # CG.Type.Void
       THEN RETURN p.result_typename;
       ELSE RETURN NoQID;
     END;


### PR DESCRIPTION
then return typename:NoQID instead of typename:Record.