### PR TITLE
m3core: Fix pipe prototype to match between m3c and C.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -1019,6 +1019,24 @@ passwd* __cdecl Upwd__getpwnam(char*);
 
 m3_pid_t __cdecl Uprocess__getpid (void);
 
+#if 0 // This would be nice, but structural type equivalence gets
+      // in the way. There are other equivalent types
+      // and the names clash.
+#define Unix__PipeArray Unix__PipeArray /* inhibit m3c type */
+STRUCT_TYPEDEF(Unix__PipeArray)
+struct Unix__PipeArray
+{
+    int files [2];
+};
+
+int __cdecl Unix__pipe (Unix__PipeArray* files);
+
+#else
+
+int __cdecl UnixC__pipe (int* files);
+
+#endif
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/m3-libs/m3core/src/unix/Common/Unix.i3
+++ b/m3-libs/m3core/src/unix/Common/Unix.i3
@@ -108,7 +108,7 @@ PROCEDURE open (name: const_char_star; flags: int; mode: mode_t): int;
 CONST
   readEnd = 0;
   writeEnd = 1;
-<*EXTERNAL "Unix__pipe"*>PROCEDURE pipe (VAR fildes: ARRAY [0..1] OF int): int;
+PROCEDURE pipe (VAR fildes: ARRAY [0..1] OF int): int;
 
 <*EXTERNAL "Unix__readlink"*>
 PROCEDURE readlink (path: const_char_star; buf: ADDRESS; bufsize: INTEGER): INTEGER;

--- a/m3-libs/m3core/src/unix/Common/Unix.m3
+++ b/m3-libs/m3core/src/unix/Common/Unix.m3
@@ -1,8 +1,14 @@
-(* Copyright (C) 1993, Digital Equipment Corporation                  *)
-(* All rights reserved.                                               *)
-(* See the file COPYRIGHT for a full description.                     *)
+UNSAFE MODULE Unix;
+IMPORT UnixC;
+FROM Ctypes IMPORT int;
 
-MODULE Unix;
+(* This is unfortunate but structural type equivalence get in the way of
+ * passing the fixed size array directly to C.
+ *)
+PROCEDURE pipe (VAR files: ARRAY [0..1] OF int): int =
+BEGIN
+  RETURN UnixC.pipe (ADR (files [0]));
+END pipe;
 
 BEGIN
   Assertions();

--- a/m3-libs/m3core/src/unix/Common/UnixC.c
+++ b/m3-libs/m3core/src/unix/Common/UnixC.c
@@ -122,7 +122,6 @@ M3WRAP3(int, execve, const char*, char**, char**)
 M3WRAP1(unsigned, sleep, unsigned)
 M3WRAP3(m3_off_t, lseek, int, m3_off_t, int)
 M3WRAP2(int, mkdir, const char*, m3_mode_t)
-M3WRAP1(int, pipe, int*)
 M3WRAP2(int, gethostname, char*, size_t)
 M3WRAP2(char*, getcwd, char*, size_t)
 
@@ -188,7 +187,7 @@ Unix__mkdir(const char* path, m3_mode_t mode)
 }
 
 M3_DLL_EXPORT int __cdecl
-Unix__pipe(int* files)
+UnixC__pipe (int* files)
 {
     return _pipe(files, 0, _O_BINARY);
 }
@@ -287,6 +286,25 @@ Unix__ioctl(int fd, INTEGER request, void* argp)
     return r;
 }
 
+#endif
+
+#ifndef _WIN32
+#undef M3MODULE /* Support concatenating multiple .c files. */
+#define M3MODULE UnixC
+
+#if 0 // This would be nice, but structural type equivalence gets
+      // in the way. There are other equivalent types
+      // and the names clash.
+int __cdecl Unix__pipe (Unix__PipeArray* files)
+{
+    return pipe (files->files);
+}
+
+#else
+
+M3WRAP1(int, pipe, int*)
+
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/m3-libs/m3core/src/unix/Common/UnixC.i3
+++ b/m3-libs/m3core/src/unix/Common/UnixC.i3
@@ -1,0 +1,7 @@
+UNSAFE INTERFACE UnixC;
+
+FROM Ctypes IMPORT int, int_star;
+
+<*EXTERNAL "UnixC__pipe"*>PROCEDURE pipe (fildes: int_star): int;
+
+END UnixC.

--- a/m3-libs/m3core/src/unix/Common/m3makefile
+++ b/m3-libs/m3core/src/unix/Common/m3makefile
@@ -1,5 +1,6 @@
 c_source ("UtimeC")
 c_source ("UnixC")
+interface("UnixC")
 c_source ("UnixLink")
 Interface("Uexec")
 c_source("Uexec")


### PR DESCRIPTION
Fixed sized array is not exactly pointer to element.
We cannot declare and pass fixed sized arrays to C
because other fixed sized arrays passed indirectly will clash.
Typenames should be able to help here but do not presently.