### PR TITLE
m3core: Add memcmp/memset/memmove/memcpy wrappers, for m3c to generate calls to.

### DIFF
--- a/m3-libs/m3core/src/Csupport/hand.c
+++ b/m3-libs/m3core/src/Csupport/hand.c
@@ -16,6 +16,8 @@
 #include "m3core.h"
 #endif
 
+#include <string.h>
+
 #if M3_HAS_VISIBILITY
 #ifdef __APPLE__
 #pragma GCC visibility push(default)
@@ -329,6 +331,26 @@ m3_rotate64(UINT64 value, int shift)
 }
 
 #endif /* WIN32 */
+
+void __cdecl m3_memcpy(void* dest, const void* source, size_t n)
+{
+    memmove(dest, source, n); // memmove is more conservative than memcpy
+}
+
+void __cdecl m3_memmove(void* dest, const void* source, size_t n)
+{
+    memmove(dest, source, n);
+}
+
+void __cdecl m3_memset(void* dest, int fill, size_t count)
+{
+    memset(dest, fill, count);
+}
+
+int __cdecl m3_memcmp(const void* a, const void* b, size_t n)
+{
+    return memcmp(a, b, n);
+}
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
The wrappers are just prefixed with "m3_".
Currently m3c declares and calls the C runtime functions directly.
This has been ok, and is a nice optimization, but a. it is extra
code in m3c b. it causes problems on Mac/arm64 (Mac/all?) when compiling as C++,
and I've always known it was dodgy, to declare these functions ourselves.