### PR TITLE
Add AMD64_MINGW config and script support.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_MINGW
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_MINGW
@@ -1,0 +1,58 @@
+% Use GNU minimally, instead of Visual C++
+%   Use g++ to compile and link, targeting Windows.
+%   This could be hypothetically any host (Linux, Msys, Cygwin).
+%   use native Windows threads, gui, C runtime
+%
+%-------------------------------------------------------------------
+
+M3_BACKEND_MODE = "C"
+
+% Some of this seems redundant: AMD64 implies 64bits+little.
+% AMD64_MINGW implies AMD64 and NT.
+% WIN32 implies NT
+readonly TARGET_ENDIAN = "LITTLE"  % { "BIG" OR "LITTLE" }
+readonly TARGET_ARCH = "AMD64"
+readonly WORD_SIZE = "64BITS"      % { "32BITS" or "64BITS" }
+readonly TARGET_OS = "NT"
+readonly OS_TYPE = "WIN32"         % host vs. target confusion?
+readonly TARGET = "AMD64_MINGW"    % host vs. target confusion?
+
+M3_PARALLEL_BACK = 20              % host vs. target confusion
+
+include ("cm3cfg.common")
+
+SYSTEM_LIBS =
+{
+  "LIBC" : [ "-liphlpapi", "-lrpcrt4", "-lcomctl32", "-lws2_32", "-lgdi32", "-luser32", "-ladvapi32" ],
+  "TCP" : [ ],
+}
+
+SYSTEM_LIBORDER = [ "LIBC" ]
+
+proc compile_c(source, object, options, optimize, debug) is
+  % clang probably works too
+  exec ("@x86_64-w64-mingw32-g++", "-g", "-xc++", "-c", options, source, "-o", object)
+  return 0
+end
+
+proc m3_link(prog, options, objects, imported_libs, shared) is
+  imported_libs = ConvertLibsToStandalone(imported_libs, shared)
+  % clang probably works too
+  exec ("x86_64-w64-mingw32-g++", "-o", prog, options, arglist("@", [objects, imported_libs]))
+  return 0
+end
+
+proc skip_lib(lib, shared) is
+  % TODO (see NT.common etc.)
+  deriveds ("", [lib & ".lib"])
+  return 0
+end
+
+proc make_lib(lib, options, objects, imported_libs, shared) is
+  % TODO shared support (see NT.common etc.)
+  % arglist is to make a response file -- command line in file,
+  % which really is required due to restrictive command line length limits
+  deriveds ("", [lib & ".lib"])
+  exec("ar", "cr", lib & ".lib", arglist("@", objects))
+  return 0
+end

--- a/m3-sys/windowsResources/src/winRes.tmpl
+++ b/m3-sys/windowsResources/src/winRes.tmpl
@@ -22,10 +22,12 @@ readonly proc WindowsResource (file) is
    if equal (OS_TYPE, "WIN32")
       if defined ("_all")
          if stale (res, src)
-            if equal (M3_BACKEND_MODE, "0") or equal (M3_BACKEND_MODE, "C")
+            % Next line is all wrong, confusing mode and host and target. This
+            % entire function should probably be in config files.
+            if (equal (M3_BACKEND_MODE, "0") or equal (M3_BACKEND_MODE, "C")) and not equal (TARGET, "AMD64_MINGW")
               exec ("rc -DWIN32 -i", path_of(""), "-fo", res, src)
             else
-              exec ("windres -DWIN32 -I", path_of(""), "-o", res, "-i", src)
+              exec ("windres -DWIN32 -I", path_of(""), "-o", res, "-i", subst_chars(src, "\\", "/"))
             end
          end
       end

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1195,6 +1195,7 @@ def Boot():
         # gcc and other platforms
         CCompiler = {
             "SOLgnu" : "/usr/sfw/bin/g++",
+            "AMD64_MINGW"   : "x86_64-w64-mingw32-g++",
             "AMD64_NT"      : "cl",
             }.get(Config) or "g++"
 
@@ -1202,6 +1203,7 @@ def Boot():
         # -fPIC breaks Interix and is not needed on Cygwin/Mingw.
         CCompilerFlags = {
             "I386_INTERIX"  : " -g ", # gcc -fPIC generates incorrect code on Interix
+            "AMD64_MINGW"   : " -g ", # No need for -pthread
             #"AMD64_NT"      : " -Zi -MD -Gy ",
             "AMD64_NT"      : " -Zi -Gy ", # hack some problem with exception handling and alignment otherwise
             }.get(Config) or " -pthread -g "
@@ -1248,7 +1250,7 @@ def Boot():
     if darwin:
         pass
     elif mingw:
-        pass
+        Link = Link  +  " -liphlpapi -lrpcrt4 -lcomctl32 -lws2_32 -lgdi32 -luser32 -ladvapi32 "
     elif solaris or sol:
         Link = Link  +  " -lpthread -lrt -lm -lnsl -lsocket -lc -pthread "
     elif hpux:


### PR DESCRIPTION
This is mostly monolithic, but small.
Use the C backend yet again.
Single file release does not yet work for Win32.