### PR TITLE
m3core: Solaris: RTProcess__RegisterForkHandlers: Error: Only one of a set of overloaded functions can be extern "C".

### DIFF
--- a/m3-libs/m3core/src/runtime/common/RTProcessC.c
+++ b/m3-libs/m3core/src/runtime/common/RTProcessC.c
@@ -1,5 +1,3 @@
-typedef void (*ForkHandler)(void);
-
 #ifndef INCLUDED_M3CORE_H
 #include "m3core.h"
 #endif
@@ -7,6 +5,8 @@ typedef void (*ForkHandler)(void);
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef void (*ForkHandler)(void);
 
 #ifdef M3_USER_THREADS
 


### PR DESCRIPTION
The problem is likely that Sun compiler considers extern "C" as part of types,
or at least function pointer types. So move the function pointer typedef within the extern "C" block.

Some day maybe we can remove the extern "C", at least when concatenating all the files.