### PR TITLE
m3c: Enable QID for types.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -707,9 +707,12 @@ BEGIN
    * lowlevel CG type like Int32, Int64, Address.
    * Gradually all types should be qidtext and never just CG.
    * Historically the other way around: There was only CG and no qid.
+   *
+   * Nested scopes do not work properly. They should be using something
+   * more like GlobalName instead of ModuleName. Thus the check for
+   * first character.
    *)
-  qidtext := NIL;
-  IF qidtext # NIL THEN
+  IF qidtext # NIL AND Text.Length (qidtext) > 0 AND Text.GetChar (qidtext, 0) IN ASCII.Letters THEN
     IF NOT self.typedef_defined.insert(qidtext) THEN
       ifndef(self, qidtext);
       print(self, "typedef " & type_text & " " & qidtext & ";");

--- a/m3-sys/m3front/src/misc/Scope.m3
+++ b/m3-sys/m3front/src/misc/Scope.m3
@@ -113,7 +113,7 @@ PROCEDURE LookUpQID (t: T;  VAR q: QID): Value.T =
     IF (q.module = M3ID.NoID) THEN
       v := LookUp (t, q.item, FALSE);
       IF v # NIL THEN
-        q.module := ModuleName (v);
+        q.module := ModuleName (v); (* TODO GlobalName *)
         <* ASSERT q.module # M3ID.NoID *>
       END;
     ELSE


### PR DESCRIPTION
So we get like Ctypes__int instead of INTEGER.
But disable for nested scopes, which do not produce good data currently.
m3front should be using more like GlobalName instead of ModuleName.

This much improves the C output.