### PR TITLE
m3tcp: Fix build or warnings.

### DIFF
--- a/m3-comm/tcp/src/WIN32/IP.m3
+++ b/m3-comm/tcp/src/WIN32/IP.m3
@@ -11,7 +11,7 @@
 
 UNSAFE MODULE IP;
 
-IMPORT IPError, M3toC, IPInternal, Ctypes;
+IMPORT IPError, M3toC, IPInternal, Ctypes, Process;
 TYPE int = Ctypes.int;
 
 (************

--- a/m3-comm/tcp/src/common/IP_h.h
+++ b/m3-comm/tcp/src/common/IP_h.h
@@ -57,7 +57,7 @@ void
 __cdecl
 IPInternal__CopyStoT(const char* name, TEXT* text);
 
-void
+BOOLEAN
 __cdecl
 IPInternal__Init(void);
 


### PR DESCRIPTION
IPInternal__Init now returns BOOLEAN.
IMPORT Process on Win32.