### PR TITLE
m3core: Remove Cstdlib.atexit.

### DIFF
--- a/m3-libs/m3core/src/C/Common/Cstdlib.i3
+++ b/m3-libs/m3core/src/C/Common/Cstdlib.i3
@@ -13,7 +13,6 @@ FROM Ctypes IMPORT int, char_star, const_char_star, char_star_star, double,
 FROM Cstddef IMPORT size_t;
 
 <*EXTERNAL Cstdlib__abort*>  PROCEDURE abort ();
-<*EXTERNAL Cstdlib__atexit*> PROCEDURE atexit (func: PROCEDURE ()): int;
 <*EXTERNAL Cstdlib__exit*>   PROCEDURE exit (status: int);
 <*EXTERNAL Cstdlib__getenv*> PROCEDURE getenv (name: const_char_star): char_star;
 <*EXTERNAL Cstdlib__system*> PROCEDURE system (string: const_char_star): int;

--- a/m3-libs/m3core/src/C/Common/CstdlibC.c
+++ b/m3-libs/m3core/src/C/Common/CstdlibC.c
@@ -13,9 +13,6 @@ extern "C" {
 #undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Cstdlib
 
-typedef void (__cdecl*AtExitFunction)(void);
-
-M3WRAP1(int, atexit, AtExitFunction)
 M3WRAP1(char*, getenv, const char*)
 M3WRAP1(int, system, const char*)
 M3WRAP2(double, strtod, const char*, char**)


### PR DESCRIPTION
This is another case where function pointer hash collisions
cause Cstdlib.atexit declaration to fail to compile.

Again we could fix with:
 typename
 loophole
 having this be the one function pointer type
 improve the hashing

This is not used in the tree. Remove it.
If this a problem, we can try the others.