### PR TITLE
m3c: Allow enabling verbosity in source.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -7854,9 +7854,9 @@ BEGIN
     BitsToUInt[64] := Text_uint64;
     SignedAndBitsToCGType[TRUE] := BitsToCGInt;
     SignedAndBitsToCGType[FALSE] := BitsToCGUInt;
-    debug_verbose := RTParams.IsPresent ("m3c-debug-verbose");
-    debug_types := RTParams.IsPresent ("m3c-debug-types");
-    debug := debug_verbose OR debug_types OR RTParams.IsPresent ("m3c-debug");
-    debug_comment_stdio := RTParams.IsPresent ("m3c-debug-comment-stdio");
-    debug_comment := debug_comment_stdio OR debug_types OR debug OR debug_verbose OR RTParams.IsPresent ("m3c-debug-comment");
+    debug_verbose := debug_verbose OR RTParams.IsPresent ("m3c-debug-verbose");
+    debug_types := debug_types OR RTParams.IsPresent ("m3c-debug-types");
+    debug := debug OR debug_verbose OR debug_types OR RTParams.IsPresent ("m3c-debug");
+    debug_comment_stdio := debug_comment_stdio OR RTParams.IsPresent ("m3c-debug-comment-stdio");
+    debug_comment := debug_comment OR debug_comment_stdio OR debug_types OR debug OR debug_verbose OR RTParams.IsPresent ("m3c-debug-comment");
 END M3C.


### PR DESCRIPTION
Or the globals with the command line variables.