### PR TITLE
Remove "register" from C.

### DIFF
--- a/m3-libs/m3core/src/Csupport/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/dtoa.c
@@ -651,12 +651,12 @@ s2b
  static int
 hi0bits
 #ifdef KR_headers
-	(x) register ULong x;
+	(x) ULong x;
 #else
-	(register ULong x)
+	(ULong x)
 #endif
 {
-	register int k = 0;
+	int k = 0;
 
 	if (!(x & 0xffff0000)) {
 		k = 16;
@@ -690,8 +690,8 @@ lo0bits
 	(ULong *y)
 #endif
 {
-	register int k;
-	register ULong x = *y;
+	int k;
+	ULong x = *y;
 
 	if (x & 7) {
 		if (x & 1)
@@ -1111,7 +1111,7 @@ ulp
 	(double x)
 #endif
 {
-	register Long L;
+	Long L;
 	double a;
 
 	L = (word0(x) & Exp_mask) - (P-1)*Exp_msk1;

--- a/m3-libs/m3core/src/Csupport/old_divmod.c
+++ b/m3-libs/m3core/src/Csupport/old_divmod.c
@@ -48,7 +48,7 @@ extern "C"
 INTEGER m3_div(INTEGER b, INTEGER a)
 {
   typedef  INTEGER ST; /* signed type */
-  register ST c;
+  ST c;
   if ((a == 0) && (b != 0))  {  c = 0;
   } else if (a > 0)  {  c = (b >= 0) ? (a) / (b) : -1 - (a-1) / (-b);
   } else /* a < 0 */ {  c = (b >= 0) ? -1 - (-1-a) / (b) : (-a) / (-b);
@@ -59,7 +59,7 @@ INTEGER m3_div(INTEGER b, INTEGER a)
 INTEGER m3_mod(INTEGER b, INTEGER a)
 {
   typedef  INTEGER ST; /* signed type */
-  register ST c;
+  ST c;
   if ((a == 0) && (b != 0)) {  c = 0;
   } else if (a > 0)  {  c = (b >= 0) ? a % b : b + 1 + (a-1) % (-b);
   } else /* a < 0 */ {  c = (b >= 0) ? b - 1 - (-1-a) % (b) : - ((-a) % (-b));
@@ -71,7 +71,7 @@ INT64 m3_div64(INT64 b, INT64 a)
 {
   typedef  INT64 ST; /* signed type */
   typedef UINT64 UT; /* unsigned type */
-  register ST c;
+  ST c;
   if ((a == 0) && (b != 0))  {  c = 0;
   } else if (a > 0)  {  c = (b >= 0) ? (a) / (b) : -1 - (a-1) / (-b);
   } else /* a < 0 */ {  c = (b >= 0) ? -1 - (-1-a) / (b) : (-a) / (-b);
@@ -82,7 +82,7 @@ INT64 m3_div64(INT64 b, INT64 a)
 INT64 m3_mod64(INT64 b, INT64 a)
 {
   typedef  INT64 ST; /* signed type */
-  register ST c;
+  ST c;
   if ((a == 0) && (b != 0)) {  c = 0;
   } else if (a > 0)  {  c = (b >= 0) ? a % b : b + 1 + (a-1) % (-b);
   } else /* a < 0 */ {  c = (b >= 0) ? b - 1 - (-1-a) % (b) : - ((-a) % (-b));

--- a/m3-libs/m3core/src/Csupport/test_hand.c
+++ b/m3-libs/m3core/src/Csupport/test_hand.c
@@ -5,8 +5,8 @@ __fastcall
 test_set_member(WORD_T elt, WORD_T* set)
 /* never used by current backend */
 {
-  register WORD_T word = elt / SET_GRAIN;
-  register WORD_T bit  = elt % SET_GRAIN;
+  WORD_T word = elt / SET_GRAIN;
+  WORD_T bit  = elt % SET_GRAIN;
   return (set[word] & (1UL << bit)) != 0;
 }
 

--- a/m3-mail/llscan/src/err.c
+++ b/m3-mail/llscan/src/err.c
@@ -81,8 +81,8 @@ void error(string msg, ...)
 static void preprocess(msg)
 string msg;
 {
-    register char *src, *dst;
-    register const char *cp;
+    char *src, *dst;
+    const char *cp;
     char c;
 
     src = msg;

--- a/m3-mail/llscan/src/file.c
+++ b/m3-mail/llscan/src/file.c
@@ -112,7 +112,7 @@ string filename;
 string defext(filename, ext)
 string filename, ext;
 {
-    register char c, *cp;
+    char c, *cp;
     char *xp;
     bool forceext;
 
@@ -248,7 +248,7 @@ string _mappath(fn, path, filename, arg)
 strfn fn;
 string path, filename, arg;
 {
-    register char *cp;
+    char *cp;
     char c;
     string start, finish, localpath, tempname, result;
 

--- a/m3-mail/llscan/src/llscan.c
+++ b/m3-mail/llscan/src/llscan.c
@@ -391,7 +391,7 @@ static void ErrorHelp()
 /***************************************************************/
 
 static void ScanSwitch(cp)
-register char *cp;
+char *cp;
 {
     char c;
 
@@ -615,7 +615,7 @@ madechanges = TRUE;
 
 static void DumpCache()
 {
-    register int i;
+    int i;
     static char iQuaStr[20];
     stream cachefile, headerfile;
     hashentryptr hp;
@@ -849,8 +849,8 @@ if ((subject == NULL) || subject[0] == 0) return NULL;
 if ((pattern == NULL) || pattern[0] == 0) return subject;
 while (*subject) {
   if (*subject++ == *pattern) {
-    register char *stmp = subject;
-    register char *ptmp = pattern + 1;
+    char *stmp = subject;
+    char *ptmp = pattern + 1;
     while ((*ptmp) && (*stmp++ == *ptmp++)) ;
     if (*ptmp == '\0') return(subject-1);
   } /*if*/
@@ -1141,7 +1141,7 @@ static void ReadScan()
 	  while(fgets(linebuf, MAXLINE, ef) != NULL) {
 	    nonempty++;
 	    { 
-	      register char *s;
+	      char *s;
 	      s = linebuf;
 	      while (*s != 0) { *s = tolower(*s); s++; }
             }
@@ -1553,8 +1553,8 @@ static void SetMinMsg()
 
 static void SetBBoardName()
 {
-    register char *src, *dst;
-    register int len;
+    char *src, *dst;
+    int len;
     string bbpath;
     stream bbfile;
     bool fullpath;
@@ -1752,7 +1752,7 @@ string name;
 static bool IsAMessage(name)
 string name;
 {
-    register char *cp;
+    char *cp;
     char c;
 
     cp = name;

--- a/m3-mail/llscan/src/strlib.c
+++ b/m3-mail/llscan/src/strlib.c
@@ -147,7 +147,7 @@ int p1, p2;
 int findstr(text, pat)
 string text, pat;
 {
-    register string s;
+    string s;
     int nch;
 
     nch = strlen(pat);

--- a/m3-tools/gnuemacs/src/flex-bison/lex.yy.c
+++ b/m3-tools/gnuemacs/src/flex-bison/lex.yy.c
@@ -597,9 +597,9 @@ YY_MALLOC_DECL
 
 YY_DECL
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
 
 #line 34 "../parse.lex"
 
@@ -647,7 +647,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
 			if ( yy_accept[yy_current_state] )
 				{
 				yy_last_accepting_state = yy_current_state;
@@ -1085,9 +1085,9 @@ case YY_STATE_EOF(Prag):
 
 static int yy_get_next_buffer()
 	{
-	register char *dest = yy_current_buffer->yy_ch_buf;
-	register char *source = yytext_ptr;
-	register int number_to_move, i;
+	char *dest = yy_current_buffer->yy_ch_buf;
+	char *source = yytext_ptr;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1] )
@@ -1217,15 +1217,15 @@ static int yy_get_next_buffer()
 
 static yy_state_type yy_get_previous_state()
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
 
 	yy_current_state = yy_start;
 	yy_current_state += YY_AT_BOL();
 
 	for ( yy_cp = yytext_ptr + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			yy_last_accepting_state = yy_current_state;
@@ -1257,10 +1257,10 @@ static yy_state_type yy_try_NUL_trans( yy_current_state )
 yy_state_type yy_current_state;
 #endif
 	{
-	register int yy_is_jam;
-	register char *yy_cp = yy_c_buf_p;
+	int yy_is_jam;
+	char *yy_cp = yy_c_buf_p;
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		yy_last_accepting_state = yy_current_state;
@@ -1281,14 +1281,14 @@ yy_state_type yy_current_state;
 
 #ifndef YY_NO_UNPUT
 #ifdef YY_USE_PROTOS
-static void yyunput( int c, register char *yy_bp )
+static void yyunput( int c, char *yy_bp )
 #else
 static void yyunput( c, yy_bp )
 int c;
-register char *yy_bp;
+char *yy_bp;
 #endif
 	{
-	register char *yy_cp = yy_c_buf_p;
+	char *yy_cp = yy_c_buf_p;
 
 	/* undo effects of setting up yytext */
 	*yy_cp = yy_hold_char;
@@ -1296,10 +1296,10 @@ register char *yy_bp;
 	if ( yy_cp < yy_current_buffer->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register int number_to_move = yy_n_chars + 2;
-		register char *dest = &yy_current_buffer->yy_ch_buf[
+		int number_to_move = yy_n_chars + 2;
+		char *dest = &yy_current_buffer->yy_ch_buf[
 					yy_current_buffer->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&yy_current_buffer->yy_ch_buf[number_to_move];
 
 		while ( source > yy_current_buffer->yy_ch_buf )
@@ -1761,7 +1761,7 @@ yyconst char *s2;
 int n;
 #endif
 	{
-	register int i;
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 	}
@@ -1775,7 +1775,7 @@ static int yy_flex_strlen( s )
 yyconst char *s;
 #endif
 	{
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 

--- a/m3-tools/gnuemacs/src/flex-bison/y.tab.c
+++ b/m3-tools/gnuemacs/src/flex-bison/y.tab.c
@@ -1000,9 +1000,9 @@ __yy_memcpy (to, from, count)
      char *from;
      unsigned int count;
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -1015,9 +1015,9 @@ __yy_memcpy (to, from, count)
 static void
 __yy_memcpy (char *to, char *from, unsigned int count)
 {
-  register char *t = to;
-  register char *f = from;
-  register int i = count;
+  char *t = to;
+  char *f = from;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -1060,10 +1060,10 @@ int
 yyparse(YYPARSE_PARAM_ARG)
      YYPARSE_PARAM_DECL
 {
-  register int yystate;
-  register int yyn;
-  register short *yyssp;
-  register YYSTYPE *yyvsp;
+  int yystate;
+  int yyn;
+  short *yyssp;
+  YYSTYPE *yyvsp;
   int yyerrstatus;	/*  number of tokens to shift before error messages enabled */
   int yychar1 = 0;		/*  lookahead token as an internal (translated) token number */
 

--- a/m3-tools/gnuemacs/src/lex-yacc-HPPA/lex.yy.c
+++ b/m3-tools/gnuemacs/src/lex-yacc-HPPA/lex.yy.c
@@ -745,8 +745,8 @@ int *yyfnd;
 extern struct yysvf *yyestate;
 int yyprevious = YYNEWLINE;
 yylook(){
-	register struct yysvf *yystate, **lsp;
-	register struct yywork *yyt;
+	struct yysvf *yystate, **lsp;
+	struct yywork *yyt;
 	struct yysvf *yyz;
 	int yych, yyfirst;
 	struct yywork *yyr;

--- a/m3-tools/gnuemacs/src/lex-yacc-HPPA/y.tab.c
+++ b/m3-tools/gnuemacs/src/lex-yacc-HPPA/y.tab.c
@@ -980,9 +980,9 @@ __yy_bcopy (from, to, count)
      char *to;
      int count;
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -995,9 +995,9 @@ __yy_bcopy (from, to, count)
 static void
 __yy_bcopy (char *from, char *to, int count)
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -1010,10 +1010,10 @@ __yy_bcopy (char *from, char *to, int count)
 int
 yyparse()
 {
-  register int yystate;
-  register int yyn;
-  register short *yyssp;
-  register YYSTYPE *yyvsp;
+  int yystate;
+  int yyn;
+  short *yyssp;
+  YYSTYPE *yyvsp;
   int yyerrstatus;	/*  number of tokens to shift before error messages enabled */
   int yychar1 = 0;		/*  lookahead token as an internal (translated) token number */
 

--- a/m3-tools/gnuemacs/src/lex-yacc/lex.yy.c
+++ b/m3-tools/gnuemacs/src/lex-yacc/lex.yy.c
@@ -597,9 +597,9 @@ YY_MALLOC_DECL
 
 YY_DECL
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
 
 #line 34 "../parse.lex"
 
@@ -647,7 +647,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
 			if ( yy_accept[yy_current_state] )
 				{
 				yy_last_accepting_state = yy_current_state;
@@ -1085,9 +1085,9 @@ case YY_STATE_EOF(Prag):
 
 static int yy_get_next_buffer()
 	{
-	register char *dest = yy_current_buffer->yy_ch_buf;
-	register char *source = yytext_ptr;
-	register int number_to_move, i;
+	char *dest = yy_current_buffer->yy_ch_buf;
+	char *source = yytext_ptr;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1] )
@@ -1217,15 +1217,15 @@ static int yy_get_next_buffer()
 
 static yy_state_type yy_get_previous_state()
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
 
 	yy_current_state = yy_start;
 	yy_current_state += YY_AT_BOL();
 
 	for ( yy_cp = yytext_ptr + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			yy_last_accepting_state = yy_current_state;
@@ -1257,10 +1257,10 @@ static yy_state_type yy_try_NUL_trans( yy_current_state )
 yy_state_type yy_current_state;
 #endif
 	{
-	register int yy_is_jam;
-	register char *yy_cp = yy_c_buf_p;
+	int yy_is_jam;
+	char *yy_cp = yy_c_buf_p;
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		yy_last_accepting_state = yy_current_state;
@@ -1281,14 +1281,14 @@ yy_state_type yy_current_state;
 
 #ifndef YY_NO_UNPUT
 #ifdef YY_USE_PROTOS
-static void yyunput( int c, register char *yy_bp )
+static void yyunput( int c, char *yy_bp )
 #else
 static void yyunput( c, yy_bp )
 int c;
-register char *yy_bp;
+char *yy_bp;
 #endif
 	{
-	register char *yy_cp = yy_c_buf_p;
+	char *yy_cp = yy_c_buf_p;
 
 	/* undo effects of setting up yytext */
 	*yy_cp = yy_hold_char;
@@ -1296,10 +1296,10 @@ register char *yy_bp;
 	if ( yy_cp < yy_current_buffer->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register int number_to_move = yy_n_chars + 2;
-		register char *dest = &yy_current_buffer->yy_ch_buf[
+		int number_to_move = yy_n_chars + 2;
+		char *dest = &yy_current_buffer->yy_ch_buf[
 					yy_current_buffer->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&yy_current_buffer->yy_ch_buf[number_to_move];
 
 		while ( source > yy_current_buffer->yy_ch_buf )
@@ -1761,7 +1761,7 @@ yyconst char *s2;
 int n;
 #endif
 	{
-	register int i;
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 	}
@@ -1775,7 +1775,7 @@ static int yy_flex_strlen( s )
 yyconst char *s;
 #endif
 	{
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 

--- a/m3-tools/gnuemacs/src/lex-yacc/y.tab.c
+++ b/m3-tools/gnuemacs/src/lex-yacc/y.tab.c
@@ -1000,9 +1000,9 @@ __yy_memcpy (to, from, count)
      char *from;
      unsigned int count;
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -1015,9 +1015,9 @@ __yy_memcpy (to, from, count)
 static void
 __yy_memcpy (char *to, char *from, unsigned int count)
 {
-  register char *t = to;
-  register char *f = from;
-  register int i = count;
+  char *t = to;
+  char *f = from;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -1060,10 +1060,10 @@ int
 yyparse(YYPARSE_PARAM_ARG)
      YYPARSE_PARAM_DECL
 {
-  register int yystate;
-  register int yyn;
-  register short *yyssp;
-  register YYSTYPE *yyvsp;
+  int yystate;
+  int yyn;
+  short *yyssp;
+  YYSTYPE *yyvsp;
   int yyerrstatus;	/*  number of tokens to shift before error messages enabled */
   int yychar1 = 0;		/*  lookahead token as an internal (translated) token number */
 

--- a/m3-tools/pp/src/Parse.yacc
+++ b/m3-tools/pp/src/Parse.yacc
@@ -1830,11 +1830,11 @@ static const char *builtins[] = {
 void PRID(const char *s)
 #else
 PRID(s)
-    register char *s;
+    char *s;
 #endif
 {
-    register int i;
-    register const char *b;
+    int i;
+    const char *b;
 
     for (i = 0; (b = builtins[i]) != NULL; ++i) {
 	if (*b == *s && strcmp(b, s) == 0) {
@@ -2221,7 +2221,7 @@ HandleComments(firstTime, initNPS, doBreak)
 /* Comment and newline handling code. */
 {
     int i;
-    register char *s, c;
+    char *s, c;
     int startCol, ws;
     int needEnd = 0;
 

--- a/m3-tools/pp/src/flex-bison/y.tab.c
+++ b/m3-tools/pp/src/flex-bison/y.tab.c
@@ -5384,11 +5384,11 @@ static const char *builtins[] = {
 void PRID(const char *s)
 #else
 PRID(s)
-    register char *s;
+    char *s;
 #endif
 {
-    register int i;
-    register const char *b;
+    int i;
+    const char *b;
 
     for (i = 0; (b = builtins[i]) != NULL; ++i) {
 	if (*b == *s && strcmp(b, s) == 0) {
@@ -5775,7 +5775,7 @@ HandleComments(firstTime, initNPS, doBreak)
 /* Comment and newline handling code. */
 {
     int i;
-    register char *s, c;
+    char *s, c;
     int startCol, ws;
     int needEnd = 0;
 

--- a/m3-tools/pp/src/lex-yacc-HPPA/lex.yy.c
+++ b/m3-tools/pp/src/lex-yacc-HPPA/lex.yy.c
@@ -703,8 +703,8 @@ int *yyfnd;
 extern struct yysvf *yyestate;
 int yyprevious = YYNEWLINE;
 yylook(){
-	register struct yysvf *yystate, **lsp;
-	register struct yywork *yyt;
+	struct yysvf *yystate, **lsp;
+	struct yywork *yyt;
 	struct yysvf *yyz;
 	int yych, yyfirst;
 	struct yywork *yyr;

--- a/m3-tools/pp/src/lex-yacc-HPPA/y.tab.c
+++ b/m3-tools/pp/src/lex-yacc-HPPA/y.tab.c
@@ -2102,9 +2102,9 @@ __yy_bcopy (from, to, count)
      char *to;
      int count;
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -2117,9 +2117,9 @@ __yy_bcopy (from, to, count)
 static void
 __yy_bcopy (char *from, char *to, int count)
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -2132,10 +2132,10 @@ __yy_bcopy (char *from, char *to, int count)
 int
 yyparse()
 {
-  register int yystate;
-  register int yyn;
-  register short *yyssp;
-  register YYSTYPE *yyvsp;
+  int yystate;
+  int yyn;
+  short *yyssp;
+  YYSTYPE *yyvsp;
   int yyerrstatus;	/*  number of tokens to shift before error messages enabled */
   int yychar1 = 0;		/*  lookahead token as an internal (translated) token number */
 
@@ -3273,10 +3273,10 @@ static char *builtins[] = {
     
 
 PRID(s)
-    register char *s;
+    char *s;
 {
-    register int i;
-    register char *b;
+    int i;
+    char *b;
 
     for (i = 0; (b = builtins[i]) != NULL; ++i) {
 	if (*b == *s && strcmp(b, s) == 0) {
@@ -3514,7 +3514,7 @@ HandleComments(firstTime, initNPS, doBreak)
     int doBreak;		/* is a Break about to happen? */
 {
     int i;
-    register char *s, c;
+    char *s, c;
     int startCol, ws;
     int needEnd = 0;
 

--- a/m3-tools/pp/src/lex-yacc/lex.yy.c
+++ b/m3-tools/pp/src/lex-yacc/lex.yy.c
@@ -651,9 +651,9 @@ YY_MALLOC_DECL
 
 YY_DECL
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
 
 #line 26 "../Parse.lex"
 
@@ -700,7 +700,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
 			if ( yy_accept[yy_current_state] )
 				{
 				yy_last_accepting_state = yy_current_state;
@@ -1222,9 +1222,9 @@ case YY_STATE_EOF(Prag):
 
 static int yy_get_next_buffer()
 	{
-	register char *dest = yy_current_buffer->yy_ch_buf;
-	register char *source = yytext_ptr;
-	register int number_to_move, i;
+	char *dest = yy_current_buffer->yy_ch_buf;
+	char *source = yytext_ptr;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1] )
@@ -1354,14 +1354,14 @@ static int yy_get_next_buffer()
 
 static yy_state_type yy_get_previous_state()
 	{
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
 
 	yy_current_state = yy_start;
 
 	for ( yy_cp = yytext_ptr + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 3);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 3);
 		if ( yy_accept[yy_current_state] )
 			{
 			yy_last_accepting_state = yy_current_state;
@@ -1393,10 +1393,10 @@ static yy_state_type yy_try_NUL_trans( yy_current_state )
 yy_state_type yy_current_state;
 #endif
 	{
-	register int yy_is_jam;
-	register char *yy_cp = yy_c_buf_p;
+	int yy_is_jam;
+	char *yy_cp = yy_c_buf_p;
 
-	register YY_CHAR yy_c = 3;
+	YY_CHAR yy_c = 3;
 	if ( yy_accept[yy_current_state] )
 		{
 		yy_last_accepting_state = yy_current_state;
@@ -1417,14 +1417,14 @@ yy_state_type yy_current_state;
 
 #ifndef YY_NO_UNPUT
 #ifdef YY_USE_PROTOS
-static void yyunput( int c, register char *yy_bp )
+static void yyunput( int c, char *yy_bp )
 #else
 static void yyunput( c, yy_bp )
 int c;
-register char *yy_bp;
+char *yy_bp;
 #endif
 	{
-	register char *yy_cp = yy_c_buf_p;
+	char *yy_cp = yy_c_buf_p;
 
 	/* undo effects of setting up yytext */
 	*yy_cp = yy_hold_char;
@@ -1432,10 +1432,10 @@ register char *yy_bp;
 	if ( yy_cp < yy_current_buffer->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register int number_to_move = yy_n_chars + 2;
-		register char *dest = &yy_current_buffer->yy_ch_buf[
+		int number_to_move = yy_n_chars + 2;
+		char *dest = &yy_current_buffer->yy_ch_buf[
 					yy_current_buffer->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&yy_current_buffer->yy_ch_buf[number_to_move];
 
 		while ( source > yy_current_buffer->yy_ch_buf )
@@ -1888,7 +1888,7 @@ yyconst char *s2;
 int n;
 #endif
 	{
-	register int i;
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 	}
@@ -1902,7 +1902,7 @@ static int yy_flex_strlen( s )
 yyconst char *s;
 #endif
 	{
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 

--- a/m3-tools/pp/src/lex-yacc/y.tab.c
+++ b/m3-tools/pp/src/lex-yacc/y.tab.c
@@ -502,7 +502,7 @@ union yyalloc
 #   define YYCOPY(To, From, Count)		\
       do					\
 	{					\
-	  register size_t yyi;		\
+	  size_t yyi;				\
 	  for (yyi = 0; yyi < (Count); yyi++)	\
 	    (To)[yyi] = (From)[yyi];		\
 	}					\
@@ -3690,7 +3690,7 @@ yystrlen (yystr)
      const char *yystr;
 #   endif
 {
-  register const char *yys = yystr;
+  const char *yys = yystr;
 
   while (*yys++ != '\0')
     continue;
@@ -3715,8 +3715,8 @@ yystpcpy (yydest, yysrc)
      const char *yysrc;
 #   endif
 {
-  register char *yyd = yydest;
-  register const char *yys = yysrc;
+  char *yyd = yydest;
+  const char *yys = yysrc;
 
   while ((*yyd++ = *yys++) != '\0')
     continue;
@@ -3851,8 +3851,8 @@ yyparse ()
 #endif
 {
   
-  register int yystate;
-  register int yyn;
+  int yystate;
+  int yyn;
   int yyresult;
   /* Number of tokens to shift before error messages enabled.  */
   int yyerrstatus;
@@ -3870,12 +3870,12 @@ yyparse ()
   /* The state stack.  */
   short int yyssa[YYINITDEPTH];
   short int *yyss = yyssa;
-  register short int *yyssp;
+  short int *yyssp;
 
   /* The semantic value stack.  */
   YYSTYPE yyvsa[YYINITDEPTH];
   YYSTYPE *yyvs = yyvsa;
-  register YYSTYPE *yyvsp;
+  YYSTYPE *yyvsp;
 
 
 
@@ -5295,10 +5295,10 @@ static char *builtins[] = {
     
 
 PRID(s)
-    register char *s;
+    char *s;
 {
-    register int i;
-    register char *b;
+    int i;
+    char *b;
 
     for (i = 0; (b = builtins[i]) != NULL; ++i) {
 	if (*b == *s && strcmp(b, s) == 0) {
@@ -5546,7 +5546,7 @@ HandleComments(firstTime, initNPS, doBreak)
     int doBreak;		/* is a Break about to happen? */
 {
     int i;
-    register char *s, c;
+    char *s, c;
     int startCol, ws;
     int needEnd = 0;
 

--- a/m3-tools/pp/src/lex_help.h
+++ b/m3-tools/pp/src/lex_help.h
@@ -226,7 +226,7 @@ static EndComment()
 static int IsWhite(char c)
 #else
 static int IsWhite(c)
-    register char c;
+    char c;
 #endif
 {
     return c == ' ' || c == '\t' || c == '\f' || c == '\n' || c == '\r';
@@ -306,7 +306,7 @@ int HandleCommentPragma ()
 {
     /* use 'int' instead of 'char' for distinguishing between end of file
        and characters above 127 */
-    register int c, c2;
+    int c, c2;
 
     StartNPS();
     /* Now deal with the main loop. */

--- a/m3-ui/juno-2/juno-machine/src/OLD/CRowOp.c
+++ b/m3-ui/juno-2/juno-machine/src/OLD/CRowOp.c
@@ -13,11 +13,11 @@ rowop(len, target, src, factor)
   float *target, *src;
   float factor;
 {
-    register int i, i2;
-    register float maxAbs = 0.0;
-    register float abs;
-    register float t0, t1, t2, t3;
-    register int maxCol = -1;
+    int i, i2;
+    float maxAbs = 0.0;
+    float abs;
+    float t0, t1, t2, t3;
+    int maxCol = -1;
 
     for (i=0; i<len-2; i+=2) {
         t0 = src[i];


### PR DESCRIPTION
Newer C/C++ deprecates/disallows it.
It has a vestigial meaning of "not allowed to take address"
which does in fact help optimization, but otherwise,
compilers do their own register allocation.