### PR TITLE
Ongoing m3c/C convergence.

### DIFF
--- a/m3-libs/libm3/src/os/POSIX/OSConfigPosix.m3
+++ b/m3-libs/libm3/src/os/POSIX/OSConfigPosix.m3
@@ -6,7 +6,7 @@ UNSAFE MODULE OSConfigPosix EXPORTS OSConfig, OSConfigPosixC;
 IMPORT Env, OSError, Process, OSConfigPosixC, M3toC, Ctypes;
 (* IMPORT OSConfigPosix_DefaultOSName, OSConfigPosix_DefaultArch; *)
 
-TYPE char_star = Ctypes.char_star;
+TYPE const_char_star = Ctypes.const_char_star;
 
 VAR
   host_name  : TEXT := NIL;
@@ -54,7 +54,7 @@ PROCEDURE UserHome (): TEXT =
 
 (*---------------------------------------------------------- internal ---*)
 
-PROCEDURE CopyStoT (c: char_star; VAR text: TEXT) =
+PROCEDURE CopyStoT (c: const_char_star; VAR text: TEXT) =
 BEGIN
   IF text = NIL THEN
     text := M3toC.CopyStoT(c);
@@ -62,7 +62,7 @@ BEGIN
 END CopyStoT;
 
 (* Callback from C to Modula3 so that C does not traffic in traced references. *)
-PROCEDURE InitFromC (c_host_name, c_host_arch, c_os_name, c_os_version: char_star) =
+PROCEDURE InitFromC (c_host_name, c_host_arch, c_os_name, c_os_version: const_char_star) =
 BEGIN
   CopyStoT(c_host_name, host_name);
   CopyStoT(c_host_arch, host_arch);

--- a/m3-libs/libm3/src/os/POSIX/OSConfigPosixC.i3
+++ b/m3-libs/libm3/src/os/POSIX/OSConfigPosixC.i3
@@ -3,10 +3,10 @@
 
 INTERFACE OSConfigPosixC;
 
-FROM Ctypes IMPORT char_star;
+FROM Ctypes IMPORT const_char_star;
 
 (* Callback from C to Modula3 so that C does not traffic in traced references. *)
-PROCEDURE InitFromC (host_name, host_arch, os_name, os_version: char_star);
+PROCEDURE InitFromC (host_name, host_arch, os_name, os_version: const_char_star);
 
 <*EXTERNAL OSConfigPosixC__InitC*>
 PROCEDURE InitC ();

--- a/m3-libs/m3core/src/C/Common/CsetjmpC.c
+++ b/m3-libs/m3core/src/C/Common/CsetjmpC.c
@@ -35,18 +35,18 @@ extern "C" {
 //
 // Wrapper for longjmp / siglongjmp specifically for use by Modula-3 exception handling.
 #ifdef __sun
-void __cdecl Csetjmp__m3_longjmp(sigjmp_buf env, int val)
+void __cdecl Csetjmp__m3_longjmp(Csetjmp__jmp_buf env, int val)
 {
-    siglongjmp(env, val);
+    siglongjmp(*env, val);
 }
 #else
-void __cdecl Csetjmp__m3_longjmp(jmp_buf env, int val)
+void __cdecl Csetjmp__m3_longjmp(Csetjmp__jmp_buf env, int val)
 {
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__)
     // No signal mask to save/restore, longjmp is the only longjmp.
-    longjmp(env, val);
+    longjmp(*env, val);
 #else
-    _longjmp(env, val);
+    _longjmp(*env, val);
 #endif
 }
 #endif

--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -583,9 +583,9 @@ typedef void (__cdecl*   Csignal__Handler)(int s);
 
 #define Csetjmp__jmp_buf            Csetjmp__jmp_buf            /* inhibit m3c type */
 #ifdef __sun /* Messy. See Csetjmp.c. */
-typedef sigjmp_buf    Csetjmp__jmp_buf;
+typedef sigjmp_buf*   Csetjmp__jmp_buf;
 #else
-typedef jmp_buf       Csetjmp__jmp_buf;
+typedef jmp_buf*      Csetjmp__jmp_buf;
 #endif
 
 #define ContextC__T                    ContextC__T                    /* inhibit m3c type */
@@ -1038,8 +1038,26 @@ int __cdecl UnixC__pipe (int* files);
 
 #endif
 
-// see RT0.i3 for the types here
-// It would be good for the Modula-3 compiler to generate C headers.
+// See RTMachine.i3, RTStack.i3, RTStackC.c
+// TYPE Frame = RECORD pc, sp: ADDRESS END;
+#define RTStack__Frame RTStack__Frame /* inhibit m3c type */
+STRUCT_TYPEDEF(RTStack__Frame)
+struct RTStack__Frame
+{
+  ADDRESS pc; // program counter, instruction pointer, etc.
+  ADDRESS sp; // stack pointer
+};
+
+#if 0
+
+#define RT0__Binder       RT0__Binder       /* inhibit m3c type */
+#define RT0__Fingerprint  RT0__Fingerprint  /* inhibit m3c type */
+#define RT0__TypeInitProc RT0__TypeInitProc /* inhibit m3c type */
+#define RT0__Revelation   RT0__Revelation   /* inhibit m3c type */
+#define RT0__Typecell     RT0__Typecell     /* inhibit m3c type */
+#define RT0__TypeInitProc RT0__TypeInitProc /* inhibit m3c type */
+#define RT0__TypeLink     RT0__TypeLink     /* inhibit m3c type */
+#define RT0__ModulePtr    RT0__ModulePtr    /* inhibit m3c type */
 STRUCT_TYPEDEF(RT0__Module)
 STRUCT_TYPEDEF(RT0__Import)
 STRUCT_TYPEDEF(RT0__Revelation)
@@ -1049,9 +1067,11 @@ STRUCT_TYPEDEF(RT0__TypeLink)
 STRUCT_TYPEDEF(RT0__Proc)
 
 typedef unsigned char    RT0__Fingerprint[8]; // 64 bits, no alignment (but actually 2pointer aligned)
-
 typedef RT0__Module* (__cdecl*RT0__Binder)(INTEGER mode);
 typedef         void (__cdecl*RT0__TypeInitProc)(ADDRESS);
+typedef RT0__Module* RT0__ModulePtr;
+
+void __cdecl RTLinker__PrintModule(RT0__Module* module);
 
 struct RT0__Proc // one of these is generated for each top-level procedure
 {
@@ -1121,6 +1141,8 @@ struct RT0__Module
     RT0__Binder      binder;         // 44 88
     INTEGER          gc_flags;       // 48 96
 };
+
+#endif
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/m3-libs/m3core/src/runtime/POSIX/RTOSc.c
+++ b/m3-libs/m3core/src/runtime/POSIX/RTOSc.c
@@ -10,7 +10,7 @@ extern "C" {
 #define MAP_ANON MAP_ANONYMOUS
 #endif
 
-void*
+ADDRESS
 __cdecl
 RTOS__GetMemory(INTEGER isize)
 {
@@ -37,11 +37,11 @@ RTOS__GetMemory(INTEGER isize)
     // Anecdotal evidence:
     // https://github.com/modula3/cm3/commit/518f93e67ed8f3291a5cd5cf0a39d1fefbc79969
     // https://github.com/modula3/cm3/commit/384b3cc05fcedf4307f077f49cde3d6675b039c6
-    return sbrk(size);
+    return (ADDRESS)sbrk(size);
 
 #else
 
-    return mmap(0, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    return (ADDRESS)mmap(0, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
 
 #endif
 }

--- a/m3-libs/m3core/src/runtime/common/RTIOc.c
+++ b/m3-libs/m3core/src/runtime/common/RTIOc.c
@@ -68,17 +68,17 @@ void __cdecl RTIO__PutBytes(ADDRESS addr, INTEGER icount)
     fflush(NULL);
 }
 
-void __cdecl RTIO__PutLong(INT64 i)
+void __cdecl RTIO__PutLong(LONGINT i)
 {
     RTIO__Flush();
     printf("%" I64 "d", i);
     fflush(NULL);
 }
 
-void __cdecl RTIO__PutLongHex(UINT64 i)
+void __cdecl RTIO__PutLongHex(LONGINT i)
 {
     RTIO__Flush();
-    printf("0x%" I64 "x", i);
+    printf("0x%" I64 "x", (UINT64)i);
     fflush(NULL);
 }
 

--- a/m3-libs/m3core/src/runtime/common/RTLinker.i3
+++ b/m3-libs/m3core/src/runtime/common/RTLinker.i3
@@ -43,12 +43,14 @@ PROCEDURE RunMainBody (m: RT0.ModulePtr);
    Note: this procedure is only exported so that stack walkers
    can know when to quit looking at frames. *)
 
-<*EXTERNAL RTLinker__PrintString*> PROCEDURE PrintString (a : ADDRESS);
+(*
+<*EXTERNAL RTLinker__PrintString*> PROCEDURE PrintString (a : Ctypes.const_char_star);
 <*EXTERNAL RTLinker__PrintText*> PROCEDURE PrintText(a : TEXT);
 <*EXTERNAL RTLinker__PrintInt*> PROCEDURE PrintInt(a : INTEGER);
-<*EXTERNAL RTLinker__PrintModule*> PROCEDURE PrintModule(a : ADDRESS);
+<*EXTERNAL RTLinker__PrintModule*> PROCEDURE PrintModule(a : RT0.ModulePtr);
 (* TYPE Trace_t = { None, M3, C };
 <*EXTERNAL RTLinker__traceInit*> VAR traceInit : Trace_t; *)
+*)
 
 END RTLinker.
 

--- a/m3-libs/m3core/src/runtime/ex_frame/RTStackC.c
+++ b/m3-libs/m3core/src/runtime/ex_frame/RTStackC.c
@@ -21,19 +21,11 @@
 extern "C" {
 #endif
 
-/* TYPE Frame = RECORD pc, sp: ADDRESS END; */
-typedef struct {
-  unsigned long pc;
-  unsigned long sp;
-} Frame;
-
-
 /*---------------------------------------------------------------------------*/
 /* PROCEDURE GetThreadFrame (VAR f: Frame;  start: ADDRESS;  len: INTEGER);
    Return in "f" the frame of the thread whose machine state is in bytes
    [start .. start+len).  Returns with f.pc=NIL on failure. */
-
-void __cdecl RTStack__GetThreadFrame (Frame *f, char *start, int len)
+void __cdecl RTStack__GetThreadFrame (RTStack__Frame* f, ADDRESS start, INTEGER len)
 {
   abort ();
 }
@@ -42,7 +34,7 @@ void __cdecl RTStack__GetThreadFrame (Frame *f, char *start, int len)
 /* PROCEDURE CurrentFrame (VAR(*OUT*) f: Frame);
    Return in "f" the frame of its caller.  Returns with pc = NIL on failure. */
 
-void __cdecl RTStack__CurFrame (Frame *f)
+void __cdecl RTStack__CurFrame (RTStack__Frame* f)
 {
   abort ();
 }
@@ -51,8 +43,7 @@ void __cdecl RTStack__CurFrame (Frame *f)
 /* PROCEDURE PreviousFrame (READONLY f: Frame): Frame;
    Return the stack frame that called "f".  Returns with pc = NIL if
    "f" is the first frame on the stack or its predecessor is ill-formed. */
-
-void __cdecl RTStack__PrevFrame (Frame *callee, Frame *caller)
+void __cdecl RTStack__PrevFrame (RTStack__Frame* callee, RTStack__Frame* caller)
 {
   abort ();
 }
@@ -62,8 +53,7 @@ void __cdecl RTStack__PrevFrame (Frame *callee, Frame *caller)
    Restore the machine state back to the frame "f".  All callee-saved
    registers must be restored to the state they were in when frame "f"
    made its last call. */
-
-void __cdecl RTStack__Unwind (Frame *target)
+void __cdecl RTStack__Unwind (RTStack__Frame* target)
 {
   abort ();
 }
@@ -73,8 +63,7 @@ void __cdecl RTStack__Unwind (Frame *target)
    Return the null-terminated constant string that names the procedure
    corresponding to the stack frame "f".  Returns NIL if no name is
    known. */
-
-ADDRESS __cdecl RTStack__ProcName (Frame *f)
+ADDRESS __cdecl RTStack__ProcName (RTStack__Frame* f)
 {
   return 0;
 }


### PR DESCRIPTION
 - OSConfigPosixC.InitFromC: add const

 - RTStack: Redirect record Frame to C type in the new now usual way.
   (To avoid C code using type hashes.)
   Change unsigned long to ADDRESS to match Modula-3. The fields are not used.
   Their type does not matter. Not even the size of the struct matters.

 - RTIOc.c: replace INT64 and UINT64 with correct LONGINT,
   which is the type in RTIO.i3. Cast LONGINT to UINT64.

 - m3c: Try a little hack where all function types
   are void (*)(void) instead of the recent previous ADDRESS (char* or void*)
   Every case seen so far is actually this. This does not scale,
   but there is also only so much C code likely be subjected to this. We will see.
   Fixing the hashes is also desirable. More typenames. Or generating
   reasonable typenames. Or something.

 - RTLinkerC: Usual typename redirection to avoid hashes.
  Also disable the code.

 - m3c: A little more verbose output (comments in .c)

 - m3_longjmp: Fix Csetjmp__jmp_buf to be pointer to jmpbuf, not jmpbuf value.
   jmpbuf is array, that decays to pointer, but you cannot cast to it.