### PR TITLE
m3core: Fix Unix__ioctl prototype.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -745,7 +745,7 @@ int __cdecl Unix__ftruncate(int fd, m3_off_t length);
 m3_off_t __cdecl Unix__lseek(int fd, m3_off_t offset, int whence);
 m3_off_t __cdecl Unix__tell(int fd);
 int __cdecl Unix__fcntl(int fd, INTEGER request, INTEGER arg);
-int __cdecl Unix__ioctl(int fd, INTEGER request, void* argp);
+int __cdecl Unix__ioctl(int fd, INTEGER request, ADDRESS argp);
 int __cdecl Unix__mknod(const char* path, m3_mode_t mode, m3_dev_t dev);
 m3_mode_t __cdecl Unix__umask(m3_mode_t newmask);
 

--- a/m3-libs/m3core/src/unix/Common/UnixC.c
+++ b/m3-libs/m3core/src/unix/Common/UnixC.c
@@ -270,7 +270,7 @@ Unix__fcntl(int fd, INTEGER request, INTEGER m3_arg)
 }
 
 M3_DLL_EXPORT int __cdecl
-Unix__ioctl(int fd, INTEGER request, void* argp)
+Unix__ioctl(int fd, INTEGER request, ADDRESS argp)
 /* ioctl is varargs. See fcntl. */
 {
 /* Errno preservation for success:


### PR DESCRIPTION
ADDRESS is not currently the same as void*. Use ADDRESS. Hopefully fix it later.
This is so m3c output and hand written C agree and can be combined.