### PR TITLE
User threads: When attempting to measure stack,

### DIFF
--- a/m3-libs/m3core/src/thread/POSIX/ThreadPosixC.c
+++ b/m3-libs/m3core/src/thread/POSIX/ThreadPosixC.c
@@ -304,12 +304,13 @@ DisposeContext(Context **c)
   *c = NULL;
 }
 
+// Do not inline to help ensure stack range is understandable.
+M3_NO_INLINE
 void
 __cdecl
 ProcessContext(Context *c, char *bottom, char *top,
                void (*p) (void *start, void *limit))
 {
-  char xx = 0;
   if (top == NULL)
   {
     /* live thread */
@@ -319,7 +320,7 @@ ProcessContext(Context *c, char *bottom, char *top,
 #else
     if (getcontext(&(c->uc))) abort();
 #endif
-    top = &xx;
+    top = (char*)alloca(1);
   }
   if (bottom < top)
     p(bottom, top);


### PR DESCRIPTION
do not inline and do use alloca to get stack pointer
instead of the address of a local. Either should suffice.

The prior code could fail under optimization.
Caller inlined into callee, leads to intermingling of locals
and no ordering. Such inlining is possible with LTCG/LTO.

There are other places that use address of local.
But Modula-3 lacks noinline and alloca.
Arguably it is ok, as long as some uses are correct.
i.e. at least one of each caller/callee pair that attempt
math on their respective locals.

Also cooperative GC should remove most/all notion of stack,
some day.