### PR TITLE
m3c / m3core: Repair integer types.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -511,6 +511,7 @@ typedef INTEGER m3_uid_t;
 // and could be ommited here as well.
 //
 // The names should match the .i3 files, assuming full qualification and replacing "." with "__".
+#define Cstddef__ptrdiff_t          Cstddef__ptrdiff_t          /* inhibit m3c type */
 #define Cstddef__size_t             Cstddef__size_t             /* inhibit m3c type */
 #define Cstddef__ssize_t            Cstddef__ssize_t            /* inhibit m3c type */
 #define Cstdio__FILE_star           Cstdio__FILE_star           /* inhibit m3c type */
@@ -524,13 +525,17 @@ typedef INTEGER m3_uid_t;
 #define Ctypes__int_star            Ctypes__int_star            /* inhibit m3c type */
 #define Ctypes__long                Ctypes__long                /* inhibit m3c type */
 #define Ctypes__size_t              Ctypes__size_t              /* inhibit m3c type */
+#define Ctypes__unsigned            Ctypes__unsigned            /* inhibit m3c type */
+#define Ctypes__unsigned_int        Ctypes__unsigned_int        /* inhibit m3c type */
 #define Ctypes__unsigned_long       Ctypes__unsigned_long       /* inhibit m3c type */
+#define Ctypes__unsigned_long_int   Ctypes__unsigned_long_int   /* inhibit m3c type */
 #define Ctypes__void_star           Ctypes__void_star           /* inhibit m3c type */
 #define Utypes__size_t              Utypes__size_t              /* inhibit m3c type */
 #define WinBaseTypes__const_UINT32  WinBaseTypes__const_UINT32  /* inhibit m3c type */
 
 typedef size_t        Cstddef__size_t;
-typedef ssize_t       Cstddef__ssize_t;
+typedef ssize_t       Cstddef__ssize_t; /* provided above for msc */
+typedef ptrdiff_t     Cstddef__ptrdiff_t;
 typedef FILE*         Cstdio__FILE_star;
 typedef char          Ctypes__char;
 typedef char*         Ctypes__char_star;
@@ -541,7 +546,10 @@ typedef const void*   Ctypes__const_void_star;
 typedef int           Ctypes__int;
 typedef int*          Ctypes__int_star;
 typedef long          Ctypes__long;
+typedef unsigned      Ctypes__unsigned;
+typedef unsigned      Ctypes__unsigned_int;
 typedef unsigned long Ctypes__unsigned_long;
+typedef unsigned long Ctypes__unsigned_long_int;
 typedef void*         Ctypes__void_star;
 typedef size_t        Utypes__size_t;             // redundant
 typedef UINT32        WinBaseTypes__const_UINT32;

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -713,8 +713,7 @@ END TypeText;
 TYPE Type_t = OBJECT
     bit_size := 0;  (* FUTURE Target.Int or LONGINT *)
     typeid: TypeUID := 0;
-    text: TEXT := NIL; (* Replaced with typename. Use for params, returns, locals, globals, fields. *)
-    base_text: TEXT := NIL; (* The first value, typically a hash. Use for maybe typedefs and struct definitions. *)
+    text: TEXT := NIL;
     cgtype: CGType := CGType.Addr;
     state := Type_State.None;
 METHODS
@@ -919,9 +918,7 @@ BEGIN
 
     IF NOT x.typedef_defined.insert(typetext) THEN
       ifndef (self, typetext);
-      (* TODO It might be possible to eliminate the hashed names. *)
-      print(x, "typedef " & type.refers_to_type.base_text & " " & typetext & ";");
-      type.refers_to_type.text := typetext;
+      print(x, "typedef " & type.refers_to_type.text & " " & typetext & ";");
       endif (self);
     END;
 END typename_define;
@@ -1084,9 +1081,9 @@ BEGIN
         NARROW(record.fields.get(j), Field_t).type.Define(self);
     END;
 
-    ifndef(x, record.base_text); (* ifdef so multiple files can be concatenated and compiled at once *)
+    ifndef(x, record.text); (* ifdef so multiple files can be concatenated and compiled at once *)
 
-    print(x, "/*record_define*/struct " & record.base_text & "{\n");
+    print(x, "/*record_define*/struct " & record.text & "{\n");
 
     FOR j := 0 TO field_count - 1 DO
         field := NARROW(record.fields.get(j), Field_t);
@@ -1283,7 +1280,7 @@ OVERRIDES
 END;
 
 PROCEDURE array_forwardDeclare(type: Array_t; self: T) =
-VAR id := type.base_text;
+VAR id := type.text;
 BEGIN
     (*  typedef struct foo foo is different than
         struct foo; typedef struct foo foo, in the presence of C++ namespaces?,
@@ -1302,9 +1299,9 @@ PROCEDURE fixedArray_define(type: FixedArray_t; x: T) =
 BEGIN
     type.element_type.Define(x);
 
-    ifndef(x, type.base_text); (* ifdef so multiple files can be concatenated and compiled at once *)
+    ifndef(x, type.text); (* ifdef so multiple files can be concatenated and compiled at once *)
 
-    print(x, "/*fixedArray_define*/struct " & type.base_text & "{");
+    print(x, "/*fixedArray_define*/struct " & type.text & "{");
     print(x, type.element_type.text);
     print(x, " _elts[");
     print(x, IntToDec(type.bit_size DIV type.element_type.bit_size));
@@ -1349,9 +1346,9 @@ BEGIN
         element_type_text := "char/*TODO*/";
     END;
 
-    ifndef(x, type.base_text); (* ifdef so multiple files can be concatenated and compiled at once *)
+    ifndef(x, type.text); (* ifdef so multiple files can be concatenated and compiled at once *)
 
-    text := "/*openArray_define*/struct " & type.base_text & "{\n" & element_type_text;
+    text := "/*openArray_define*/struct " & type.text & "{\n" & element_type_text;
     FOR i := 1 TO dimensions DO
         text := text & "*";
     END;
@@ -1458,7 +1455,6 @@ BEGIN
             type.text := TypeIDToText(type.typeid) & type_text_tail;
         END;
     END;
-    type.base_text := type.text;
 
     IF type.typeid # -1 AND type.typeid # 0 THEN
         EVAL self.typeidToType.put(type.typeid, type);
@@ -3134,7 +3130,7 @@ BEGIN
             typeid := typeid,
             refers_to_typeid := target,
             brand := brand,
-            text := target_typename,
+            target_typename := target_typename,
             traced := traced));
 END declare_pointer_no_trace;
 


### PR DESCRIPTION
m3front issues:
 declare_typename INTEGER size_t  very questionable
 declare_typename INTEGER ssize_t ok

To cope with this, maybe more than necessary:
 - m3core.h: provide the various unsigned, unsigned_long, unsigned_int, etc. types.
   When combined with m3c output and m3core.h comes first,
   this will lock them in as unsigned as they probably should be.
   It is in their names, right?

   This is only needed in as much as these types occur in
   prototypes in hand written C, so this is probably overkill,
   which is why I said "and then some".

 - m3c: In declare_typename, stop replacing types
   with typenames; so for example INT64 will not change to size_t.
   Typenames remain for parameters, for which the aggressive
   typename work was initially intended, but not on types,
   where I was probably being too clever, not then
   being used where there are no typenames.

This addresses the error resulting from the combination of:

 ADDRESS Cstddef_I3(Cstddef__ptrdiff_t)
 ADDRESS Cstddef_I3(Cstddef__size_t)

which is obviously wrong. These typename-less prototypes
come from special case code in m3front. Another fix
would be to give them typenames for consistency.
Which is to say, all parameters should have typenames.
The types of variables matter less, because there is
no "combination", and their uses are full of casts.

In working on this, it struck me that VMS needs work.
It violates the presumed size matches among pointer, size_t, intptr_t, INTEGER.
Like m3core/src/C/VMS will be needed if we ever really run on VMS.