### PR TITLE
Coroutine: Fix non-Linux/amd64 when combining m3c and C.

### DIFF
--- a/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.c
+++ b/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.c
@@ -62,7 +62,7 @@ ContextC__DisposeContext(Context* c)
     assert(0);
 }
 
-void*
+Context*
 __cdecl
 ContextC__Current(void)
 {


### PR DESCRIPTION
void* vs. Context*