### PR TITLE
Revert "m3tcp: Fix build or warnings. (#603)"

### DIFF
--- a/m3-comm/tcp/src/WIN32/IP.m3
+++ b/m3-comm/tcp/src/WIN32/IP.m3
@@ -11,7 +11,7 @@
 
 UNSAFE MODULE IP;
 
-IMPORT IPError, M3toC, IPInternal, Ctypes, Process;
+IMPORT IPError, M3toC, IPInternal, Ctypes;
 TYPE int = Ctypes.int;
 
 (************
@@ -103,7 +103,5 @@ PROCEDURE GetHostAddr(): Address =
   END GetHostAddr;
 
 BEGIN
-  IF IPInternal.Init() THEN
-    Process.RegisterExitor(IPInternal.Exitor);
-  END;
+  IPInternal.Init();
 END IP.

--- a/m3-comm/tcp/src/common/IPInternal.i3
+++ b/m3-comm/tcp/src/common/IPInternal.i3
@@ -31,10 +31,7 @@ PROCEDURE InterpretError(err: int) RAISES {IP.Error};
 (* The rest is C code so Modula3 does not interact directly with /usr/include. *)
 
 <*EXTERNAL "IPInternal__Init"*>
-PROCEDURE Init(): BOOLEAN; (* true for success and register exiter *)
-
-<*EXTERNAL "IPInternal__Exitor"*>
-PROCEDURE Exitor();
+PROCEDURE Init();
 
 (* return hostent=NIL for error to mimic old patterns *)
 <*EXTERNAL "IPInternal__GetHostByName"*>

--- a/m3-comm/tcp/src/common/IP_c.c
+++ b/m3-comm/tcp/src/common/IP_c.c
@@ -269,16 +269,19 @@ IPInternal__GetNameInfo(int family, int port, const void* addr, TEXT* hostText, 
     return err;
 }
 
+#ifdef _WIN32
+
+static
 void
 __cdecl
 IPInternal__Exitor(void)
 {
-#ifdef _WIN32
     WSACleanup();
-#endif
 }
 
-BOOLEAN
+#endif
+
+void
 __cdecl
 IPInternal__Init(void)
 {
@@ -289,13 +292,10 @@ IPInternal__Init(void)
     WSADATA data;
     ZeroMemory(&data, sizeof(data));
     if (WSAStartup(WinSockVersion, &data))
-    {
         IPError__Die();
-        return FALSE;
-    }
-    return TRUE; // Process__RegisterExitor(IPInternal__Exitor);
+    else
+        Process__RegisterExitor(IPInternal__Exitor);
 #endif
-    return FALSE;
 }
 
 #ifndef _WIN32

--- a/m3-comm/tcp/src/common/IP_h.h
+++ b/m3-comm/tcp/src/common/IP_h.h
@@ -57,7 +57,7 @@ void
 __cdecl
 IPInternal__CopyStoT(const char* name, TEXT* text);
 
-BOOLEAN
+void
 __cdecl
 IPInternal__Init(void);
 

--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -857,6 +857,10 @@ int
 __cdecl
 ThreadInternal__StackGrowsDown (void);
 
+void
+__cdecl
+Process__RegisterExitor(void (__cdecl*)(void));
+
 // GET_PC returns approximately size_t.
 // Broadly speaking, try to keep most platform specific code here.
 


### PR DESCRIPTION
 This reverts commit 02f82bb1cdc02116dfbe27506816556868711d28.

Revert "m3core, tcp: Remove Process_Exitor from C surface area. (#600)"
 This reverts commit 508f044a320d40b3bf76eda789fbe6042ea31ddc.

These were ok, but now that m3c assumes all procedure types are void (*)(void)
they are not needed. Procedure types frequently have hash collisions.
I had worked around by making them all merely ADDRESS (char* or void*).

However if we assume they are void (*)(void) then we can at least be correct
in this place and another.