### PR TITLE
m3c: Disable typenames again.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2807,6 +2807,8 @@ BEGIN
     RETURN;
   END;
 
+  RETURN; (* TODO temporarily disable typenames *)
+
   TextToId (nameText);
   (* typename is like pointer but without the star and without a hash in the name *)
   self.Type_Init (NEW (Typename_t, text := nameText, refers_to_typeid := typeid, name := name));
@@ -3281,6 +3283,9 @@ BEGIN
   ELSE
     x.comment ("declare_formal");
   END;
+
+  typename := M3ID.NoID; (* TODO temporarily disable typenames *)
+
   procType.typeids [procType.index] := typeid;
   procType.typenames [procType.index] := typename;
   INC (procType.index);
@@ -4895,6 +4900,9 @@ BEGIN
     ELSE
         self.comment("internal_declare_param");
     END;
+
+    typename_text := NIL;  (* TODO temporarily disable typenames *)
+    typename := M3ID.NoID; (* TODO temporarily disable typenames *)
 
     type_text := TypeText (self, cgtype, typename_text, typeid, type_text, name);
 


### PR DESCRIPTION
There are several problems to fix.

 - We are issuing typedefs for typenames before the base type
   is defined or forward declared.

 - Fixing that is at first easy, you hook Typename_t into
   the existing framework, where types are defined or forward
   declared as possible, until done.

 - However you then run into that m3front omits many typenames.

 - And possibly the hash collisions.