### PR TITLE
m3c: Fix error in procedure TypeText to say TypeText.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -684,7 +684,7 @@ VAR type: Type_t := NIL;
 BEGIN
   (* All typeids must be known, though this is maybe overkill. *)
   IF typeid # -1 AND typeid # 0 AND NOT ResolveType(self, typeid, type) THEN
-    Err(self, "declare_param:"
+    Err(self, "TypeText:"
               & " unknown typeid:" & TypeIDToText(typeid)
               & " type:" & cgtypeToText[cgtype]
               & " name:" & TextOrNil(NameT(name)) & "\n");


### PR DESCRIPTION
Instead of where it was copied from, declare_param.