### PR TITLE
Add "target64".

### DIFF
--- a/m3-libs/m3core/src/C/m3makefile
+++ b/m3-libs/m3core/src/C/m3makefile
@@ -13,17 +13,23 @@ proc FileExists(a) is
   return not stale (a, a)
 end
 
+if not defined ("M3_TARGET64")
+  M3_TARGET64 = ""
+end
+
 % none exist
 %if FileExists(path() & "/" & TARGET & "/m3makefile")
 %  include_dir (TARGET)
 %end
 
 if equal(OS_TYPE, "WIN32")
-  if equal(WORD_SIZE, "64BITS")
+  if equal(WORD_SIZE, "64BITS") or M3_TARGET64
     include_dir("WIN64")
   else
     include_dir("32BITS")
   end
+else if equal(WORD_SIZE, "64BITS") or M3_TARGET64
+  include_dir("64BITS")
 else
   include_dir(WORD_SIZE)
-end
+end end

--- a/m3-libs/m3core/src/runtime/POSIX/RTOSc.c
+++ b/m3-libs/m3core/src/runtime/POSIX/RTOSc.c
@@ -14,7 +14,7 @@ ADDRESS
 __cdecl
 RTOS__GetMemory(INTEGER isize)
 {
-    WORD_T const size = (WORD_T)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const size = (size_t)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
     // TODO autoconf/make HAVE_MMAP
 #if defined(ULTRIX)                           || \
     defined(ultrix)                           || \

--- a/m3-libs/m3core/src/runtime/WIN32/RTOSc.c
+++ b/m3-libs/m3core/src/runtime/WIN32/RTOSc.c
@@ -11,7 +11,7 @@ extern "C" {
 
 ADDRESS __cdecl RTOS__GetMemory(INTEGER isize)
 {
-    WORD_T const Size = (WORD_T)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const Size = (size_t)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
     return (ADDRESS)calloc(Size, 1);
 }
 
@@ -19,7 +19,7 @@ ADDRESS __cdecl RTOS__GetMemory(INTEGER isize)
 
 ADDRESS __cdecl RTOS__GetMemory(INTEGER isize)
 {
-    WORD_T const Size = (WORD_T)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const Size = (size_t)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
     return (ADDRESS)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Size);
 }
 
@@ -27,7 +27,7 @@ ADDRESS __cdecl RTOS__GetMemory(INTEGER isize)
 
 ADDRESS __cdecl RTOS__GetMemory(INTEGER isize)
 {
-    WORD_T const Size = (WORD_T)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const Size = (size_t)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
     return (ADDRESS)VirtualAlloc(NULL, Size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 }
 
@@ -38,17 +38,17 @@ reveals the lossage that results from using VirtualAlloc with RTMachine.PageSize
 */
 typedef struct _RTOSMemoryLogEntry_t
 {
-    WORD_T Size;
+    size_t Size;
     void* Result;
 } RTOSMemoryLogEntry_t;
 
 RTOSMemoryLogEntry_t RTOSMemoryLog[128];
-WORD_T RTOSMemoryLogIndex;
+size_t RTOSMemoryLogIndex;
 #define NUMBER_OF(a) (sizeof(a)/sizeof((a)[0]))
 
 ADDRESS __cdecl RTOS__GetMemory(INTEGER isize)
 {
-    WORD_T const Size = (WORD_T)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const Size = (size_t)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
     RTOSMemoryLogEntry_t LogEntry;
     
     LogEntry.Size = Size;

--- a/m3-libs/m3core/src/runtime/common/RTIOc.c
+++ b/m3-libs/m3core/src/runtime/common/RTIOc.c
@@ -43,12 +43,12 @@ void __cdecl RTIO__PutG(double a)
 
 void __cdecl RTIO__PutBytes(ADDRESS addr, INTEGER icount)
 {
-    WORD_T const count = (WORD_T)icount; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const count = (size_t)icount; // Modula-3 lacks unsigned types, pass as signed and cast.
     unsigned char const * const p = (const unsigned char*)addr;
     char buffer[33]; /* size must be odd */
     const static char hex[] = "0123456789ABCDEF";
-    WORD_T i = { 0 };
-    WORD_T j = { 0 };
+    size_t i = { 0 };
+    size_t j = { 0 };
     
     RTIO__Flush();
     for (i = 0; i < count; ++i)

--- a/m3-libs/m3core/src/runtime/common/RTMiscC.c
+++ b/m3-libs/m3core/src/runtime/common/RTMiscC.c
@@ -14,13 +14,13 @@ extern "C" {
 
 void __cdecl RTMisc__Copy(ADDRESS src, ADDRESS dest, INTEGER ilen)
 {
-    WORD_T const len = (WORD_T)ilen; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const len = (size_t)ilen; // Modula-3 lacks unsigned types, pass as signed and cast.
     memmove(dest, src, len);
 }
 
 void __cdecl RTMisc__Zero(ADDRESS dest, INTEGER ilen)
 {
-    WORD_T const len = (WORD_T)ilen; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const len = (size_t)ilen; // Modula-3 lacks unsigned types, pass as signed and cast.
     memset(dest, 0, len);
 }
 

--- a/m3-libs/m3core/src/runtime/common/RTUntracedMemoryC.c
+++ b/m3-libs/m3core/src/runtime/common/RTUntracedMemoryC.c
@@ -29,14 +29,10 @@ reducing C runtime dependency.
 extern "C" {
 #endif
 
-// WORD_T is:
-// unsigned, INTEGER-sized, pointer-sized
-// There is no such type in Modula3.
-
 void* __cdecl RTUntracedMemory__AllocZ(INTEGER icount)
 /* Z = zeroed = calloc */
 {
-    WORD_T const count = (WORD_T)icount; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const count = (size_t)icount; // Modula-3 lacks unsigned types, pass as signed and cast.
     return WIN(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, count))
            POSIX(calloc(count, 1));
 }
@@ -44,9 +40,9 @@ void* __cdecl RTUntracedMemory__AllocZ(INTEGER icount)
 void* __cdecl RTUntracedMemory__AllocZV(INTEGER icount, INTEGER isize)
 /* ZV = zeroed vector = calloc */
 {
-    WORD_T const count = (WORD_T)icount; // Modula-3 lacks unsigned types, pass as signed and cast.
-    WORD_T const size = (WORD_T)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
-    WORD_T max = ~(WORD_T)0;
+    size_t const count = (size_t)icount; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t const size = (size_t)isize; // Modula-3 lacks unsigned types, pass as signed and cast.
+    size_t max = ~(size_t)0;
     if (count > 1 && size > 1 && count > (max / size)) /* implies count * size > max */
         return 0;
     return WIN(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, count * size))

--- a/m3-libs/m3core/src/thread/POSIX/ThreadPosixC.c
+++ b/m3-libs/m3core/src/thread/POSIX/ThreadPosixC.c
@@ -128,7 +128,7 @@ disallow_signals(void) /* disallow all, really */
 
 typedef struct {
   void *stackaddr;
-  WORD_T stacksize;
+  INTEGER stacksize;
   void *sp;
 #ifdef M3_USE_SIGALTSTACK
   sigjmp_buf jb;
@@ -181,7 +181,7 @@ xMakeContext(
     Context *context, 
     void (*function)(void),
     void *stack,
-    WORD_T stack_size) 
+    INTEGER stack_size)
 {
     struct sigaction sa;
     struct sigaction osa;

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -226,7 +226,7 @@ ThreadPThread__thread_create(size_t stackSize,
                              void *arg)
 {
   int r = { 0 };
-  WORD_T bytes = { 0 };
+  size_t bytes = { 0 };
   pthread_attr_t attr;
   pthread_t pthread;
 
@@ -350,7 +350,7 @@ typedef int (*generic_init_t)(void *, const void *);
 
 void *
 __cdecl
-ThreadPThread_pthread_generic_new(WORD_T size, generic_init_t init)
+ThreadPThread_pthread_generic_new(size_t size, generic_init_t init)
 {
   int r = ENOMEM;
   void *p = calloc(1, size);

--- a/m3-libs/m3core/src/unix/Common/UnixC.c
+++ b/m3-libs/m3core/src/unix/Common/UnixC.c
@@ -52,7 +52,7 @@ Unix__Assertions(void)
     M3_STATIC_ASSERT((sizeof(void*) == 4) || (sizeof(void*) == 8));
     M3_STATIC_ASSERT((sizeof(size_t) == 4) || (sizeof(size_t) == 8));
     M3_STATIC_ASSERT(sizeof(ptrdiff_t) == sizeof(size_t));
-    M3_STATIC_ASSERT(sizeof(void*) == sizeof(WORD_T));
+    M3_STATIC_ASSERT(sizeof(void*) <= sizeof(WORD_T)); // C backend can have 64bit word and 32bit pointer
 #if !defined(_WIN64) && !defined(__vms)
     M3_STATIC_ASSERT(sizeof(void*) == sizeof(long));
     M3_STATIC_ASSERT(sizeof(size_t) == sizeof(long));

--- a/m3-sys/cm3/src/Builder.m3
+++ b/m3-sys/cm3/src/Builder.m3
@@ -308,7 +308,7 @@ PROCEDURE CompileUnits (main     : TEXT;
       END;
     END;
 
-    IF NOT Target.Init (s.target, GetConfigItem (s, "OS_TYPE", "POSIX"), s.m3backend_mode) THEN
+    IF NOT Target.Init (s.target, GetConfigItem (s, "OS_TYPE", "POSIX"), s.m3backend_mode, GetConfigBool (s, "M3_TARGET64")) THEN
       Msg.FatalError (NIL, "unrecognized target machine: TARGET = ", s.target);
     END;
 

--- a/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
+++ b/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
@@ -71,6 +71,7 @@ m3back_optimize = ""
 
 proc compile_c (source, object, options, optimize, debug) is
   configure_c_compiler()
+  if M3_TARGET64 args += "-DM3_TARGET64=1" end
   return try_exec ("@" & SYSTEM_CC, options, "-c", source)
 end
 

--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -663,6 +663,8 @@ proc compile_c_ms(source, object, options, optimize, debug) is
     end
     args += "-Oi"
 
+    if M3_TARGET64 args += "-DM3_TARGET64=1" end
+
     local readonly Command = ["cl.exe", escape(subst_chars(args, "\\", "/")), "-c", escape(source), "-Fo" & object]
     local ret = try_exec("@" & Command)
 
@@ -689,6 +691,7 @@ proc compile_c_gnu(source, object, options, optimize, debug) is
     if M3_PROFILING
         args += "-pg"
     end
+    if M3_TARGET64 args += "-DM3_TARGET64=1" end
     return try_exec("@g++", "-g", escape(subst_chars(args, "\\", "/")), "-c", subst_chars(source, "\\", "/"), "-o", object)
 end
 

--- a/m3-sys/cminstall/src/config-no-install/Unix.common
+++ b/m3-sys/cminstall/src/config-no-install/Unix.common
@@ -239,6 +239,8 @@ proc compile_c(source, object, options, optimize, debug) is
     configure_c_compiler()
 
     local args = options
+
+    if M3_TARGET64 args += "-DM3_TARGET64=1" end
     if M3_PROFILING args += "-pg" end
     if debug args += "-g" end
 

--- a/m3-sys/cminstall/src/config-no-install/cm3cfg.common
+++ b/m3-sys/cminstall/src/config-no-install/cm3cfg.common
@@ -36,6 +36,16 @@ end
 
 %------------------------------------------------------------------------------
 
+% Configure a 32bit target to have 64bit INTEGER and pointer-size,
+% while still running on 32bit systems and dereferencing 32bit pointers.
+% This also halves the redistributed bootstrap matrix.
+%
+% This is *not* needed for normal 32bit or 64bit targets.
+%
+if not defined ("M3_TARGET64") M3_TARGET64 = FALSE end
+
+%------------------------------------------------------------------------------
+
 if not defined ("M3_BACKEND_MODE")
     M3_BACKEND_MODE = "3"
     % -- defines how the frontend, backend, and assembler interact

--- a/m3-sys/m3linker/src/MxGen.m3
+++ b/m3-sys/m3linker/src/MxGen.m3
@@ -55,6 +55,65 @@ PROCEDURE ContainsUnit (ui: UnitInfo; u: Mx.Unit): BOOLEAN =
 PROCEDURE GenerateMain (base: Mx.LinkSet;  c_output: Wr.T;  cg_output: M3CG.T;
                         verbose: BOOLEAN;  windowsGUI: BOOLEAN;
                         lazy := FALSE) =
+(* TODO Around here is duplicated by m3core.h, M3C.m3 and MxGen.m3; at
+ * least consolidate to two copies by moving to m3middle
+ *)
+      CONST Prefix = ARRAY OF TEXT {
+"",
+"// Put types inside extern C because some compilers (Sun) consider",
+"// such linkage as part of the type and error upon conflicts,",
+"// between m3core.h and _m3main.c when they are concatenated.",
+"// At least for function pointer types.",
+"",
+"#ifdef __cplusplus",
+"extern \"C\" {",
+"#endif",
+"",
+"#ifndef M3_TARGET64", (* see M3_TARGET64 in Target and config *)
+"#define M3_TARGET64 0",
+"#endif",
+"",
+"#if defined(_MSC_VER) || defined(__DECC) || defined(__DECCXX) || defined(__int64)",
+"typedef          __int64    INT64;",
+"typedef unsigned __int64   UINT64;",
+"#else",
+"typedef          long long  INT64;",
+"typedef unsigned long long UINT64;",
+"#endif",
+"",
+"#if __INITIAL_POINTER_SIZE == 64 || M3_TARGET64",
+"typedef INT64 INTEGER;",
+"#else",
+"typedef ptrdiff_t INTEGER;",
+"#endif",
+"",
+"#if !defined(_MSC_VER) && !defined(__cdecl)",
+"#define __cdecl /* nothing */",
+"#endif",
+"",
+"#ifndef ADDRESS",
+"#define ADDRESS ADDRESS",
+"typedef char* ADDRESS;",
+"#endif",
+"",
+"typedef void (__cdecl*M3PROC)(void);",
+"",
+"#ifndef RT0__ModulePtr",
+"#define RT0__ModulePtr RT0__ModulePtr",
+"typedef ADDRESS RT0__ModulePtr;",
+"#endif",
+"",
+"//correct, but match preexisting m3core",
+"//void __cdecl RTLinker__InitRuntime(INTEGER argc, char** argv, char** envp, void* hinstance);",
+"void __cdecl RTLinker__InitRuntime(INTEGER argc, ADDRESS argv, ADDRESS envp, ADDRESS hinstance);",
+"void __cdecl RTProcess__Exit(INTEGER);",
+"//correct, but workaround hash collisions in ProcType",
+"//void __cdecl RTLinker__AddUnitImports(void* (__cdecl*)(void));",
+"void __cdecl RTLinker__AddUnitImports(M3PROC);",
+"//correct, but void __cdecl RTLinker__AddUnit(void* (__cdecl*)(void));",
+"void __cdecl RTLinker__AddUnit(M3PROC);",
+""
+};
   VAR s: State;
   BEGIN
     <*ASSERT  (c_output = NIL) # (cg_output = NIL) *>
@@ -77,45 +136,10 @@ PROCEDURE GenerateMain (base: Mx.LinkSet;  c_output: Wr.T;  cg_output: M3CG.T;
         Out (s, "#include <windows.h>", EOL);
       END;
 
-      (* Put types inside extern C because some compilers (Sun) consider
-       * such linkage as part of the type and error upon conflicts,
-       * between m3core.h and _m3main.c when they are concatenated.
-       * At least for function pointer types.
-       *)
-      Out (s, "#ifdef __cplusplus", EOL);
-      Out (s, "extern \"C\" {", EOL);
-      Out (s, "#endif", EOL, EOL);
-
-      (* This content should match m3c output so the files can be concatenated. *)
-      Out (s, EOL, "#if __INITIAL_POINTER_SIZE == 64", EOL);
-      Out (s, "typedef __int64 INTEGER;", EOL);
-      Out (s, "#else", EOL);
-      Out (s, "typedef ptrdiff_t INTEGER;", EOL);
-      Out (s, "#endif", EOL, EOL);
-
-      Out (s, "#if !defined(_MSC_VER) && !defined(__cdecl)", EOL);
-      Out (s, "#define __cdecl /* nothing */", EOL);
-      Out (s, "#endif", EOL, EOL);
-
-      Out (s, "typedef char* ADDRESS;\n");
-      Out (s, "typedef void (__cdecl*M3PROC)(void);\n");
-
-      Out (s, "#ifndef RT0__ModulePtr\n");
-      Out (s, "#define RT0__ModulePtr RT0__ModulePtr\n");
-      Out (s, "typedef ADDRESS RT0__ModulePtr;\n");
-      Out (s, "#endif\n\n");
-
-      Out (s, "//correct, but match preexisting m3core\n");
-      Out (s, "//void __cdecl RTLinker__InitRuntime(INTEGER argc, char** argv, char** envp, void* hinstance);\n");
-      Out (s, "void __cdecl RTLinker__InitRuntime(INTEGER argc, ADDRESS argv, ADDRESS envp, ADDRESS hinstance);\n");
-      Out (s, "void __cdecl RTProcess__Exit(INTEGER);\n");
-      IF NOT s.lazyInit THEN
-        Out (s, "//correct, but workaround hash collisions in ProcType\n");
-        Out (s, "//void __cdecl RTLinker__AddUnitImports(void* (__cdecl*)(void));\n");
-        Out (s, "void __cdecl RTLinker__AddUnitImports(M3PROC);\n");
+      FOR i := FIRST(Prefix) TO LAST(Prefix) DO
+        Out (s, Prefix[i] & "\n");
       END;
-      Out (s, "//correct, but void __cdecl RTLinker__AddUnit(void* (__cdecl*)(void));\n");
-      Out (s, "void __cdecl RTLinker__AddUnit(M3PROC);\n\n");
+
     ELSE
       GenCGTypeDecls (s);
     END;

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -129,12 +129,11 @@ CONST
 
 (*-------------------------------------------------------- initialization ---*)
 
-PROCEDURE Init 
-  (system: TEXT; osname := "POSIX"; backend_mode := M3BackendMode_t.ExternalAssembly)
-: BOOLEAN;
+PROCEDURE Init (system: TEXT; osname := "POSIX"; backend_mode := M3BackendMode_t.ExternalAssembly;
+                target64 := FALSE) : BOOLEAN;
 (* Initialize the variables of this interface to reflect the architecture
    of "system".  Returns TRUE iff the "system" was known and the initialization
-   was successful.  *)
+   was successful (always).  *)
 
 VAR (*CONST*)
   System_name: TEXT := NIL; (* initialized by "Init" *)
@@ -497,5 +496,10 @@ PROCEDURE IsWideChar32 (): BOOLEAN; (* WideCharSize() = 32 *)
 PROCEDURE WideCharSize (): INTEGER;
 PROCEDURE WideCharMax (): INTEGER;
 PROCEDURE WideCharNumber (): INTEGER; (* WideCharMax() + 1 *)
+
+(* is a 32bit target being compiled with 64bit sizes
+* This is NOT for normal 64bit targets
+*)
+VAR Target64 := FALSE;
 
 END Target.

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -116,10 +116,13 @@ CONST start = ARRAY OF TEXT{"AMD64", "86",
     RETURN FALSE;
   END IsX86orAmd64;
 
-PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): BOOLEAN =
+PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t; target64: BOOLEAN): BOOLEAN =
   VAR sys := 0;  max_align := 64;
       casePreservedSystem := system;
   BEGIN
+
+    Target64 := target64;
+
     (* lookup the system -- linear search *)
     IF (system = NIL) THEN RETURN FALSE END;
     system := TextUtils.Upper(system); (* Uppercase for case insensitivity. *)
@@ -177,9 +180,27 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     (* 64bit *)
 
     IF TextUtils.StartsWith(system, "ALPHA_")       (* But not ALPHA32_. *)
-        OR TextUtils.Contains(system, "64") THEN
+        OR TextUtils.Contains(system, "64")
+        (* To halve the matrix, the C backend is always like 64bit.
+        *
+        * This has significant advantages and disadvantages.
+        *
+        * Con: Memory savings of 32bit targets are generally lost.
+        * Con: Arrays of INTEGER and pointers are larger.
+        * Pro/neutral: 32bit targets do work, i.e. on 32bit hardware and
+        *      interoperating mostly with 32bit libraries.
+        * Pro: There are fewer variations and one m3c output (bootstrap)
+        *      works on 32bit and 64bit targets.
+        * Con: As this is C backend only, not m3cc backend,
+        *      m3core becomes modal and requires define M3_TARGET64
+        *      to adjust the typedef of INTEGER. m3cc / m3c ABI
+        *      further bifurcates (previously was only for closures).
+        * Pro: Long term alignment-related regressions in m3front are side-stepped.
+        *)
+        OR target64
+        THEN
       Init64();
-    ELSIF backend_mode # M3BackendMode_t.C THEN
+    ELSE
       (* Change only alignment.  Size is always 64:
        * Aligning these types to 32 is incorrect on many but not all 32bit targets.
        * C backend cannot portably reduce alignment but it can portably increase


### PR DESCRIPTION
Add a limited form of 32bit targets that have pointers and integers that are 64bits in size.

This provides two distinct advantages:
 - It cuts the number of bootstraps in half,
   if bootstrap is defined as building just cm3,
   and not the entire system.
   For example the X11 bindings are broken in this scheme.

 - It works around m3front regressions.
   Again, not for the entire system.

It provides "neutral":
 - It continues to work on 32bit hardware
   using 32bit instructions/registers, etc.

It provides not great:
 - Interoperability with native code is reduced.
   In particular, structs get the wrong layout.
   m3core is taught to handle this, with "#if M3_TARGET64'.

 - It doubles some costs.

 - The resulting minimal system is an ABI fork.

 - It is tempting to declare this "the 32bit system",
   but again, it breaks X11 and surely more.

It is not meant to be used with actual 64bit targets,
but should work with them with essentially no change.
Perhaps some code quality reduction (upleveling of all params and locals).

But again, the main point is to provide a
word-size agnostic .cpp file to build cm3.

The m3front regressions still need to be fixed.

It is not enough to just tell m3front that pointers or integers are 64bits.
They probably must be the same size.
And making them both 64bits is also not enough.
If you do that, what happens is we get native pointers, that m3front casts
address to a 64bit integer and writes, corrupting neighbor.

There are a few possible solutions to this.

One is:

templte <typename T>
struct M3Ptr
{
  union { T* p; INTEGER i; } data;
};

And change everything to this, including parameters, including in m3core/*.c.

This would likely work.

But another approach is tried here.
In this approach, m3core is changed less.
INTEGER is still widened, but pointers are not exactly, at least not as shown.

What we try here is:
 - upon function entry (begin_procedure) assign all parameters to locals;
   Er, well, make them all uplevel.
   This should be limited to pointers but is not.

 - Align all locals smaller than size 8 to 8.
   Er, well, append "[2]" to all uplevel declarations and "[0]" to all uplevel uses.
   That is, double all pointer sizes. Er, all locals. It should be limited to pointers.

 - C code needs no change to its parameters or locals.
   Except that INTEGER becomes long long. Pointers are still 32bits.
   Pointers in structs, of which are there are approximately zero in the base
   system, would need more attention.

Macros are now provided to provided "addresses" (ADDRESS, could be UINT64), to "pointer" (void*).
Because some compilers require this go through uintptr_t.

 This mode is triggered with cm3 -DM3_TARGET64
  cc -DM3_TARGET64
  scripts/*.py target64

64bit targets are not affected (well, you can use the target64 flag
and it does pessimize as described, and the results should work, but it isn't useful).

Non-C backends are not affected.
 Except there is a new mode of building m3core (i.e. C) that they
 cannot interoperate with.