### PR TITLE
m3core: Solaris: Type mismatch errors when m3c and .c files are conca…

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -1187,6 +1187,17 @@ typedef void* (__cdecl*ThreadPThread__start_routine_t)(void*);
 #define ThreadPThread__ProcessThreadStack ThreadPThread__ProcessThreadStack
 typedef void (__cdecl*ThreadPThread__ProcessThreadStack)(void* start, void* limit);
 
+#define RT0__Binder RT0__Binder /* inhibit m3c type */
+// The correct type for RT0__Binder is:
+// typedef RT0__Module* (__cdecl*RT0__Binder)(INTEGER mode);
+// but we cannot use that due to type collision hashes,
+// until/unless significant m3c changes.
+// This works:
+typedef void (__cdecl*M3PROC)(void); // from MxGen.m3
+typedef M3PROC RT0__Binder;
+// The actual use and pass casts and so getting the type correct here does
+// not really matter. What matters is that it is the same in all function
+// declarations/definitions.
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
…tenated.

In this case the mismatch is:

void RTLinker__AddUnit(RT0__Binder)

and then RT0__Binder is either correct like:
  struct RT0__Module;
  typedef RT0__Module* (__cdecl*RT0__Binder)(INTEGER mode);

or incorrect like:
  typedef void (__cdecl*M3PROC)(void);
  typedef M3PROC RT0__Binder;

We have to use the incorrect form because function pointers have many
type collision hashes. Even if it was not comment, because the return type
is ignored, the hashing is still weak and there is no provision for collisions.

We use M3PROC has shown because it at least matches in two places (atexit and RTProcess.RegisterExitor
and maybe others).

In time maybe m3c will ignore type hashes and will produce longer strings
that encode entire type structure with much less chance of collision.
Or at least use much better hash functions, like sha1 or better, of
such long strings. Or mostly require typenames. This structural type equivalence
was well motivated but is actually quite problematic.