### PR TITLE
Revert "m3front: RefType: declare_typename before declare_pointer. (#549)"

### DIFF
--- a/m3-sys/m3front/src/types/RefType.m3
+++ b/m3-sys/m3front/src/types/RefType.m3
@@ -183,13 +183,12 @@ PROCEDURE Compiler (p: P) =
   BEGIN
     Type.Compile (p.target);
     typeid := Type.GlobalUID (p);
+    CG.Declare_pointer (typeid, Type.GlobalUID (p.target),
+                        Brand.ToText (p.brand), p.isTraced);
     user_name := p.user_name;
-    (* declare_typename before declare_pointer helps C backend render indirect better *)
     IF user_name # NIL THEN
       CG.Declare_typename (typeid, M3ID.Add (user_name));
     END;
-    CG.Declare_pointer (typeid, Type.GlobalUID (p.target),
-                        Brand.ToText (p.brand), p.isTraced);
   END Compiler;
 
 (* EXPORTED *)


### PR DESCRIPTION
This reverts commit 3fc7c4de10cd25f8ce3f3a911a9c645b829d6907.

This change was ok, but did not fully meet its goals.
The problem with having declare_typename replace the prior hashed typename,
is that we have things like:
Ctypes:
 TYPE int = ...;
 TYPE const_int = int;

And then some modules use int, some const_int, some maybe both in either order.
Considering just modules that only use one of them, sometimes the type
replacement is int, sometimes const_int. This is an inconsistency
that leads to errors when concatenting m3c output and C.

A more successful approach is to plumb typenames through more in context.
The missing one then is declare_pointer(target_typename) here.