### PR TITLE
m3core: Make Csignal__signal prototype agree between Modula-3 and C.

### DIFF
--- a/m3-libs/m3core/src/C/Common/CsignalC.c
+++ b/m3-libs/m3core/src/C/Common/CsignalC.c
@@ -9,6 +9,4 @@
 #undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Csignal
 
-typedef void (__cdecl*SignalHandler)(int s);
-
-M3WRAP2(SignalHandler, signal, int, SignalHandler)
+M3WRAP2(Csignal__Handler, signal, int, Csignal__Handler)

--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -474,6 +474,7 @@ typedef ADDRESS MUTEX;
 #define Ctypes__void_star           Ctypes__void_star           /* inhibit m3c type */
 #define Utypes__size_t              Utypes__size_t              /* inhibit m3c type */
 #define WinBaseTypes__const_UINT32  WinBaseTypes__const_UINT32  /* inhibit m3c type */
+#define Csignal__Handler            Csignal__Handler            /* inhibit m3c type */
 
 typedef size_t        Cstddef__size_t;
 typedef ssize_t       Cstddef__ssize_t;
@@ -490,6 +491,7 @@ typedef unsigned long Ctypes__unsigned_long;
 typedef ADDRESS       Ctypes__void_star;          // TODO void*
 typedef size_t        Utypes__size_t;             // redundant
 typedef UINT32        WinBaseTypes__const_UINT32;
+typedef void (__cdecl*Csignal__Handler)(int s);
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When they are seen together -- the typedefs in m3core.h shall come first and win.