### PR TITLE
m3core:M3toC: const fixes

### DIFF
--- a/m3-libs/m3core/src/C/Common/M3toC.i3
+++ b/m3-libs/m3core/src/C/Common/M3toC.i3
@@ -17,22 +17,22 @@ PROCEDURE CopyTtoS(t: TEXT): Ctypes.char_star;
    but not sharing any storage with "t".  The result should be passed
    to "FreeCopiedS" after it is irrelevant. *)
 
-PROCEDURE FreeCopiedS(s: Ctypes.char_star);
+PROCEDURE FreeCopiedS(s: Ctypes.const_char_star);
 (* Free the storage for "s", which must have been returned from a call
    of "CopyTtoS".  It is an unchecked runtime error to free "s" more
    than once or to use "s" after calling "FreeCopiedS(s)". *)
 
-PROCEDURE SharedTtoS(t: TEXT): Ctypes.char_star;
+PROCEDURE SharedTtoS(t: TEXT): Ctypes.const_char_star;
 (* Return a null-terminated C string with the same contents as "t".
    If possible, the result will share storage with "t".  "FreeSharedS"
    should be called on the value returned by "SharedTtoS". *)
 
-PROCEDURE FreeSharedS(t: TEXT;  s: Ctypes.char_star);
+PROCEDURE FreeSharedS(t: TEXT;  s: Ctypes.const_char_star);
 (* Free the storage for "s", which must have been returned from a call
    of "SharedTtoS(t)".  It is an unchecked runtime error to free "s" more
    than once or to use "s" after calling "FreeSharedS(s)". *)
 
-PROCEDURE FlatTtoS(t: TEXT): Ctypes.char_star;
+PROCEDURE FlatTtoS(t: TEXT): Ctypes.const_char_star;
 (* Return a null-terminated C string with the same contents as "t", where
    the result shares storage with "t".  It is a checked runtime if "t" is
    not a flat text of "CHAR".   The standard "flat" texts are Text8,
@@ -45,12 +45,12 @@ PROCEDURE FlatTtoS(t: TEXT): Ctypes.char_star;
    Alternatively, the collector can be disabled.  See the
    "RTCollector" interface for details. *)
 
-PROCEDURE StoT(s: Ctypes.char_star): TEXT;
+PROCEDURE StoT(s: Ctypes.const_char_star): TEXT;
 (* Return a text with the same contents as the null-terminated C
    string "s" and sharing storage with "t".  The result is invalid
    after "s" is freed. *)
 
-PROCEDURE CopyStoT(s: Ctypes.char_star): TEXT;
+PROCEDURE CopyStoT(s: Ctypes.const_char_star): TEXT;
 (* Return a text with the same contents as the null-terminated C
    string "s". This copies "s", so the result is valid even if "s" is
    later freed. *)

--- a/m3-libs/m3core/src/C/Common/M3toC.m3
+++ b/m3-libs/m3core/src/C/Common/M3toC.m3
@@ -25,7 +25,6 @@ TYPE
     length : INTEGER;
   END;
 
-
 PROCEDURE CopyTtoS (t: TEXT): Ctypes.char_star =
   VAR info: TextClass.Info;  arr: OpenArray;
   BEGIN
@@ -40,15 +39,14 @@ PROCEDURE CopyTtoS (t: TEXT): Ctypes.char_star =
     RETURN arr.start;
   END CopyTtoS;
 
-PROCEDURE FreeCopiedS (s: Ctypes.char_star) =
+PROCEDURE FreeCopiedS (s: Ctypes.const_char_star) =
   BEGIN
     IF (s # NIL) AND (s # zeroPtr) THEN
       Cstdlib.free (s);
     END;
   END FreeCopiedS;
 
-
-PROCEDURE SharedTtoS (t: TEXT): Ctypes.char_star =
+PROCEDURE SharedTtoS (t: TEXT): Ctypes.const_char_star =
   VAR info: TextClass.Info;
   BEGIN
     IF (t = NIL) THEN RETURN zeroPtr; END;
@@ -62,7 +60,7 @@ PROCEDURE SharedTtoS (t: TEXT): Ctypes.char_star =
     RETURN CopyTtoS (t);
   END SharedTtoS;
 
-PROCEDURE FreeSharedS (t: TEXT;  s: Ctypes.char_star) =
+PROCEDURE FreeSharedS (t: TEXT;  s: Ctypes.const_char_star) =
   VAR info: TextClass.Info;
   BEGIN
     IF (s # NIL) AND (s # zeroPtr) THEN
@@ -73,8 +71,7 @@ PROCEDURE FreeSharedS (t: TEXT;  s: Ctypes.char_star) =
     END;
   END FreeSharedS;
 
-
-PROCEDURE FlatTtoS (t: TEXT): Ctypes.char_star =
+PROCEDURE FlatTtoS (t: TEXT): Ctypes.const_char_star =
   VAR info: TextClass.Info;
   BEGIN
     IF (t = NIL) THEN RETURN zeroPtr; END;
@@ -90,13 +87,12 @@ PROCEDURE FlatTtoS (t: TEXT): Ctypes.char_star =
     RETURN NIL;
   END FlatTtoS;
 
-
-PROCEDURE StoT (s: Ctypes.char_star): TEXT =
+PROCEDURE StoT (s: Ctypes.const_char_star): TEXT =
   BEGIN
     RETURN Text8CString.New (s);
   END StoT;
 
-PROCEDURE CopyStoT (s: Ctypes.char_star): TEXT =
+PROCEDURE CopyStoT (s: Ctypes.const_char_star): TEXT =
   VAR len := Cstring.strlen (s);  t := Text8.Create (len);
   BEGIN
     EVAL Cstring.memcpy (ADR (t.contents[0]), s, len);


### PR DESCRIPTION
Const is missing in a number of places here.
This shows up when you combine m3c output with m3core.h, in which I made similar fixes.