### PR TITLE
m3-sys: Fix m3gdb declare_typename

### DIFF
--- a/m3-sys/m3cc/gcc/gcc/m3cg/m3-def.h
+++ b/m3-sys/m3cc/gcc/gcc/m3cg/m3-def.h
@@ -6,7 +6,7 @@ M3CG (SET_SOURCE_FILE, STRING (name, name_length))
 M3CG (SET_SOURCE_LINE, UNSIGNED_INTEGER (i))
 M3CG (DECLARE_TYPENAME,
       TYPEID (my_id)
-      STRING (name, name_length))
+      STRING (fullname, fullname_length))
 M3CG (DECLARE_ARRAY,
       TYPEID (my_id)
       TYPEID (index_id)

--- a/m3-sys/m3cc/gcc/gcc/m3cg/parse.c
+++ b/m3-sys/m3cc/gcc/gcc/m3cg/parse.c
@@ -2372,11 +2372,11 @@ trace_typeid (PCSTR name, UINT32 val)
 
 static PCSTR
 scan_string (long length)
-/* NOTE: these are not null terminated */
+/* NOTE: these are null terminated */
 {
   PCSTR result = { 0 };
   if (length > 0)
-    result = (PCSTR)get_bytes_direct (long_to_sizet (length));
+    result = (PCSTR)get_bytes_direct (long_to_sizet (length + 1));
   return result;
 }
 
@@ -3761,13 +3761,7 @@ M3CG_HANDLER (SET_SOURCE_LINE)
 
 M3CG_HANDLER (DECLARE_TYPENAME)
 {
-  size_t fullname_length =
-    sizet_add (current_unit_name_length, sizet_add (long_to_sizet (name_length), 1));
-  PSTR fullname = (PSTR)alloca (fullname_length);
-  gcc_assert (name_length > 0);
-  memcpy(fullname, current_unit_name, current_unit_name_length);
-  fullname[current_unit_name_length] = '.';
-  memcpy(&fullname[current_unit_name_length + 1], name, name_length);
+  gcc_assert (fullname_length > 0);
 
   debug_tag ('N', my_id, "");
   debug_field_name_length (fullname, fullname_length);

--- a/m3-sys/m3middle/src/M3CG_BinRd.m3
+++ b/m3-sys/m3middle/src/M3CG_BinRd.m3
@@ -275,6 +275,8 @@ PROCEDURE Scan_text (VAR s: State): TEXT =
       FOR i := 0 TO len-1 DO buf[i] := VAL (GetByte (s), CHAR); END;
       txt := txt & Text.FromChars (SUBARRAY (buf, 0, len));
     END;
+    (* consume terminal nul *)
+    EVAL GetByte (s);
     RETURN txt;
   END Scan_text;
 

--- a/m3-sys/m3middle/src/M3CG_BinWr.m3
+++ b/m3-sys/m3middle/src/M3CG_BinWr.m3
@@ -273,7 +273,8 @@ PROCEDURE Txt (u: U;  t: TEXT) =
       OutI (u, len);
       M3Buf.PutText (u.buf, t);
       INC (u.buf_len, len);
-      IF (u.buf_len >= 16_F000) THEN Flush (u) END;
+      OutB (u, 0);
+      (* OutB flushes *)
     END;
   END Txt;
 


### PR DESCRIPTION
Accept new full typename from m3front (with underscores
intead of dot).
Add terminal nuls to m3cg strings.