### PR TITLE
m3-sys: Plumb typename through import_global.

### DIFF
--- a/m3-sys/m3front/src/misc/CG.i3
+++ b/m3-sys/m3front/src/misc/CG.i3
@@ -171,7 +171,7 @@ PROCEDURE Set_runtime_proc (n: Name;  p: Proc);
 *)
 
 PROCEDURE Import_global (n: Name;  s: Size;  a: Alignment;
-                         t: Type;  m3t: TypeUID): Var;
+                         t: Type;  m3t: TypeUID; typename := M3ID.NoID): Var;
 (* imports the specified global variable. *)
 
 PROCEDURE Declare_segment (n: Name;  m3t: TypeUID;  is_const: BOOLEAN): Var;

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -446,12 +446,12 @@ PROCEDURE Set_runtime_proc (n: Name;  p: Proc) =
 (*------------------------------------------------- variable declarations ---*)
 
 PROCEDURE Import_global (n: Name;  s: Size;  a: Alignment;  t: Type;
-                         m3t: TypeUID): Var =
+                         m3t: TypeUID; typename: Name): Var =
   VAR ref: REFANY;  v: Var;
   BEGIN
     IF (variables = NIL) THEN variables := NewNameTbl () END;
     IF variables.get (n, ref) THEN RETURN ref END;
-    v := cg.import_global (n, ToVarSize (s, a), ByteAlign (a), t, m3t);
+    v := cg.import_global (n, ToVarSize (s, a), ByteAlign (a), t, m3t, typename);
     EVAL variables.put (n, v);
     RETURN v;
   END Import_global;

--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -570,8 +570,9 @@ PROCEDURE Declare (t: T): BOOLEAN =
       externName := Value.GlobalName (t, dots := FALSE, with_module := FALSE);
       externM3ID := M3ID.Add (externName);
       t.nextTWACGVar := TsWCGVars;  TsWCGVars := t;
-      t.cg_var
-        := CG.Import_global (externM3ID, size, align, mtype, 0(*no mangling*));
+      Type.Typename (t.type, typename);
+
+      t.cg_var := CG.Import_global (externM3ID, size, align, mtype, 0(*no mangling*), typename);
       t.cg_align := align;
 
     ELSIF (t.imported) THEN

--- a/m3-sys/m3middle/src/M3CG.m3
+++ b/m3-sys/m3middle/src/M3CG.m3
@@ -364,9 +364,9 @@ PROCEDURE set_runtime_proc (xx: T;  n: Name;  p: Proc) =
 (*------------------------------------------------- variable declarations ---*)
 
 PROCEDURE import_global (xx: T;  n: Name;  s: ByteSize;  a: Alignment;
-                         t: Type;  m3t: TypeUID; <*UNUSED*>typename: Name): Var =
+                         t: Type;  m3t: TypeUID; typename: Name): Var =
   BEGIN
-    RETURN xx.child.import_global (n, s, a, t, m3t);
+    RETURN xx.child.import_global (n, s, a, t, m3t, typename);
   END import_global;
 
 PROCEDURE declare_segment (xx: T;  n: Name;  m3t: TypeUID; is_const: BOOLEAN): Var =

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -722,6 +722,7 @@ PROCEDURE import_global (VAR s: State) =
       type  := Scan_type (s);
       m3t   := Scan_tipe (s);
       v     := Scan_int (s);
+      (* TODO typename *)
   BEGIN
     AddVar (s, v, s.cg.import_global (name, size, align, type, m3t));
   END import_global;

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -681,6 +681,7 @@ PROCEDURE import_global (u: U;  n: Name;  s: ByteSize;  a: Alignment;
     TName (u, t);
     Tipe  (u, m3t);
     VName (u, v);
+    (* TODO typename *)
     RETURN v;
   END import_global;
 

--- a/m3-sys/m3middle/src/M3CG_MultiPass.i3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.i3
@@ -65,7 +65,7 @@ TYPE declare_constant_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; align
 TYPE declare_local_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; OVERRIDES replay := replay_declare_local END;
 TYPE declare_param_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; in_memory, up_level: BOOLEAN; frequency: Frequency; typename := M3ID.NoID; OVERRIDES replay := replay_declare_param END;
 TYPE declare_temp_t = op_tag_t OBJECT byte_size: ByteSize; alignment: Alignment; type: Type; in_memory: BOOLEAN; OVERRIDES replay := replay_declare_temp END;
-TYPE import_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; OVERRIDES replay := replay_import_global END;
+TYPE import_global_t = op_tag_t OBJECT name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: typeid_t; typename := M3ID.NoID; OVERRIDES replay := replay_import_global END;
 
 TYPE set_error_handler_t = op_t OBJECT proc: PROCEDURE(msg: TEXT); OVERRIDES replay := replay_set_error_handler END;
 TYPE begin_procedure_t = op_t OBJECT proc: INTEGER(*proc_t*); OVERRIDES replay := replay_begin_procedure END;

--- a/m3-sys/m3middle/src/M3CG_MultiPass.m3
+++ b/m3-sys/m3middle/src/M3CG_MultiPass.m3
@@ -332,10 +332,10 @@ BEGIN
     RETURN label;
 END next_label;
 
-PROCEDURE import_global(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; <*UNUSED*>typename: Name): Var =
+PROCEDURE import_global(self: T; name: Name; byte_size: ByteSize; alignment: Alignment; type: Type; typeid: TypeUID; typename: Name): Var =
 VAR var := self.refs.NewVar();
 BEGIN
-self.Add(NEW(import_global_t, op := Op.import_global, name := name, byte_size := byte_size, alignment := alignment, type := type, typeid := typeid, tag := var.tag));
+self.Add(NEW(import_global_t, op := Op.import_global, name := name, byte_size := byte_size, alignment := alignment, type := type, typeid := typeid, typename := typename, tag := var.tag));
 RETURN var;
 END import_global;
 
@@ -1105,7 +1105,7 @@ END replay_declare_procedure;
 
 PROCEDURE replay_import_global(self: import_global_t; replay: Replay_t; cg: cg_t) =
 BEGIN
-    replay.PutRef(self.tag, cg.import_global(self.name, self.byte_size, self.alignment, self.type, self.typeid));
+    replay.PutRef(self.tag, cg.import_global(self.name, self.byte_size, self.alignment, self.type, self.typeid, self.typename));
 END replay_import_global;
 
 PROCEDURE replay_begin_procedure(self: begin_procedure_t; replay: Replay_t; cg: cg_t) =

--- a/m3-sys/m3middle/src/M3CG_Rd.m3
+++ b/m3-sys/m3middle/src/M3CG_Rd.m3
@@ -835,6 +835,7 @@ PROCEDURE import_global (VAR s: State) =
       type  := Scan_type (s);
       m3t   := Scan_tipe (s);
       v     := Scan_varName (s);
+      (* TODO typename *)
   BEGIN
     AddVar (s, v, s.cg.import_global (name, size, align, type, m3t));
   END import_global;

--- a/m3-sys/m3middle/src/M3CG_Wr.m3
+++ b/m3-sys/m3middle/src/M3CG_Wr.m3
@@ -705,6 +705,7 @@ PROCEDURE import_global (u: U;  n: Name;  s: ByteSize;  a: Alignment;
     Tipe  (u, m3t);
     VName (u, v);
     NL    (u);
+    (* TODO typename *)
     RETURN v;
   END import_global;
 


### PR DESCRIPTION
This is needed so const_int and const_UINT32 are not lowered,
and then m3c and C agree.

The point is to preserve const, to keep the "variables" in
read only memory, which is more efficient -- is unlikely
to suffer copy on write (unless it is mprotected), and
will remain backed by original executable not pagefile,
and can remain in CPU cached shared instead of exclusive.

Later better typing may also be possible.