### PR TITLE
m3core: Fix Apple-specific minor m3c/C divergences.

### DIFF
--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadApple.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadApple.c
@@ -25,7 +25,7 @@ void __cdecl ThreadApple__Dummy(void) { } /* avoid empty file */
 
 #else /* Apple */
 
-int
+BOOLEAN
 __cdecl
 ThreadPThread__SuspendThread (m3_pthread_t mt)
 {
@@ -36,7 +36,7 @@ ThreadPThread__SuspendThread (m3_pthread_t mt)
   {
     fprintf(stderr, "thread_suspend returned %d instead of %d\n",
             (int)status, (int)KERN_SUCCESS);
-    return 0;
+    return FALSE;
   }
   status = thread_abort_safely(mach_thread);
   if (status != KERN_SUCCESS)
@@ -50,12 +50,12 @@ ThreadPThread__SuspendThread (m3_pthread_t mt)
               (int)status, (int)KERN_SUCCESS);
       abort();
     }
-    return 0;
+    return FALSE;
   }
-  return 1;
+  return TRUE;
 }
 
-int
+BOOLEAN
 __cdecl
 ThreadPThread__RestartThread (m3_pthread_t mt)
 {
@@ -112,7 +112,7 @@ typedef _STRUCT_ARM_THREAD_STATE64 m3_thread_state_t;
 
 void
 __cdecl
-ThreadPThread__ProcessStopped (m3_pthread_t mt, void *bottom, void *context,
+ThreadPThread__ProcessStopped (m3_pthread_t mt, ADDRESS bottom, ADDRESS context,
                                void (*p)(void *start, void *limit))
 {
   char *sp = { 0 };

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -131,7 +131,7 @@ ThreadPThread__RestartThread (m3_pthread_t mt)
 
 void
 __cdecl
-ThreadPThread__ProcessStopped (m3_pthread_t mt, char *bottom, char *context,
+ThreadPThread__ProcessStopped (m3_pthread_t mt, ADDRESS bottom, ADDRESS context,
                                void (*p)(void *start, void *limit))
 {
   /* process stack */
@@ -152,9 +152,9 @@ ThreadPThread__ProcessStopped (m3_pthread_t mt, char *bottom, char *context,
 
 #else /* M3_DIRECT_SUSPEND */
 
-void __cdecl ThreadPThread__sem_wait(void)      { M3_DIRECT_SUSPEND_ASSERT_FALSE }
-void __cdecl ThreadPThread__sem_post(void)      { M3_DIRECT_SUSPEND_ASSERT_FALSE }
-void __cdecl ThreadPThread__sem_getvalue(void)  { M3_DIRECT_SUSPEND_ASSERT_FALSE }
+int __cdecl ThreadPThread__sem_wait(void)       { M3_DIRECT_SUSPEND_ASSERT_FALSE return -1; }
+int __cdecl ThreadPThread__sem_post(void)       { M3_DIRECT_SUSPEND_ASSERT_FALSE return -1; }
+int __cdecl ThreadPThread__sem_getvalue(void)   { M3_DIRECT_SUSPEND_ASSERT_FALSE return -1; }
 void __cdecl ThreadPThread__sigsuspend(void)    { M3_DIRECT_SUSPEND_ASSERT_FALSE }
 
 #endif /* M3_DIRECT_SUSPEND */


### PR DESCRIPTION
char* vs. void* (ADDRESS)
int vs. BOOLEAN
void vs. int return in functions that only assert(false)