### PR TITLE
m3core: Undef before define thousand, million, billion.

### DIFF
--- a/m3-libs/m3core/src/thread/Common/ThreadInternal.c
+++ b/m3-libs/m3core/src/thread/Common/ThreadInternal.c
@@ -44,6 +44,7 @@ enum {WaitResult_Ready, WaitResult_Error, WaitResult_FDError, WaitResult_Timeout
 /* ^Must match TYPE WaitResult declared in SchedularPosix.i3. */ 
 
 #undef THOUSAND /* Support concatenating multiple .c files. */
+#undef MILLION  /* Support concatenating multiple .c files. */
 #define THOUSAND (1000)
 #define MILLION (1000 * 1000)
 

--- a/m3-libs/m3core/src/time/POSIX/TimePosixC.c
+++ b/m3-libs/m3core/src/time/POSIX/TimePosixC.c
@@ -20,6 +20,8 @@ extern "C" {
 #endif
 
 #undef THOUSAND /* Support concatenating multiple .c files. */
+#undef MILLION  /* Support concatenating multiple .c files. */
+#undef BILLION  /* Support concatenating multiple .c files. */
 #define THOUSAND ((UINT64)1000)
 #define MILLION (THOUSAND * THOUSAND)
 #define BILLION (THOUSAND * MILLION)


### PR DESCRIPTION
In future will use longer identifiers.