### PR TITLE
m3core: Fix Udir__readdir to match between m3c output and C.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -698,6 +698,9 @@ ssize_t __cdecl Usocket__recvfrom(int s, void* buf, size_t len, int flags, M3Soc
 DIR* __cdecl Udir__opendir(const char* a);
 #define Udir__DIR_star Udir__DIR_star /* inhibit m3c type */
 typedef DIR*           Udir__DIR_star;
+#define Udir__struct_dirent_star Udir__struct_dirent_star /* inhibit m3c type */
+STRUCT_TYPEDEF(dirent)
+typedef dirent* Udir__struct_dirent_star;
 #endif
 
 // char* (caddr_t) instead of void* for default Solaris

--- a/m3-libs/m3core/src/unix/Common/UdirC.c
+++ b/m3-libs/m3core/src/unix/Common/UdirC.c
@@ -11,7 +11,7 @@
 #undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Udir
 M3WRAP1(DIR*, opendir, const char*)
-M3WRAP1(void*, readdir, DIR*)
+M3WRAP1(dirent*, readdir, DIR*)
 M3WRAP1(int, closedir, DIR*)
 
 #endif


### PR DESCRIPTION
Return struct dirent* instead of void*.
So they can be combined into one file.