### PR TITLE
Revert "Solaris C++:Add return to RTHeapInfo.Producer. (#269)"

### DIFF
--- a/m3-libs/m3core/src/runtime/common/RTHeapInfo.m3
+++ b/m3-libs/m3core/src/runtime/common/RTHeapInfo.m3
@@ -53,7 +53,6 @@ PROCEDURE Producer (<*UNUSED*> self: Thread.Closure): REFANY =
 
       Thread.Pause (update);
     END;
-    RETURN NIL; <*NOWARN*>(* not reachable but needed by some backends *)
   END Producer;
 
 PROCEDURE SendTypes (nTypes: INTEGER) =


### PR DESCRIPTION
This reverts commit d0ff3b281b30559a57127922d3c10ccad16f4aa4.

m3c now adds returns to non-void functions that lack any.