### PR TITLE
m3core: Remove no longer used ulongjmp.

### DIFF
--- a/m3-libs/m3core/src/C/Common/Csetjmp.i3
+++ b/m3-libs/m3core/src/C/Common/Csetjmp.i3
@@ -5,11 +5,6 @@
 UNSAFE INTERFACE Csetjmp;
 FROM Ctypes IMPORT int;
 
-(* temporary for compat, not used; u is for underscore;
- * _longjmp does not save/restore signal mask, saving much time
- *)
-<*EXTERNAL "Csetjmp__ulongjmp" *> PROCEDURE ulongjmp (env: ADDRESS; val: int);
-
 (* Modula-3 exception uses setjmp/longjmp, without signal mask save/restore
  * TODO: Use C++ exceptions or Win32 exceptions or libunwind.
  *)

--- a/m3-libs/m3core/src/C/Common/CsetjmpC.c
+++ b/m3-libs/m3core/src/C/Common/CsetjmpC.c
@@ -6,19 +6,6 @@
 extern "C" {
 #endif
 
-// _longjmp does not work on Solaris/C++ because it is std::_longjump.
-#if !defined(__sun) || !defined(__cplusplus)
-
-// Temporary for compat, not used.
-// u is for underscore, do not save/restore signal mask.
-#if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__)
-M3WRAP_RETURN_VOID(Csetjmp__ulongjmp, longjmp, (jmp_buf env, int val), (env, val))
-#else
-M3WRAP_RETURN_VOID(Csetjmp__ulongjmp, _longjmp, (jmp_buf env, int val), (env, val))
-#endif
-
-#endif
-
 // This is messy.
 //  - _setjmp does not work in Solaris C++; it is accidentally placed in std::
 //  - sigsetjmp is a good portable idea. We should use it on all Unix platforms.


### PR DESCRIPTION
It has been replaced with m3_longjmp.