### PR TITLE
m3core: Consolidate dtoa.

### DIFF
--- a/m3-libs/m3core/src/Csupport/Common/dtoa.h
+++ b/m3-libs/m3core/src/Csupport/Common/dtoa.h
@@ -1,3 +1,26 @@
+#ifndef INCLUDED_M3CORE_H
+#include "m3core.h"
+#endif
+
+#ifndef __cplusplus
+#define KR_headers
+#endif
+
+#define MULTIPLE_THREADS
+#define ACQUIRE_DTOA_LOCK(n) CConvert__Acquire(n)
+#define FREE_DTOA_LOCK(n) CConvert__Release(n)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void __cdecl CConvert__Acquire(INTEGER);
+void __cdecl CConvert__Release(INTEGER);
+
+#ifdef __cplusplus
+} /* extern C */
+#endif
+
 #ifdef _MSC_VER
 #pragma warning(disable:4514) /* unused inline function removed */
 #pragma warning(disable:4242) /* possible loss of data */
@@ -3358,3 +3381,5 @@ m3_dtoa
 #if M3_HAS_VISIBILITY
 #pragma GCC visibility pop
 #endif
+
+#undef Bias

--- a/m3-libs/m3core/src/Csupport/big-endian/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/big-endian/dtoa.c
@@ -2,35 +2,7 @@
 /* All rights reserved.                                                      */
 /* See the file COPYRIGHT for a full description.                            */
 
-#ifndef INCLUDED_M3CORE_H
-#include "m3core.h"
-#endif
-
-#ifndef __cplusplus
-#define KR_headers
-#endif
 #define IEEE_MC68k
 #undef IEEE_8087
 
-#define MULTIPLE_THREADS
-#define ACQUIRE_DTOA_LOCK(n) CConvert__Acquire(n)
-#define FREE_DTOA_LOCK(n) CConvert__Release(n)
-
-#if defined(__STDC__) || defined(__cplusplus)
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void __cdecl CConvert__Acquire(INTEGER);
-void __cdecl CConvert__Release(INTEGER);
-
-#ifdef __cplusplus
-} /* extern C */
-#endif
-
-#endif /* STDC || C++ */
-
 #include "dtoa.h"
-
-#undef Bias

--- a/m3-libs/m3core/src/Csupport/little-endian/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/little-endian/dtoa.c
@@ -2,31 +2,7 @@
 /* All rights reserved.                                                      */
 /* See the file COPYRIGHT for a full description.                            */
 
-#ifndef INCLUDED_M3CORE_H
-#include "m3core.h"
-#endif
-
-#ifndef __cplusplus
-#define KR_headers
-#endif
 #define IEEE_8087
 #undef IEEE_MC68k
 
-#define MULTIPLE_THREADS
-#define ACQUIRE_DTOA_LOCK(n) CConvert__Acquire(n)
-#define FREE_DTOA_LOCK(n) CConvert__Release(n)
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void __cdecl CConvert__Acquire(INTEGER);
-void __cdecl CConvert__Release(INTEGER);
-
-#ifdef __cplusplus
-} /* extern C */
-#endif
-
 #include "dtoa.h"
-
-#undef Bias


### PR DESCRIPTION
 - Move what is repeated in the dtoa.c files into dtoa.h.
 - This should almost enable:

 cat m3core.h *.c dtoa.h > cm3.c

 except for the pesky include. Think about it more later.