### PR TITLE
m3front: Remove my recent addition of original_type and OriginalTypeOf.

### DIFF
--- a/m3-sys/m3front/src/values/Formal.i3
+++ b/m3-sys/m3front/src/values/Formal.i3
@@ -17,7 +17,7 @@ TYPE
     name   : M3ID.T   := M3ID.NoID;
     mode   : Mode     := FIRST (Mode);
     offset : INTEGER  := 0;
-    type   : Type.T   := NIL; (* original_type *)
+    type   : Type.T   := NIL;
     dfault : Expr.T   := NIL;
     unused : BOOLEAN  := FALSE;
     trace  : Tracer.T := NIL;

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -16,11 +16,10 @@ IMPORT Variable, Procedure, UserProc, Target, M3RT;
 TYPE
   T = Value.T BRANDED OBJECT 
         offset   : INTEGER    := 0;
-        type     : Type.T     := NIL;
+        type     : Type.T     := NIL; (* only written once, not lowered, to retain NamedType *)
         repType  : Type.T     := NIL;
         dfault   : Expr.T     := NIL;
         refType  : Type.T     := NIL; (* Needed to copy an open array. *)
-        original_type: Type.T := NIL; (* only written once, to retain NamedType *)
         tempCGVal: CG.Val     := NIL;
         cg_type  : CG.TypeUID := 0;
         mode     : Mode       := FIRST (Mode);
@@ -65,7 +64,6 @@ PROCEDURE NewBuiltin (name: TEXT;  offset: INTEGER;  type: Type.T): Value.T =
     t.offset   := offset;
     t.mode     := Mode.mVALUE;
     t.type     := type;
-    t.original_type := type;
     t.unused   := FALSE;
     t.kind     := Type.Class.Error;
     RETURN t;
@@ -80,7 +78,6 @@ PROCEDURE New (READONLY info: Info): Value.T =
     t.offset   := info.offset;
     t.mode     := info.mode;
     t.type     := info.type;
-    t.original_type := info.type;
     t.dfault   := info.dfault;
     t.unused   := info.unused;
     t.kind     := Type.Class.Error;
@@ -95,7 +92,7 @@ PROCEDURE Split (formal: Value.T;  VAR info: Info) =
     info.name   := t.name;
     info.offset := t.offset;
     info.mode   := t.mode;
-    info.type   := OriginalTypeOf (t);
+    info.type   := TypeOf (t);
     info.dfault := t.dfault;
     info.unused := t.unused;
     info.trace  := t.trace;
@@ -131,7 +128,7 @@ PROCEDURE EmitDeclaration (formal: Value.T;  types_only, param: BOOLEAN) =
         size  := info.size;
         align := info.alignment;
         mtype := info.mem_type;
-        Type.Typename (OriginalTypeOf (t), typename);
+        Type.Typename (TypeOf (t), typename);
       END;
       EVAL CG.Declare_param (t.name, size, align, mtype,
                              t.cg_type, in_memory := FALSE, up_level := FALSE,
@@ -174,30 +171,11 @@ PROCEDURE OpenArrayByVALUE (formal: Value.T;  VAR refType: Type.T): BOOLEAN =
 (* Externally dispatched-to: *)
 PROCEDURE TypeOf (t: T): Type.T =
   BEGIN
-    (* Type and original_type should both transition to non-nil at about
-     * the same time and then never become nil.
-     *)
-    <* ASSERT (t.original_type = NIL) = (t.type = NIL) *>
     IF (t.type = NIL) THEN
       t.type := Expr.TypeOf (t.dfault);
-      t.original_type := t.type;
     END;
-    <* ASSERT t.original_type # NIL AND t.type # NIL *>
     RETURN t.type;
   END TypeOf;
-
-PROCEDURE OriginalTypeOf (t: T): Type.T =
-  BEGIN
-    (* Type and original_type should both transition to non-nil at about
-     * the same time and then never become nil.
-     *)
-    <* ASSERT (t.original_type = NIL) = (t.type = NIL) *>
-    IF t.original_type = NIL THEN
-      EVAL TypeOf (t);
-    END;
-    <* ASSERT t.original_type # NIL AND t.type # NIL *>
-    RETURN t.original_type;
-  END OriginalTypeOf;
 
 (* Externally dispatched-to: *)
 PROCEDURE RepTypeOf (t: T): Type.T =
@@ -277,7 +255,6 @@ PROCEDURE Compile (t: T) =
     Type.Compile (RepTypeOf (t));
     Type.Compile (t.refType);
     Type.Compile (Expr.TypeOf (t.dfault));
-    Type.Compile (OriginalTypeOf (t));
   END Compile;
 
 (* Externally dispatched-to: *)


### PR DESCRIPTION
They have been replaced by selectively not lowering type.
To retain NamedType.
This approach might not scale though. There are many other places
in m3front where original types are lost, relying
on backends to aggressively cast to a generic pointer type,
and to have structs that are just arrays of bytes.