### PR TITLE
caltech-other: Win64: Fix overshifting of integers.

### DIFF
--- a/caltech-other/bool/src/bool.c
+++ b/caltech-other/bool/src/bool.c
@@ -1180,7 +1180,7 @@ void bool_print (bool_t *b)
 void bool_info (BOOL_T *B)
 {
   printf ("memory per node: %d\n", (int)sizeof(bool_t));
-  printf ("max. num. of vars: %ld\n", (1UL<<(sizeof(bool_var_t)*8-1)));
+  printf ("max. num. of vars: %ld\n", (((bool_var_t)1)<<(sizeof(bool_var_t)*8-1)));
   printf ("init. hashtable size: %d\n", HASH_BLOCK);
   printf ("var. block size: %d\n", VAR_BLOCK);
   printf ("num. of vars in use: %ld\n", B->nvar);

--- a/caltech-other/bool/src/bool.h
+++ b/caltech-other/bool/src/bool.h
@@ -42,17 +42,17 @@ struct bool_t {
 
 #define HIBIT_OFFSET (sizeof(bool_var_t)*8-1)
 
-#define BOOL_MAXVAR  (1UL<<HIBIT_OFFSET)
+#define BOOL_MAXVAR  (((bool_var_t)1)<<HIBIT_OFFSET)
 
-#define SET_HIBIT(v) (v |= 1UL << HIBIT_OFFSET)
+#define SET_HIBIT(v) (v |= ((bool_var_t)1) << HIBIT_OFFSET)
 
 #define REFMAX  ((1<<14)-1)
  /* max value of "ref" */
 
-#define ISLEAF(b)      (((b)->id & (1UL << HIBIT_OFFSET)) ? 1 : 0)
+#define ISLEAF(b)      (((b)->id & (((bool_var_t)1) << HIBIT_OFFSET)) ? 1 : 0)
  /* True if "b" is a leaf */
 
-#define ASSIGN_LEAF(b,n) ((b)->id = ((b)->id & ~(1UL<<HIBIT_OFFSET))|(((size_t)n) << HIBIT_OFFSET))
+#define ASSIGN_LEAF(b,n) ((b)->id = ((b)->id & ~(((bool_var_t)1)<<HIBIT_OFFSET))|(((size_t)n) << HIBIT_OFFSET))
  /* assign to the "leaf" bit. */
 
 #define REF(b)         ((b)->ref)


### PR DESCRIPTION
On Windows 64bit, `unsigned long` is 32 bits, not 64.
Shifting `1UL` by 63 is undefined.
Replace `1UL` with `((bool_var_t)1)`.

Printf bugs are left unfixed.