### PR TITLE
m3core: Remove wrappers for memchr, strchr, strrchr, strpbrk, strstr.

### DIFF
--- a/m3-libs/m3core/src/C/Common/Cstring.i3
+++ b/m3-libs/m3core/src/C/Common/Cstring.i3
@@ -7,15 +7,11 @@ INTERFACE Cstring;
 FROM Ctypes IMPORT char_star, const_char_star, const_void_star, int, void_star;
 FROM Cstddef IMPORT size_t;
 
-<*EXTERNAL Cstring__memchr *> PROCEDURE memchr   (s: const_void_star; c: int; n: size_t): void_star;
 <*EXTERNAL Cstring__memcpy *> PROCEDURE memcpy   (s1: void_star; s2: const_void_star; n: size_t): void_star;
 <*EXTERNAL Cstring__memset *> PROCEDURE memset   (s: void_star; c: int; n: size_t): void_star;
 <*EXTERNAL Cstring__memcmp *> PROCEDURE memcmp   (s1: const_void_star; s2: const_void_star; n: size_t): int;
 <*EXTERNAL Cstring__strncpy*> PROCEDURE strncpy  (s1: char_star; s2: const_char_star; n: size_t): char_star;
 <*EXTERNAL Cstring__strncat*> PROCEDURE strncat  (s1: char_star; s2: const_char_star; n: size_t): char_star;
-<*EXTERNAL Cstring__strchr *> PROCEDURE strchr   (s: const_char_star; c: int): char_star;
-<*EXTERNAL Cstring__strrchr*> PROCEDURE strrchr  (s: const_char_star; c: int): char_star;
-<*EXTERNAL Cstring__strpbrk*> PROCEDURE strpbrk  (s1: const_char_star; s2: const_char_star): char_star;
 <*EXTERNAL Cstring__strtok *> PROCEDURE strtok   (s1: char_star; s2: const_char_star): char_star;
 <*EXTERNAL Cstring__strcmp *> PROCEDURE strcmp   (s1: const_char_star; s2: const_char_star): int;
 <*EXTERNAL Cstring__strncmp*> PROCEDURE strncmp  (s1: const_char_star; s2: const_char_star; n: size_t): int;
@@ -25,7 +21,6 @@ FROM Cstddef IMPORT size_t;
 <*EXTERNAL Cstring__memmove*> PROCEDURE memmove  (s1: void_star; s2: const_void_star; n: size_t): void_star;
 <*EXTERNAL Cstring__strcoll*> PROCEDURE strcoll  (s1: const_char_star; s2: const_char_star): int;
 <*EXTERNAL Cstring__strxfrm*> PROCEDURE strxfrm  (s1: char_star; s2: const_char_star; n: size_t): size_t;
-<*EXTERNAL Cstring__strstr *> PROCEDURE strstr   (s1: const_char_star; s2: const_char_star): char_star;
 <*EXTERNAL Cstring__strerror*> PROCEDURE strerror (errnum: int): char_star;
 
 (* These are bad functions, that OpenBSD linker rightfully warns about, so

--- a/m3-libs/m3core/src/C/Common/CstringC.c
+++ b/m3-libs/m3core/src/C/Common/CstringC.c
@@ -9,15 +9,11 @@
 #undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Cstring
 
-M3WRAP3(const void*, memchr, const void*, int, WORD_T)
 M3WRAP3(void*, memcpy, void*, const void*, WORD_T)
 M3WRAP3(void*, memset, void*, int, WORD_T)
 M3WRAP3(int, memcmp, const void*, const void*, WORD_T)
 M3WRAP3(char*, strncpy, char*, const char*, WORD_T)
 M3WRAP3(char*, strncat, char*, const char*, WORD_T)
-M3WRAP2(const char*, strchr, const char*, int)
-M3WRAP2(const char*, strrchr, const char*, int)
-M3WRAP2(const char*, strpbrk, const char*, const char*)
 M3WRAP2(char*, strtok, char*, const char*)
 M3WRAP2(int, strcmp, const char*, const char*)
 M3WRAP3(int, strncmp, const char*, const char*, WORD_T)
@@ -27,5 +23,4 @@ M3WRAP2(WORD_T, strcspn, const char*, const char*)
 M3WRAP3(void*, memmove, void*, const void*, WORD_T)
 M3WRAP2(int, strcoll, const char*, const char*)
 M3WRAP3(WORD_T, strxfrm, char*, const char*, WORD_T)
-M3WRAP2(const char*, strstr, const char*, const char*)
 M3WRAP1(char*, strerror, int)


### PR DESCRIPTION
They have const problems, and are trouble to get correct (C and C++ disagree), and are not used.
Null terminated strings rarely occur in Modula-3, good.

If they are needed they can be put back here or where needed, or outside of cm3 itself (outside of m3core, libm3, sysutils), and likely const ignored.