### PR TITLE
m3front: Pass typeids for import_global.

### DIFF
--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -598,7 +598,7 @@ PROCEDURE Declare (t: T): BOOLEAN =
         RTIO.Flush ();
       END;
 
-      t.cg_var := CG.Import_global (externM3ID, size, align, mtype, 0(*no mangling*), typename);
+      t.cg_var := CG.Import_global (externM3ID, size, align, mtype, typeUID, typename);
       t.cg_align := align;
 
     ELSIF (t.imported) THEN


### PR DESCRIPTION
This is needed so C globals can be const.
Previously the code avoided this, with an unclear comment. Why?