### PR TITLE
m3core: DragonT.strtod was declared incorrectly.

### DIFF
--- a/m3-libs/m3core/src/float/Common/DragonT.i3
+++ b/m3-libs/m3core/src/float/Common/DragonT.i3
@@ -27,12 +27,6 @@ PROCEDURE F (e              : INTEGER;
    For Quad precision EXTENDED
    The 128 mantissa bits are ((f3 & 16_ffffffff) << 96) + (f2 & 16_ffffffff << 64) +                 
                              ((f1 & 16_ffffffff) << 32) + (f0 & 16_ffffffff) *)
-
-
-<*EXTERNAL strtod*>
-PROCEDURE strtod (nptr: Ctypes.char_star; 
-                  eptr: Ctypes.char_star_star): LONGREAL;
-
 END DragonT.
 
 (*

--- a/m3-libs/m3core/src/float/IEEE/LongFloat.m3
+++ b/m3-libs/m3core/src/float/IEEE/LongFloat.m3
@@ -13,7 +13,7 @@ UNSAFE MODULE LongFloat;
    that do not depend on the operating system. *)
 
 IMPORT LongRealRep AS Rep;
-IMPORT DragonT, FPU, Word, Ctypes, Convert, Grisu;
+IMPORT DragonT, FPU, Word, Ctypes, Convert, Grisu, Cstdlib;
 
 PROCEDURE Scalb (x: T; n: INTEGER): T =
   BEGIN
@@ -207,7 +207,7 @@ PROCEDURE FromDecimal (sign   : [0..1];
     END;
     buf[len] := 0;
 
-    res := FLOAT (DragonT.strtod (ADR(buf[0]), NIL), T);
+    res := FLOAT (Cstdlib.strtod (ADR(buf[0]), NIL), T);
     DISPOSE(buf);
     RETURN res
   END FromDecimal;

--- a/m3-libs/m3core/src/float/IEEE/RealFloat.m3
+++ b/m3-libs/m3core/src/float/IEEE/RealFloat.m3
@@ -13,7 +13,7 @@ UNSAFE MODULE RealFloat;
    that do not depend on the operating system. *)
 
 IMPORT RealRep AS Rep;
-IMPORT DragonT, FPU, Word, Ctypes, Convert, Grisu;
+IMPORT DragonT, FPU, Word, Ctypes, Convert, Grisu, Cstdlib;
 
 PROCEDURE Scalb (x: T; n: INTEGER): T =
   BEGIN
@@ -186,7 +186,7 @@ PROCEDURE FromDecimal (sign   : [0..1];
     END;
     buf[len] := 0;
 
-    res := FLOAT (DragonT.strtod (ADR(buf[0]), NIL), T);
+    res := FLOAT (Cstdlib.strtod (ADR(buf[0]), NIL), T);
     DISPOSE(buf);
     RETURN res
   END FromDecimal;

--- a/m3-libs/m3core/src/float/VAX/LongFloat.m3
+++ b/m3-libs/m3core/src/float/VAX/LongFloat.m3
@@ -9,7 +9,7 @@
 
 UNSAFE MODULE LongFloat;
 
-IMPORT FPU, LongRealRep, Convert, DragonT, Ctypes, Word;
+IMPORT FPU, LongRealRep, Convert, DragonT, Ctypes, Word, Cstdlib;
 
 PROCEDURE Scalb(x: T; n: INTEGER): T =
   BEGIN
@@ -114,7 +114,7 @@ PROCEDURE FromDecimal(
     END;
     buf[len] := 0;
 
-    res := FLOAT (DragonT.strtod (ADR(buf[0]), NIL), T);
+    res := FLOAT (Cstdlib.strtod (ADR(buf[0]), NIL), T);
     DISPOSE(buf);
     RETURN res
   END FromDecimal;

--- a/m3-libs/m3core/src/float/VAX/RealFloat.m3
+++ b/m3-libs/m3core/src/float/VAX/RealFloat.m3
@@ -10,7 +10,7 @@
 
 UNSAFE MODULE RealFloat;
 
-IMPORT FPU, RealRep, Convert, DragonT, Ctypes, Word;
+IMPORT FPU, RealRep, Convert, DragonT, Ctypes, Word, Cstdlib;
 
 PROCEDURE Scalb(x: T; n: INTEGER): T =
   BEGIN
@@ -117,7 +117,7 @@ PROCEDURE FromDecimal(
     END;
     buf[len] := 0;
 
-    res := FLOAT (DragonT.strtod (ADR(buf[0]), NIL), T);
+    res := FLOAT (Cstdlib.strtod (ADR(buf[0]), NIL), T);
     DISPOSE(buf);
     RETURN res
   END FromDecimal;


### PR DESCRIPTION
Use Cstdlib.strtod instead.