### PR TITLE
AMD64_LINUX - build with -no-pie and DWARF-2

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_LINUX
@@ -1,10 +1,14 @@
 readonly TARGET = "AMD64_LINUX" % code generation target
 readonly GNU_PLATFORM = "amd64-linux" % "cpu-os" string for GNU
 
-SYSTEM_CC = "gcc -g -m64 -fPIC" % C compiler
-SYSTEM_CXXC = "g++ -g -m64 -fPIC" % C++ compiler
+SYSTEM_CC = "gcc -gdwarf-2 -gstrict-dwarf -m64 -fPIC" % C compiler
+SYSTEM_CXXC = "g++ -gdwarf-2 -gstrict-dwarf -m64 -fPIC" % C++ compiler
 
 readonly SYSTEM_ASM = "as --64" % Assembler
+
+% PIE debugging requires gdb 7.1 or newer, even for C
+% see http://www.gnu.org/software/gdb/download/ANNOUNCEMENT
+readonly POSITION_INDEPENDENT_EXECUTABLE = "-no-pie"
 
 include("AMD64.common")
 include("Linux.common")


### PR DESCRIPTION
AMD64_LINUX - build with -no-pie and DWARF-2

Tested on Debian 10.8.0 x64 with m3gdb builded on Debian 8.11.1 x64