### PR TITLE
m3core: Arrange for Csetjmp__longjmp prototype to match

### DIFF
--- a/m3-libs/m3core/src/C/Common/Csetjmp.i3
+++ b/m3-libs/m3core/src/C/Common/Csetjmp.i3
@@ -5,9 +5,11 @@
 UNSAFE INTERFACE Csetjmp;
 FROM Ctypes IMPORT int;
 
+TYPE jmp_buf = ADDRESS; (* Name for m3core.h to replace. *)
+
 (* Modula-3 exception uses setjmp/longjmp, without signal mask save/restore
  * TODO: Use C++ exceptions or Win32 exceptions or libunwind.
  *)
-<*EXTERNAL "Csetjmp__m3_longjmp" *> PROCEDURE m3_longjmp (env: ADDRESS; val: int);
+<*EXTERNAL "Csetjmp__m3_longjmp" *> PROCEDURE m3_longjmp (env: jmp_buf; val: int);
 
 END Csetjmp.

--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -475,6 +475,7 @@ typedef ADDRESS MUTEX;
 #define Utypes__size_t              Utypes__size_t              /* inhibit m3c type */
 #define WinBaseTypes__const_UINT32  WinBaseTypes__const_UINT32  /* inhibit m3c type */
 #define Csignal__Handler            Csignal__Handler            /* inhibit m3c type */
+#define Csetjmp__jmp_buf            Csetjmp__jmp_buf            /* inhibit m3c type */
 
 typedef size_t        Cstddef__size_t;
 typedef ssize_t       Cstddef__ssize_t;
@@ -492,6 +493,12 @@ typedef void*         Ctypes__void_star;
 typedef size_t        Utypes__size_t;             // redundant
 typedef UINT32        WinBaseTypes__const_UINT32;
 typedef void (__cdecl*Csignal__Handler)(int s);
+
+#ifdef __sun /* Messy. See Csetjmp.c. */
+typedef sigjmp_buf    Csetjmp__jmp_buf;
+#else
+typedef jmp_buf       Csetjmp__jmp_buf;
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
when m3c output and hand written .c combined.