### PR TITLE
m3core: Fix more Unix prototypes to m3c output and hand written C agree.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -746,15 +746,18 @@ int __cdecl Unix__ioctl(int fd, INTEGER request, void* argp);
 int __cdecl Unix__mknod(const char* path, m3_mode_t mode, m3_dev_t dev);
 m3_mode_t __cdecl Unix__umask(m3_mode_t newmask);
 
-struct m3_hostent_t;
-typedef struct m3_hostent_t m3_hostent_t;
+STRUCT_TYPEDEF(m3_hostent_t)
+
+#define Unetdb__struct_hostent_star Unetdb__struct_hostent_star /* inhibit m3c type */
+typedef m3_hostent_t* Unetdb__struct_hostent_star;
 
 m3_hostent_t* __cdecl Unetdb__gethostbyname(const char* name, m3_hostent_t* m3);
 m3_hostent_t* __cdecl Unetdb__gethostbyaddr(const char* addr, int len, int type, m3_hostent_t* m3);
 
+STRUCT_TYPEDEF(m3_group_t)
 
-struct m3_group_t;
-typedef struct m3_group_t m3_group_t;
+#define Ugrp__struct_group_star Ugrp__struct_group_star /* inhibit m3c type */
+typedef m3_group_t* Ugrp__struct_group_star;
 
 m3_group_t* __cdecl Ugrp__getgrent(m3_group_t* m3group);
 m3_group_t* __cdecl Ugrp__getgrgid(m3_group_t* m3group, m3_gid_t gid);


### PR DESCRIPTION
  gethostbyname
  gethostbyaddr
  getgrent
  getgrgid
  getgrnam

(struct hostent and struct group_t)