### PR TITLE
m3c: st_mtime is a macro on Unix and cannot be used along with include

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -533,6 +533,9 @@ Cstring.i3 declares strcpy and strcat incorrectly..on purpose.
 (* brk, sbrk deprecated on MacOS X 10.10.4, ok on 10.5.8. *)
 "brk", "sbrk",
 
+(* st_mtime is a macro on Linux and cannot be used along with #include sys/stat.h *)
+"st_mtime",
+
 (* symbols internal to the generated code *)
 "M3_HIGH_BITS",
 "M3_LOW_BITS",


### PR DESCRIPTION
sys/stat.h. Replace it with another.