### PR TITLE
Revert "m3core: dtoa: remove code that is not used due to ifdef (#671)"

### DIFF
--- a/m3-libs/m3core/src/Csupport/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/dtoa.c
@@ -292,14 +292,12 @@ static const union {
 #define dval(x) ((U*)&x)->d
 #endif
 
-#if 0 /* not used due to ifdefs */
 void M3DtoaStoreincFunction (ULong** a, ULong hi, ULong lo)
 {
     *((*a)++) = (((hi & 0xFFFF) << 16) | (lo & 0xFFFF));
 }
 
 #define Storeinc(a, hi, lo) (M3DtoaStoreincFunction(&(a), (hi), (lo)))
-#endif /* not used due to ifdefs */
 
 /* #define P DBL_MANT_DIG */
 /* Ten_pmax = floor(P*log(2)/log(5)) */


### PR DESCRIPTION
This reverts commit 9f96f0a5dde0e1b0b931e61e860754ac0f145c36.