### PR TITLE
m3c: Consider s_addr a reserved word.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -544,6 +544,7 @@ so i.e. they can be used for parameter, local, field names *)
 "register",
 "reinterpret_cast",
 "return",
+"s_addr", (* a macro on Solaris *)
 "short",
 "signed",
 "size_t",


### PR DESCRIPTION
Because it is a macro on Solaris and that breaks things.