### PR TITLE
m3quake: MxConfigC__HOST returns const char* not char*.

### DIFF
--- a/m3-sys/m3quake/src/MxConfigC.c
+++ b/m3-sys/m3quake/src/MxConfigC.c
@@ -41,7 +41,7 @@ ToUpper(char* a)
     }
 }
 
-char*
+const char*
 __cdecl
 MxConfigC__HOST(void)
 {


### PR DESCRIPTION
Fix combining m3c and C.