### PR TITLE
m3c: Remove support for context-free typenames.

### DIFF
--- a/m3-sys/m3front/src/values/Tipe.m3
+++ b/m3-sys/m3front/src/values/Tipe.m3
@@ -134,7 +134,7 @@ PROCEDURE Compile (t: T): BOOLEAN =
     Type.Compile (t.value);
     (*IF NOT t.imported THEN*)
       uid  := Type.GlobalUID (t.value);
-      name := Value.GlobalName (t, dots := Target.TypenameDots, with_module := Target.TypenameWithModule);
+      name := Value.GlobalName (t, dots := TRUE, with_module := FALSE); (* Type, not Module.Type, not Module__Type *)
       CG.Declare_typename (uid, M3ID.Add (name));
       WebInfo.Declare_typename (uid, t);
     (*END;*)

--- a/m3-sys/m3middle/src/M3CG_Ops.i3
+++ b/m3-sys/m3middle/src/M3CG_Ops.i3
@@ -199,6 +199,7 @@ set_runtime_proc (n: Name;  p: Proc);
 |    f: Frequency       is the front-end estimate of how frequently the
 |                         variable is accessed.
 |    typename: M3ID     a full contextual typename like Cstddef__size_t or Ctypes__int
+|                       for parameter types, return types, etc.
 |                       Only passed if Target.Typenames, since most backends do not use them.
 
 *)

--- a/m3-sys/m3middle/src/Target.i3
+++ b/m3-sys/m3middle/src/Target.i3
@@ -481,16 +481,6 @@ VAR (*CONST*)
  * These are expensive? to produce so optional. *)
 VAR Typenames := FALSE;
 
-(* Type vs. Module.Type. And something for typenames in procedures and blocks
- * and nested procedures. m3c wants global names, m3cc does not, it forms them itself.
- *)
-VAR TypenameWithModule := FALSE;
-
-(* Module.Type vs. Module__Type; m3c wants underscores, m3cc is unclear due
- * to TypenameWithModule = FALSE but preserve historical parameter.
- *)
-VAR TypenameDots := TRUE;
-
 (* Ideally the value 0 would be uninitialized, but it is used publically in Quake? *)
 VAR BackendMode: M3BackendMode_t;
 VAR BackendModeInitialized := FALSE;

--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -151,12 +151,6 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
       Sigsetjmp := FALSE;
     END;
 
-    IF backend_mode = M3BackendMode_t.C THEN
-      Typenames := TRUE;          (* on declare_param, etc. *)
-      TypenameWithModule := TRUE; (* Type vs. Module.Type *)
-      TypenameDots := FALSE;      (* Module.Type vs. Module__Type *)
-    END;
-
     (* There is no portable stack walker, and therefore few systems have one.
        Having a stack walker theoretically speeds up everything nicely.  If
        you are familiar with NT exception handling, all but x86 have a stack


### PR DESCRIPTION
They turn out to be, not so useful.
What ended up required is passing type names
to e.g. declare_param, import_global,
so that typenames could precisely match hand written C,
on a case by case basis. Instead of having so many
names for INTEGER and not knowing which to use,
e.g. size_t and ptrdiff_t are the same thing in IR
(Modula-3 has no unsigned types), or int vs. const_int
(Modula-3 has no const). Those are not the entire problem
though.

Perhaps perhaps we could leverage these typenames
kinda like m3cc and get the data through m3gdb, easily,
via the C compiler and Dwarf. Perhaps.
So the code remains, but disabled, and sharing code with contextual typenames, so nothing really extra that is unused.