### PR TITLE
m3-sys: Conditionally restore m3cc typenames.

### DIFF
--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -9,7 +9,7 @@
 MODULE Tipe;
 
 IMPORT M3, M3ID, CG, Value, ValueRep, Scope, OpaqueType, WebInfo, TypeRep;
-IMPORT Token, Type, Decl, Scanner, NamedType, RefType, ObjectType, Module;
+IMPORT Token, Type, Decl, Scanner, NamedType, RefType, ObjectType, Module, Target;
 FROM Scanner IMPORT GetToken, Fail, Match, MatchID, cur;
 FROM M3 IMPORT QID;
 
@@ -134,7 +134,7 @@ PROCEDURE Compile (t: T): BOOLEAN =
     Type.Compile (t.value);
     (*IF NOT t.imported THEN*)
       uid  := Type.GlobalUID (t.value);
-      name := Value.GlobalName (t, dots := FALSE);
+      name := Value.GlobalName (t, dots := Target.TypenameDots, with_module := Target.TypenameWithModule);
       CG.Declare_typename (uid, M3ID.Add (name));
       WebInfo.Declare_typename (uid, t);
     (*END;*)

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -477,8 +477,19 @@ VAR (*CONST*)
      test for nested procedures passed as parameters must be more
      elaborate (e.g. HPPA). *)
 
-(* Backend uses full typenames. These are expensive? to produce so optional. *)
+(* Backend uses contextual typenames. i.e. on declare_param, etc.
+ * These are expensive? to produce so optional. *)
 VAR Typenames := FALSE;
+
+(* Type vs. Module.Type. And something for typenames in procedures and blocks
+ * and nested procedures. m3c wants global names, m3cc does not, it forms them itself.
+ *)
+VAR TypenameWithModule := FALSE;
+
+(* Module.Type vs. Module__Type; m3c wants underscores, m3cc is unclear due
+ * to TypenameWithModule = FALSE but preserve historical parameter.
+ *)
+VAR TypenameDots := TRUE;
 
 (* Ideally the value 0 would be uninitialized, but it is used publically in Quake? *)
 VAR BackendMode: M3BackendMode_t;

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -143,13 +143,18 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
     IF backend_mode = M3BackendMode_t.C THEN
       Setjmp := "m3_setjmp";
       Sigsetjmp := FALSE;
-      Typenames := TRUE;
     ELSIF Solaris() THEN
       Setjmp := "sigsetjmp";
       Sigsetjmp := TRUE;
     ELSE
       Setjmp := "_setjmp";
       Sigsetjmp := FALSE;
+    END;
+
+    IF backend_mode = M3BackendMode_t.C THEN
+      Typenames := TRUE;          (* on declare_param, etc. *)
+      TypenameWithModule := TRUE; (* Type vs. Module.Type *)
+      TypenameDots := FALSE;      (* Module.Type vs. Module__Type *)
     END;
 
     (* There is no portable stack walker, and therefore few systems have one.


### PR DESCRIPTION
Type vs. Type.Module vs. Type__Module, to each backend, its own.

This adds flexibility/compatibilty upon commit c847fcd6e22f7b8b674d107350b62ea3fa09b78a.