### PR TITLE
m3core: m3c/c convergence.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -471,8 +471,19 @@ typedef ptrdiff_t INTEGER;
 typedef size_t WORD_T;
 #endif
 
+// Something (m3front?) is indecisive as to if Word__T is INTEGER or INT64.
+// Or rather, if functions like Word__Divide, traffic in INTEGER or
+// Word__T. This could be m3front vs. Word.ig. This combines poorly
+// with Word__T sometimes being INT64. They do not match. As well,
+// between INT64 and INTEGER, INTEGER is preferred for portability.
+// But having actual unsigned types might be good too.
+//typedef INTEGER WORD_T;
+typedef INTEGER Word__T;
+// TODO replace WORD_T with Word__T
+
 #define INTEGER INTEGER /* Support concatenation with m3c output. */
-#define WORD_T WORD_T   /* Support concatenation with m3c output. */
+#define WORD_T  WORD_T  /* Support concatenation with m3c output. */
+#define Word__T Word__T /* Support concatenation with m3c output. */
 
 /* LONGINT is always signed and exactly 64 bits. */
 typedef INT64 LONGINT;


### PR DESCRIPTION
There are some confusions around Word.T.

 - Is it Word__T or WORD_T? Both exist.
 - Is it INTEGER or INT64 or an unsigned type (UINT64 or size_t). Both kinda.
 - Does Word.Divide etc. deal in INTEGER or Word__T? Both appear in imports.

This is a mess.
WORD_T was likely my accidental introduction. It should be Word__T.

However Modula-3's lack of full range unsigned types likely contributed to it.
I made WORD_T full range unsigned.

The varying imports of Word.Divide I suspect stem from Word being both
builtin into m3front and there being Word.ig files to parse.
It could also be lack of the new typename feature against the builtins.

And this shows up as errors if you combine m3c and C.

The builtins should probably use the typename Word__T and then m3c and m3core.h can decide what that is.
For Modula3 semantics it does probably have to be signed.
It might be desirable to have a full range unsigned type in the C, like size_t, except
that size_t is larger than pointers on some systems.

WORD cannot be used as that is 16bits on Windows, stemming from MS-DOS.
CARDINAL is another entry to this field (and LONGCARD).

In this PR, the mess is mostly left as is however m3core.h typedefs
Word__T to INTEGER. INTEGER, while signed, is still preferable over
INT64 since it is correct for hypothetical 32bit systems (does anyone still use them?)
This allows compiling all the W*.c files with m3core.h.