### PR TITLE
ARM64_DARWIN: Defer to Darwin.common for C compiler, i.e. compile as …

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/ARM64_DARWIN
+++ b/m3-sys/cminstall/src/config-no-install/ARM64_DARWIN
@@ -1,15 +1,6 @@
 readonly M3_BACKEND_MODE = "C"
-
-% TODO Remove these lines and delegate to Darwin.common
-% but there is a problem currently.
-readonly SYSTEM_ASM = "as"
-readonly SYSTEM_CC = "@clang -fPIC"
-readonly SYSTEM_CC_LD = "clang++ -g -fPIC"
-% readonly SYSTEM_LIBTOOL = "libtool"
-
 readonly TARGET = "ARM64_DARWIN"
 
-% probably not used readonly GNU_PLATFORM = "arm-apple-darwin"
 readonly DarwinArch = "arm64"
 
 include("ARM64.common")


### PR DESCRIPTION
…C++.

C no longer required since 9bd49f9eaad936bd06ecea25346cfcd67e18f890