### PR TITLE
m3core, tcp: Remove Process_Exitor from C surface area.

### DIFF
--- a/m3-comm/tcp/src/WIN32/IP.m3
+++ b/m3-comm/tcp/src/WIN32/IP.m3
@@ -103,5 +103,7 @@ PROCEDURE GetHostAddr(): Address =
   END GetHostAddr;
 
 BEGIN
-  IPInternal.Init();
+  IF IPInternal.Init() THEN
+    Process.RegisterExitor(IPInternal.Exitor);
+  END;
 END IP.

--- a/m3-comm/tcp/src/common/IPInternal.i3
+++ b/m3-comm/tcp/src/common/IPInternal.i3
@@ -31,7 +31,10 @@ PROCEDURE InterpretError(err: int) RAISES {IP.Error};
 (* The rest is C code so Modula3 does not interact directly with /usr/include. *)
 
 <*EXTERNAL "IPInternal__Init"*>
-PROCEDURE Init();
+PROCEDURE Init(): BOOLEAN; (* true for success and register exiter *)
+
+<*EXTERNAL "IPInternal__Exitor"*>
+PROCEDURE Exitor();
 
 (* return hostent=NIL for error to mimic old patterns *)
 <*EXTERNAL "IPInternal__GetHostByName"*>

--- a/m3-comm/tcp/src/common/IP_c.c
+++ b/m3-comm/tcp/src/common/IP_c.c
@@ -269,19 +269,16 @@ IPInternal__GetNameInfo(int family, int port, const void* addr, TEXT* hostText, 
     return err;
 }
 
-#ifdef _WIN32
-
-static
 void
 __cdecl
 IPInternal__Exitor(void)
 {
+#ifdef _WIN32
     WSACleanup();
+#endif
 }
 
-#endif
-
-void
+BOOLEAN
 __cdecl
 IPInternal__Init(void)
 {
@@ -292,10 +289,13 @@ IPInternal__Init(void)
     WSADATA data;
     ZeroMemory(&data, sizeof(data));
     if (WSAStartup(WinSockVersion, &data))
+    {
         IPError__Die();
-    else
-        Process__RegisterExitor(IPInternal__Exitor);
+        return FALSE;
+    }
+    return TRUE; // Process__RegisterExitor(IPInternal__Exitor);
 #endif
+    return FALSE;
 }
 
 #ifndef _WIN32

--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -846,10 +846,6 @@ int
 __cdecl
 ThreadInternal__StackGrowsDown (void);
 
-void
-__cdecl
-Process__RegisterExitor(void (__cdecl*)(void));
-
 // GET_PC returns approximately size_t.
 // Broadly speaking, try to keep most platform specific code here.
 


### PR DESCRIPTION
Now that function pointers (ProcType) are untyped (char*),
because they are very prone to type hash collisions,
because they do not hash their return type (besides that the hashing is overall weak),
we can no longer declare Process__RegisterExitor in C
and agree with m3c output.

As a reasonable workaround, return TRUE from IPInternal.Init (C)
and have Modula-3 then Process.RegisterExitor.

The Win32-specific exitor is then added to Unix, but the body
is internally ifdefed, so the function exists but does nothing,
and will never be called.

Another workaround would be to pick the Exitor type for all function pointers, as long as C only needs one accurate function pointer type.
Another workaround is likely to add a typename to Process.i3 for the exiter parameter, instead of an inline type expression.
Any of these is ok.