### PR TITLE
m3core: Fix vfork prototype. pid_t must match else C compiler

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Unix.i3
+++ b/m3-libs/m3core/src/unix/Common/Unix.i3
@@ -129,9 +129,12 @@ PROCEDURE unlink (path: const_char_star): int;
   see RTProcess.Fork *)
 
 (* Do not wrap vfork in C; doing so violates the Posix standard, because
- callers of vfork cannot return without calling exec or _exit. *)
+ * callers of vfork cannot return without calling exec or _exit.
+ * vfork must return int, not pid_t. C compilation will fail
+ * otherwise when combining m3c output with hand written C (m3core.h).
+ *)
 <*EXTERNAL*>
-PROCEDURE vfork (): pid_t;
+PROCEDURE vfork (): int;
 
 <*EXTERNAL "Unix__mknod"*>
 PROCEDURE mknod (path: const_char_star; mode: mode_t; dev: dev_t): int;


### PR DESCRIPTION
fails, at least if the C headers are included.
Use int here, and hope all platforms are ok with that.
Consider widening pid_t. Note that we never use vfork but the wrapper
is left for users outside of tree.