### PR TITLE
m3core: Fix error with older Windows compoiler:

### DIFF
--- a/m3-libs/m3core/src/win32/WinGDIc.c
+++ b/m3-libs/m3core/src/win32/WinGDIc.c
@@ -24,7 +24,9 @@ WinGDI__PointsToLParam(const POINTS* points) // s is for 16bit signed short, not
     {
         POINTS points;
         LPARAM lParam;
-    } u = {*points};
+    } u;
+    ZeroMemory(&u, sizeof(u));
+    u.points = *points;
     return u.lParam;
 }
 


### PR DESCRIPTION
WinGDIc.c(27) : error C2440: 'initializing' : cannot convert from 'const POINTS' to 'SHORT'