### PR TITLE
m3c, m3core: Start fixing single file cm3 for Windows.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -15,6 +15,7 @@
 #define _CRT_SECURE_NO_DEPRECATE 1
 #define _CRT_NONSTDC_NO_DEPRECATE 1
 #define _WINSOCK_DEPRECATED_NO_WARNINGS 1
+#define _KERNEL32_ 1 /* inhibit declspec(dllimport) for consistency; it is not needed on functions */
 #ifdef _MSC_VER
 // These two must come first.
 #pragma warning(disable:4616) /* there is no warning x (unavoidable if targeting multiple compiler versions) */
@@ -1203,6 +1204,46 @@ typedef M3PROC RT0__Binder;
 // not really matter. What matters is that it is the same in all function
 // declarations/definitions.
 
+struct _BY_HANDLE_FILE_INFORMATION;
+struct _FILETIME;
+struct _OVERLAPPED;
+struct _SYSTEMTIME;
+struct _TIME_ZONE_INFORMATION;
+
+#define WinBase__const_FILETIME_star                WinBase__const_FILETIME_star                /* inhibit m3c type */
+#define WinBase__const_SYSTEMTIME_star              WinBase__const_SYSTEMTIME_star              /* inhibit m3c type */
+#define WinBase__const_TIME_ZONE_INFORMATION_star   WinBase__const_TIME_ZONE_INFORMATION_star   /* inhibit m3c type */
+#define WinBase__LPSYSTEMTIME                       WinBase__LPSYSTEMTIME                       /* inhibit m3c type */
+#define WinBase__PBY_HANDLE_FILE_INFORMATION        WinBase__PBY_HANDLE_FILE_INFORMATION        /* inhibit m3c type */
+#define WinBase__PFILETIME                          WinBase__PFILETIME                          /* inhibit m3c type */
+#define WinBase__POVERLAPPED                        WinBase__POVERLAPPED                        /* inhibit m3c type */
+#define WinBase__PSYSTEMTIME                        WinBase__PSYSTEMTIME                        /* inhibit m3c type */
+#define WinBase__PTIME_ZONE_INFORMATION             WinBase__PTIME_ZONE_INFORMATION             /* inhibit m3c type */
+#define WinBaseTypes__BOOL                          WinBaseTypes__BOOL                          /* inhibit m3c type */
+#define WinBaseTypes__PCSTR                         WinBaseTypes__PCSTR                         /* inhibit m3c type */
+#define WinBaseTypes__PSTR                          WinBaseTypes__PSTR                          /* inhibit m3c type */
+#define WinBaseTypes__PUINT32                       WinBaseTypes__PUINT32                       /* inhibit m3c type */
+#define WinBaseTypes__UINT32                        WinBaseTypes__UINT32                        /* inhibit m3c type */
+#define WinNT__SECURITY_INFORMATION                 WinNT__SECURITY_INFORMATION                 /* inhibit m3c type */
+#define WinNT__PSECURITY_DESCRIPTOR                 WinNT__PSECURITY_DESCRIPTOR                 /* inhibit m3c type */
+
+typedef const struct _FILETIME*                 WinBase__const_FILETIME_star;
+typedef const struct _SYSTEMTIME*               WinBase__const_SYSTEMTIME_star;
+typedef const struct _TIME_ZONE_INFORMATION*    WinBase__const_TIME_ZONE_INFORMATION_star;
+typedef struct _SYSTEMTIME*                     WinBase__LPSYSTEMTIME;
+typedef struct _FILETIME*                       WinBase__PFILETIME;
+typedef struct _SYSTEMTIME*                     WinBase__PSYSTEMTIME;
+typedef struct _TIME_ZONE_INFORMATION*          WinBase__PTIME_ZONE_INFORMATION;
+typedef struct _BY_HANDLE_FILE_INFORMATION*     WinBase__PBY_HANDLE_FILE_INFORMATION;
+typedef struct _OVERLAPPED*                     WinBase__POVERLAPPED;
+typedef int                                     WinBaseTypes__BOOL;
+typedef char*                                   WinBaseTypes__PSTR;
+typedef const char*                             WinBaseTypes__PCSTR;
+typedef unsigned long*                          WinBaseTypes__PUINT32; // even on 64bit Windows
+typedef unsigned long                           WinBaseTypes__UINT32;  // even on 64bit Windows
+typedef void*                                   WinNT__PSECURITY_DESCRIPTOR;
+typedef unsigned long                           WinNT__SECURITY_INFORMATION;
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
@@ -1216,7 +1257,13 @@ typedef M3PROC RT0__Binder;
 # elif defined(__DECC) || defined(__DECCXX)
 #  define alloca(x) __ALLOCA(x)
 # elif defined(_MSC_VER)
+#ifdef __cplusplus
+extern "C" {
+#endif
    void * __cdecl _alloca(size_t size);
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 #  define alloca _alloca
 # else
 #  include <alloca.h>

--- a/m3-libs/m3core/src/thread/WIN32/ThreadWin32C.c
+++ b/m3-libs/m3core/src/thread/WIN32/ThreadWin32C.c
@@ -5,7 +5,7 @@
 /* Portions Copyright 1996-2000, Critical Mass, Inc.               */
 /* See file COPYRIGHT-CMASS for details.                           */
 
-#define _NO_CRT_STDIO_INLINE /* Do not accidentally export printf. */
+#define _NO_CRT_STDIO_INLINE 1 /* Do not accidentally export printf. */
 
 #if defined(_WIN32) && !defined(WIN32)
 #define WIN32

--- a/m3-libs/m3core/src/win32/WinBase.i3
+++ b/m3-libs/m3core/src/win32/WinBase.i3
@@ -176,6 +176,7 @@ TYPE
 (* File System time stamps are represented with the following structure: *)
 
   PFILETIME = UNTRACED REF FILETIME;
+  const_FILETIME_star = PFILETIME; (* name for m3core.h to replace with actual const *)
   LPFILETIME = PFILETIME; (* compat *)
   FILETIME = RECORD
     dwLowDateTime : UINT32;
@@ -186,6 +187,7 @@ TYPE
 
 TYPE
   PSYSTEMTIME = UNTRACED REF SYSTEMTIME;
+  const_SYSTEMTIME_star = PSYSTEMTIME; (* name for m3core.h to replace with actual const *)
   LPSYSTEMTIME = PSYSTEMTIME; (* compat *)
   SYSTEMTIME = RECORD
     wYear        : UINT16;
@@ -1660,9 +1662,9 @@ PROCEDURE GetFileTime (hFile           : HANDLE;
 
 <*EXTERNAL SetFileTime:WINAPI*>
 PROCEDURE SetFileTime (hFile           : HANDLE;
-                       lpCreationTime  : PFILETIME;
-                       lpLastAccessTime: PFILETIME;
-                       lpLastWriteTime : PFILETIME  ): BOOL;
+                       lpCreationTime  : const_FILETIME_star;
+                       lpLastAccessTime: const_FILETIME_star;
+                       lpLastWriteTime : const_FILETIME_star): BOOL;
 
 <*EXTERNAL CloseHandle:WINAPI*>
 PROCEDURE CloseHandle (hObject: HANDLE): BOOL;
@@ -1865,7 +1867,7 @@ PROCEDURE GetSystemTime (lpSystemTime: PSYSTEMTIME);
 PROCEDURE GetSystemTimeAsFileTime(VAR FileTime : FILETIME);
 
 <*EXTERNAL SetSystemTime:WINAPI*>
-PROCEDURE SetSystemTime (lpSystemTime: PSYSTEMTIME): BOOL;
+PROCEDURE SetSystemTime (lpSystemTime: const_SYSTEMTIME_star): BOOL;
 
 <*EXTERNAL GetLocalTime:WINAPI*>
 PROCEDURE GetLocalTime (lpSystemTime: PSYSTEMTIME);
@@ -1878,6 +1880,7 @@ PROCEDURE GetSystemInfo (lpSystemInfo: PSYSTEM_INFO);
 
 TYPE
   PTIME_ZONE_INFORMATION = UNTRACED REF TIME_ZONE_INFORMATION;
+  const_TIME_ZONE_INFORMATION_star = PTIME_ZONE_INFORMATION;
   LPTIME_ZONE_INFORMATION = PTIME_ZONE_INFORMATION; (* compat *)
   TIME_ZONE_INFORMATION = RECORD
     Bias        : INT32;
@@ -1895,40 +1898,40 @@ PROCEDURE GetTimeZoneInformation
 
 <*EXTERNAL SetTimeZoneInformation:WINAPI*>
 PROCEDURE SetTimeZoneInformation
-            (lpTimeZoneInformation: PTIME_ZONE_INFORMATION): BOOL;
+            (lpTimeZoneInformation: const_TIME_ZONE_INFORMATION_star): BOOL;
 
 (* Routines to convert back and forth between system time and file time *)
 
 <*EXTERNAL SystemTimeToFileTime:WINAPI*>
-PROCEDURE SystemTimeToFileTime (lpSystemTime: PSYSTEMTIME;
+PROCEDURE SystemTimeToFileTime (lpSystemTime: const_SYSTEMTIME_star;
                                 lpFileTime  : PFILETIME    ): BOOL;
 
 (* Note: As of 14-May-97, the following routine is implemented on
    Windows/NT, but not on Windows 95. -CAH *)
 <*EXTERNAL SystemTimeToTzSpecificLocalTime:WINAPI*>
 PROCEDURE SystemTimeToTzSpecificLocalTime (
-            lpTimeZoneInformation: PTIME_ZONE_INFORMATION;
-            lpUniversalTime      : PSYSTEMTIME;
+            lpTimeZoneInformation: const_TIME_ZONE_INFORMATION_star;
+            lpUniversalTime      : const_SYSTEMTIME_star;
             lpLocalTime          : PSYSTEMTIME            ): BOOL;
 
 <*EXTERNAL FileTimeToLocalFileTime:WINAPI*>
-PROCEDURE FileTimeToLocalFileTime (lpFileTime     : PFILETIME;
+PROCEDURE FileTimeToLocalFileTime (lpFileTime     : const_FILETIME_star;
                                    lpLocalFileTime: PFILETIME  ): BOOL;
 
 <*EXTERNAL LocalFileTimeToFileTime:WINAPI*>
-PROCEDURE LocalFileTimeToFileTime (lpLocalFileTime: PFILETIME;
+PROCEDURE LocalFileTimeToFileTime (lpLocalFileTime: const_FILETIME_star;
                                    lpFileTime     : PFILETIME  ): BOOL;
 
 <*EXTERNAL FileTimeToSystemTime:WINAPI*>
-PROCEDURE FileTimeToSystemTime (lpFileTime  : PFILETIME;
+PROCEDURE FileTimeToSystemTime (lpFileTime  : const_FILETIME_star;
                                 lpSystemTime: PSYSTEMTIME): BOOL;
 
 <*EXTERNAL CompareFileTime:WINAPI*>
-PROCEDURE CompareFileTime (lpFileTime1: PFILETIME;
-                           lpFileTime2: PFILETIME  ): INT32;
+PROCEDURE CompareFileTime (lpFileTime1: const_FILETIME_star;
+                           lpFileTime2: const_FILETIME_star): INT32;
 
 <*EXTERNAL FileTimeToDosDateTime:WINAPI*>
-PROCEDURE FileTimeToDosDateTime (lpFileTime: PFILETIME;
+PROCEDURE FileTimeToDosDateTime (lpFileTime: const_FILETIME_star;
                                  lpFatDate : PUINT16;
                                  lpFatTime : PUINT16      ): BOOL;
 

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2475,8 +2475,8 @@ CONST Prefix = ARRAY OF TEXT {
 "#define m3_xor(T, x, y) (((T)(x)) ^ ((T)(y)))",
 
 "#ifdef _MSC_VER",
-"#define _CRT_SECURE_NO_DEPRECATE",
-"#define _CRT_NONSTDC_NO_DEPRECATE",
+"#define _CRT_SECURE_NO_DEPRECATE 1",
+"#define _CRT_NONSTDC_NO_DEPRECATE 1",
 "#pragma warning(disable:4616) /* there is no warning x (unavoidable if targeting multiple compiler versions) */",
 "#pragma warning(disable:4619) /* there is no warning x (unavoidable if targeting multiple compiler versions) */",
 "#pragma warning(disable:4100) /* unused parameter */",


### PR DESCRIPTION
m3c: Define CRT no deprecate to 1 instead of unstated
m3core.h: Start matching windows.h; suppress declspec(dllimport) which is not needed
on functions and cm3 never considers it to be used.

Const fixes similarly.

There is more of this to do and we will have to do something about mklib.