### PR TITLE
m3front: Restore globals to have uid=0 when not targeting C.

### DIFF
--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -598,6 +598,9 @@ PROCEDURE Declare (t: T): BOOLEAN =
         RTIO.Flush ();
       END;
 
+      IF Target.BackendMode # Target.M3BackendMode_t.C THEN
+        typeUID := 0(*no mangling*);
+      END;
       t.cg_var := CG.Import_global (externM3ID, size, align, mtype, typeUID, typename);
       t.cg_align := align;
 


### PR DESCRIPTION
The identifiers do get changed and link fails otherwise.
Broken in https://github.com/modula3/cm3/commit/49ce5350b6e7c135b7cba2da7871d1b4c984ce7e