### PR TITLE
caltech-parser: Add missing include string.h.

### DIFF
--- a/caltech-parser/cit_util/src/UtimeOpsC.c
+++ b/caltech-parser/cit_util/src/UtimeOpsC.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <assert.h>
+#include <string.h>
 
 #if __cplusplus
 extern "C" {


### PR DESCRIPTION
Esp. for compiling Windows C as C++, for strcpy prototype.