### PR TITLE
m3c: Make duplicate types an error.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -1797,9 +1797,7 @@ BEGIN
 
     IF type.typeid # -1 AND type.typeid # 0 THEN
         IF TypeidToType_Get(self, type.typeid) # NIL THEN
-          IF debug_types THEN
-            self.comment ("Type_Init skipping duplicate " & TypeIDToText (type.typeid));
-          END;
+          Err (self, "Type_Init skipping duplicate " & Type_Fmt (type));
           RETURN;
         END;
         EVAL self.typeidToType.put(type.typeid, type);


### PR DESCRIPTION
LONGCARD was the only duplicate, self-inflicted.