### PR TITLE
m3front: Debug scaffolding.

### DIFF
--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -10,8 +10,10 @@ MODULE CG;
 
 IMPORT Text, IntIntTbl, IntRefTbl, Fmt, Word;
 IMPORT Scanner, Error, Module, RunTyme, WebInfo;
-IMPORT M3, M3CG, M3CG_Ops, M3CG_Check, M3ID;
+IMPORT M3, M3CG, M3CG_Ops, M3CG_Check, M3ID, RTParams;
 IMPORT Host, Target, TInt, TFloat, TWord, TargetMap, M3RT (**, RTObject **);
+
+VAR debug := FALSE;
 
 CONST
   Max_init_chars = 256; (* max size of a single init_chars string *)
@@ -4236,5 +4238,6 @@ VAR Log2OfByte : INTEGER := 3;
 
 BEGIN
   <* ASSERT Word.LeftShift (1,Log2OfByte) = Target.Byte *>
+  debug := RTParams.IsPresent ("m3front-debug-cg");
 END CG.
 

--- a/m3-sys/m3front/src/types/NamedType.m3
+++ b/m3-sys/m3front/src/types/NamedType.m3
@@ -10,7 +10,10 @@ MODULE NamedType;
 
 IMPORT M3, M3ID, Token, Type, TypeRep, Scanner, ObjectType;
 IMPORT Error, Scope, Brand, Value, ErrType, Target;
+IMPORT RTParams;
 FROM M3 IMPORT QID;
+
+VAR debug := FALSE;
 
 TYPE
   P = Type.T BRANDED "NamedType.T" OBJECT
@@ -216,4 +219,5 @@ PROCEDURE FPrinter (p: P;  VAR x: M3.FPInfo) =
   END FPrinter;
 
 BEGIN
+  debug := RTParams.IsPresent ("m3front-debug-namedtype");
 END NamedType.

--- a/m3-sys/m3front/src/types/ProcType.m3
+++ b/m3-sys/m3front/src/types/ProcType.m3
@@ -11,7 +11,10 @@ MODULE ProcType;
 IMPORT M3, M3ID, CG, Expr, Type, TypeRep, Value, Scope, Target;
 IMPORT Formal, UserProc, Token, Ident, CallExpr, Word, Error;
 IMPORT ESet, TipeMap, TipeDesc, ErrType, M3Buf, Variable, OpenArrayType;
+IMPORT RTParams;
 FROM Scanner IMPORT Match, GetToken, cur;
+
+VAR debug := FALSE;
 
 TYPE
   P = Type.T BRANDED "ProcType.T" OBJECT
@@ -528,4 +531,5 @@ PROCEDURE FPrinter (p: P;  VAR x: M3.FPInfo) =
   END FPrinter;
 
 BEGIN
+  debug := RTParams.IsPresent ("m3front-debug-proctype");
 END ProcType.

--- a/m3-sys/m3front/src/types/RefType.m3
+++ b/m3-sys/m3front/src/types/RefType.m3
@@ -12,6 +12,9 @@ IMPORT M3, M3ID, CG, Token, Type, TypeRep, Scanner, ObjectType, Target;
 IMPORT Null, Reff, Addr, Error, Module, M3Buf, Brand;
 IMPORT Revelation, OpenArrayType, TipeMap, TipeDesc, TypeFP;
 IMPORT ProcType, ObjectAdr, Word, M3RT;
+IMPORT RTParams;
+
+VAR debug := FALSE;
 
 TYPE
   P = Type.T BRANDED "RefType.T"OBJECT
@@ -403,4 +406,5 @@ PROCEDURE FPrinter (p: P;  VAR x: M3.FPInfo) =
   END FPrinter;
 
 BEGIN
+  debug := RTParams.IsPresent ("m3front-debug-reftype");
 END RefType.

--- a/m3-sys/m3front/src/types/Type.m3
+++ b/m3-sys/m3front/src/types/Type.m3
@@ -15,7 +15,10 @@ IMPORT Value, Module, Host, TypeFP, TypeTbl, WCharr, Brand;
 IMPORT Addr, Bool, Charr, Card, EReel, Int, LInt, LReel, Mutex, Null;
 IMPORT ObjectRef, ObjectAdr, Reel, Reff, Textt, Target, TInt, TFloat;
 IMPORT Text, M3RT, TipeMap, TipeDesc, ErrType, OpenArrayType, M3ID;
+IMPORT RTParams;
 FROM M3 IMPORT QID;
+
+VAR debug := FALSE;
 
 CONST
   NOT_CHECKED = -1;
@@ -1009,4 +1012,5 @@ PROCEDURE AddrNoStraddle
   END AddrNoStraddle;
 
 BEGIN
+  debug := RTParams.IsPresent ("m3front-debug-type");
 END Type.

--- a/m3-sys/m3front/src/values/Formal.m3
+++ b/m3-sys/m3front/src/values/Formal.m3
@@ -12,6 +12,9 @@ IMPORT M3, M3ID, CG, Value, ValueRep, Type, Error, Expr, ProcType;
 IMPORT KeywordExpr, OpenArrayType, RefType, CheckExpr, PackedType;
 IMPORT ArrayType, ArrayExpr, SetType, Host, NarrowExpr, M3Buf, Tracer;
 IMPORT Variable, Procedure, UserProc, Target, M3RT;
+IMPORT RTParams;
+
+VAR debug := FALSE;
 
 TYPE
   T = Value.T BRANDED OBJECT 
@@ -1177,4 +1180,5 @@ PROCEDURE GenCopy (type: Type.T) =
   END GenCopy;
 
 BEGIN
+  debug := RTParams.IsPresent ("m3front-debug-formal");
 END Formal.

--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -16,7 +16,10 @@ IMPORT Target, TInt, Token, Ident, Module, CallExpr;
 IMPORT Decl, Null, Int, LInt, Fmt, Procedure, Tracer;
 IMPORT Expr, IntegerExpr, ArrayExpr, TextExpr, NamedExpr;
 IMPORT Type, OpenArrayType, ErrType, TipeMap;
+IMPORT RTParams;
 FROM Scanner IMPORT GetToken, Match, cur;
+
+VAR debug := FALSE;
 
 CONST
   Big_Local = 8192; (* x Target.Char.size *)
@@ -1040,4 +1043,5 @@ PROCEDURE ScheduleTrace (t: T) =
   END ScheduleTrace;
 
 BEGIN
+  debug := RTParams.IsPresent ("m3front-debug-variable");
 END Variable.


### PR DESCRIPTION
In a few modules Foo.m3, introduce:

VAR debug := FALSE;
.
.
.
BEGIN
  debug := RTParams.Present ("m3front-debug-foo");
END Foo.

so that later:

  IF debug THEN
    RTIO...
  END

So then cm3 @M3m3front-debug-foo will enable printing.

Even if/when m3c debugging is better, data intensive programs
benefit from "logging".