### PR TITLE
libm3: Really fix const in OSConfig.

### DIFF
--- a/m3-libs/libm3/src/os/POSIX/OSConfigPosixC.i3
+++ b/m3-libs/libm3/src/os/POSIX/OSConfigPosixC.i3
@@ -2,11 +2,10 @@
 (* See file COPYRIGHT-CMASS for details. *)
 
 INTERFACE OSConfigPosixC;
-
-FROM Ctypes IMPORT const_char_star;
+IMPORT Ctypes;
 
 (* Callback from C to Modula3 so that C does not traffic in traced references. *)
-PROCEDURE InitFromC (host_name, host_arch, os_name, os_version: const_char_star);
+PROCEDURE InitFromC (host_name, host_arch, os_name, os_version: Ctypes.const_char_star);
 
 <*EXTERNAL OSConfigPosixC__InitC*>
 PROCEDURE InitC ();


### PR DESCRIPTION
Prior fix failed because the type got renamed to the local module.