### PR TITLE
m3core: Introduce Utime__time_t = m3_time64_t (=INT64=longlong).

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -673,9 +673,12 @@ ssize_t __cdecl Uuio__write(int, const void*, WORD_T);
 
 typedef INT64 m3_time64_t;
 
+#define Utime__time_t Utime__time_t /* inhibit m3c type */
+typedef /*const*/ m3_time64_t Utime__time_t; /* TODO READONLY should imply const */
+
 #ifndef _WIN32
 m3_time64_t __cdecl Utime__time(m3_time64_t* tloc);
-char* __cdecl Utime__ctime(const m3_time64_t* m);
+char* __cdecl Utime__ctime(/*TODO const*/ m3_time64_t* m);
 #endif
 void __cdecl Utime__tzset(void);
 

--- a/m3-libs/m3core/src/unix/Common/UtimeC.c
+++ b/m3-libs/m3core/src/unix/Common/UtimeC.c
@@ -31,7 +31,7 @@ Utime__time(m3_time64_t* tloc)
 M3_DLL_EXPORT
 char*
 __cdecl
-Utime__ctime(const m3_time64_t* m)
+Utime__ctime(/*TODO const*/ m3_time64_t* m)
 {
     m3_time_t t = m ? (m3_time_t)*m : 0;
 #ifdef _TIME64_T


### PR DESCRIPTION
This is to aid in m3c/C convergence.

This is a confusing area -- too many ideas to name.

Some systems just have time_t. It traditionally
was 32bits, but is these days 64bits.

Some systems to retain compatibility and widen
have a 32bit time_t and a 64bit time_t by some name,
such as time64_t. Tru64 for example has time64_t.

If the underlying system has an explicit 64bit time,
we use that in C. And we call it m3_time_t.
Otherwise, if there is no special 64bit time,
we use "normal" time_t (hopefully 64bits), and call it m3_time_t also.

In Modula3 we have just Utime.time_t and it is always
64 bits, and we convert back and forth through direct
integer assignment/truncation/widening to m3_time_t.
On some systems, maybe there is lossage, but there are
likely no such systems under active development.
Also, if all the times eminate from the underlying system
and not Modula-3 code (math??) then there is no lossage.

We could likely reduce this song and dance and just
assume a 64bit time_t, or a sufficient time_t, but
that would most likely degrade at least one platform, Tru64.

Windows also has both time formats and possibly varying default.

We should probably eliminate m3_time64_t and just call it Utime__time_t.
i.e. we do have more names than necessary.

Take away const, as something not crucial and not generally done well in the system.
Maybe restore it later.