### PR TITLE
m3core: Squash warning 4711

### DIFF
--- a/m3-libs/m3core/src/Csupport/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/dtoa.c
@@ -29,6 +29,7 @@ void __cdecl CConvert__Release(INTEGER);
 #pragma warning(disable:4127) /* conditional expression is constant */
 #pragma warning(disable:4706) /* assignment within conditional */
 #pragma warning(disable:4701) /* possibly uninitialized local used */
+#pragma warning(disable:4711) /* function selected for automatic inline expansion */
 #pragma warning(disable:4255) /* () changed to (void) */
 #endif
 


### PR DESCRIPTION
warning C4711: function 'Bfree' selected for automatic inline expansion
When compiling with /wall /O2