### PR TITLE
m3core: Coroutines: remove the need for one function to try to allocate stack space for another function.

### DIFF
--- a/m3-libs/m3core/src/coroutine/Common/Coroutine.i3
+++ b/m3-libs/m3core/src/coroutine/Common/Coroutine.i3
@@ -43,6 +43,10 @@ PROCEDURE Call(c : T) : T;
      list of stacks to another thread's list in ThreadPThread.m3) 
   *)
 
+(* Internal implementation details, between Modula3 and C. *)
+PROCEDURE CallInternal(to : T; myId: UNTRACED REF INTEGER; VAR me : T): T;
+PROCEDURE RunInternal(inhibit : T);
+
 PROCEDURE Retval(c : T) : REFANY;
   (* returns NIL if coroutine c is still active, returns return value
      of apply if c is done executing *)

--- a/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.i3
+++ b/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.i3
@@ -3,7 +3,7 @@
 (* see the file COPYRIGHT-INTEL for more information *)
 
 UNSAFE INTERFACE ContextC;
-IMPORT Ctypes;
+IMPORT Ctypes, Coroutine;
 FROM CoroutineUcontext IMPORT Arg, Entry;
 
 TYPE T = ADDRESS;
@@ -39,8 +39,14 @@ PROCEDURE SetLink(tgt, src : T); (* set return link of tgt to be src *)
 
 <*EXTERNAL ContextC__GetStackBase*>
 PROCEDURE GetStackBase(t : T) : ADDRESS;
+
+<*EXTERNAL ContextC__PushContextForRun*>
+PROCEDURE PushContextForRun(inhibit: Coroutine.T; t: T);
   
-<*EXTERNAL ContextC__PushContext*>
-PROCEDURE PushContext(t : T) : ADDRESS;
+<*EXTERNAL ContextC__PushContextForCall*>
+PROCEDURE PushContextForCall(to: Coroutine.T; myId: UNTRACED REF INTEGER; VAR me: Coroutine.T; t: T): Coroutine.T;
+
+<*EXTERNAL ContextC__Stack*>
+PROCEDURE Stack() : ADDRESS;
 
 END ContextC.


### PR DESCRIPTION
There are two ways to do this:
 - Continuation passing style -- call instead of return; that
   is done here.

 - Continuation passing style-lite; similar, but
   all the C code would do is allocate a local and pass its
   address and size to Modula3. Modula3 would then memmove.
   The result would be generally easier to understand
   and can be presented separately.
   The downside of this approach is that it is less general.
   The more general approach is arbitrary code move around
   between arbitrary functions, and a series of calls
   that are logically tail calls.
   The first solution is only about hiding the size of structures.
   Also notice the const-ness of the memmove size.