### PR TITLE
m3c: Remove CARDINAL as a special symbol.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -594,7 +594,6 @@ Cstring.i3 declares strcpy and strcat incorrectly..on purpose.
 "m3_set_sym_difference",
 "m3_set_union",
 "WORD_T",
-"CARDINAL",
 "DOTDOTDOT",
 "STRUCT",
 "INT8", "UINT8", "INT16", "UINT16", "INT32", "UINT32", "INT64", "UINT64",


### PR DESCRIPTION
It was getting replaced with m3_CARDINAL in an upcoming change and breaking stuff.
Putting it in the list here was confusing user code with m3c.
CARDINAL will not occur in user code, because it is reserved in Modula-3.
This is a list of reserved C and m3c identifiers, not a list of Modula-3 identifiers.