### PR TITLE
m3core: Solaris: RTProcess__RegisterForkHandlers: Error: Only one of a set of overloaded functions can be extern "C".

### DIFF
--- a/m3-libs/m3core/src/C/Common/Cstdlib.i3
+++ b/m3-libs/m3core/src/C/Common/Cstdlib.i3
@@ -13,6 +13,7 @@ FROM Ctypes IMPORT int, char_star, const_char_star, char_star_star, double,
 FROM Cstddef IMPORT size_t;
 
 <*EXTERNAL Cstdlib__abort*>  PROCEDURE abort ();
+<*EXTERNAL Cstdlib__atexit*> PROCEDURE atexit (func: PROCEDURE ()): int;
 <*EXTERNAL Cstdlib__exit*>   PROCEDURE exit (status: int);
 <*EXTERNAL Cstdlib__getenv*> PROCEDURE getenv (name: const_char_star): char_star;
 <*EXTERNAL Cstdlib__system*> PROCEDURE system (string: const_char_star): int;

--- a/m3-libs/m3core/src/C/Common/CstdlibC.c
+++ b/m3-libs/m3core/src/C/Common/CstdlibC.c
@@ -13,6 +13,9 @@ extern "C" {
 #undef M3MODULE /* Support concatenating multiple .c files. */
 #define M3MODULE Cstdlib
 
+typedef void (__cdecl*AtExitFunction)(void);
+
+M3WRAP1(int, atexit, AtExitFunction)
 M3WRAP1(char*, getenv, const char*)
 M3WRAP1(int, system, const char*)
 M3WRAP2(double, strtod, const char*, char**)


### PR DESCRIPTION
This reverts commit c2d08417eace9a4fb5412f3ff16123a5574deeeb.

m3c now considers all function pointers to be void (*)(void), which lets a few through ok, such as this.