### PR TITLE
m3core: Fix getpid prototype to agree between m3c and C.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -1014,6 +1014,8 @@ typedef passwd* Upwd__struct_passwd_star;
 passwd* __cdecl Upwd__getpwuid(m3_uid_t);
 passwd* __cdecl Upwd__getpwnam(char*);
 
+m3_pid_t __cdecl Uprocess__getpid (void);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/m3-libs/m3core/src/unix/Common/Uprocess.i3
+++ b/m3-libs/m3core/src/unix/Common/Uprocess.i3
@@ -4,8 +4,8 @@
 
 INTERFACE Uprocess;
 
-FROM Ctypes IMPORT int;
+FROM Utypes IMPORT pid_t;
 
-<*EXTERNAL "Uprocess__getpid"*>PROCEDURE getpid (): int;
+<*EXTERNAL "Uprocess__getpid"*>PROCEDURE getpid (): pid_t;
 
 END Uprocess.


### PR DESCRIPTION
Return m3_pid_t = INTEGER instead of int.