### PR TITLE
m3core: dtoa fixes for C/m3c combination.

### DIFF
--- a/m3-libs/m3core/src/Csupport/big-endian/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/big-endian/dtoa.c
@@ -22,8 +22,8 @@
 extern "C" {
 #endif
 
-void CConvert__Acquire(INTEGER);
-void CConvert__Release(INTEGER);
+void __cdecl CConvert__Acquire(INTEGER);
+void __cdecl CConvert__Release(INTEGER);
 
 #ifdef __cplusplus
 } /* extern C */
@@ -32,3 +32,5 @@ void CConvert__Release(INTEGER);
 #endif /* STDC || C++ */
 
 #include "dtoa.h"
+
+#undef Bias

--- a/m3-libs/m3core/src/Csupport/little-endian/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/little-endian/dtoa.c
@@ -20,11 +20,13 @@
 extern "C" {
 #endif
 
-void CConvert__Acquire(WORD_T);
-void CConvert__Release(WORD_T);
+void __cdecl CConvert__Acquire(INTEGER);
+void __cdecl CConvert__Release(INTEGER);
 
 #ifdef __cplusplus
 } /* extern C */
 #endif
 
 #include "dtoa.h"
+
+#undef Bias


### PR DESCRIPTION
Undef Bias after use.
Fix CConvert__Acquire/Release prototype.
Add __cdecl (Windows/x86-ism, otherwise nop)