### PR TITLE
m3core: Disable the specifying of visibility.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -46,7 +46,12 @@ typedef int BOOL;
 #define TRUE 1
 #define FALSE 0
 
-#if __GNUC__ >= 4 && !defined(__osf__) && !defined(__CYGWIN__)
+// This is disabled.
+// There are warnings about inconsistencies.
+// There is not all that much code that it affects.
+// We should be more worried the m3c output than the hand written C.
+// It is not clearly worth the platform-specificity.
+#if 0 /* __GNUC__ >= 4 && !defined(__osf__) && !defined(__CYGWIN__) */
 #define M3_HAS_VISIBILITY 1
 #else
 #define M3_HAS_VISIBILITY 0


### PR DESCRIPTION
There are warning about inconsistencies.
It is another platform-specificity that is maybe not worthwhile. Maybe.
We should be more worried about the visiblity of all the Modula-3 functions
than the relatively few hand written C functions?
(Besides, nobody ever asked for this optimization.)