### PR TITLE
m3front: RefType: declare_typename before declare_pointer.

### DIFF
--- a/m3-sys/m3front/src/types/RefType.m3
+++ b/m3-sys/m3front/src/types/RefType.m3
@@ -170,12 +170,13 @@ PROCEDURE Compiler (p: P) =
   BEGIN
     Type.Compile (p.target);
     typeid := Type.GlobalUID (p);
-    CG.Declare_pointer (typeid, Type.GlobalUID (p.target),
-                        Brand.ToText (p.brand), p.isTraced);
     user_name := p.user_name;
+    (* declare_typename before declare_pointer helps C backend render indirect better *)
     IF user_name # NIL THEN
       CG.Declare_typename (typeid, M3ID.Add (user_name));
     END;
+    CG.Declare_pointer (typeid, Type.GlobalUID (p.target),
+                        Brand.ToText (p.brand), p.isTraced);
   END Compiler;
 
 (* EXPORTED *)


### PR DESCRIPTION
This is a little gross.
Most code does not care about the order.
typenames are not much of a thing.

The C backend however sees a bunch of typenames.
Including that it will synthesize many missing typenames,
like for parameters (or fix m3front?).

Faced with so many typenames, the dilema becomes, what
to use for a typeid in the absence of a nearby typename.

The first name for most types is or shall be merely
a string form of the hash. This suffices for most purposes,
but is ugly, and does not suffice for quite all purposes.

What will likely be the case, is the first non-hash form
will stick. Specifically, the first typename for an indirect or pointer
will be whatever is the underlying's current name, followed by a "*".

Therefore it behooves us to try to give a nice typename before an indirect.

Hopefully a better design will materialize, such as typeid always
coming along with typename, and/or pass full "REF m3front Type" to all m3cg calls
and let the caller decide what information to use.

Again, this is a little gross. The ordering here is a bit of a private
interface between m3front and m3c. m3c does work either way, as long
as each file is compiled on its own. Another solution will be use
nametyped indirect parameters interfacing to C and never var/readonly.
C interop is considered fairly special, and small local interfaces are
often used, instead of C masquerading as Modula-3, so that would be ok.
The time/data code in particular is passing VAR to C.