### PR TITLE
m3core: Fix declaration of CConvert.strtod.

### DIFF
--- a/m3-libs/m3core/src/convert/CConvert.i3
+++ b/m3-libs/m3core/src/convert/CConvert.i3
@@ -11,10 +11,10 @@
 
 INTERFACE CConvert;
 
-FROM Ctypes IMPORT double, int, int_star, char_star, char_star_star; 
+FROM Ctypes IMPORT double, int, int_star, char_star, char_star_star, const_char_star;
 
 <* EXTERNAL m3_strtod *>
-PROCEDURE strtod (nptr: ADDRESS; VAR eptr: ADDRESS): LONGREAL;
+PROCEDURE strtod (str: const_char_star; ptr: char_star_star): double;
 (* Returns a nearest machine number to the input decimal string
    (or sets errno to ERANGE).  With IEEE arithmetic, ties are broken
    by the IEEE round-even rule.  Otherwise ties are broken by biased

--- a/m3-libs/m3core/src/convert/Convert.m3
+++ b/m3-libs/m3core/src/convert/Convert.m3
@@ -810,7 +810,7 @@ PROCEDURE ToBinary (
          VAR tmp        : Buffer;
          VAR used       : INTEGER;
          VAR value      : LONGREAL): BOOLEAN =
-  VAR ch: CHAR;  eptr: ADDRESS;  nchars: INTEGER := NUMBER (source);
+  VAR ch: CHAR;  eptr: Ctypes.char_star := NIL;  nchars: INTEGER := NUMBER (source);
   BEGIN
     (* copy source to tmp, fix the exponent character and null terminate *)
     FOR i := 0 TO nchars -1 DO
@@ -821,8 +821,8 @@ PROCEDURE ToBinary (
     tmp [nchars] := '\000';
 
     (* finally, do the conversion *)
-    value := strtod (ADR (tmp [0]), eptr);
-    IF eptr = LOOPHOLE (0, ADDRESS)
+    value := strtod (ADR (tmp [0]), ADR (eptr));
+    IF eptr = NIL
       THEN RETURN FALSE;
       ELSE used := eptr - ADR (tmp [0]); RETURN TRUE;
     END;


### PR DESCRIPTION
ADDRESS parameters are const_char_star and char_star_start.
And LONGREAL to double for consistency with Cstdlib.strtod.