### PR TITLE
Partially revert "m3c: Remove support for context-free typenames. (#6…

### DIFF
--- a/m3-sys/m3middle/src/Target.m3
+++ b/m3-sys/m3middle/src/Target.m3
@@ -151,6 +151,10 @@ PROCEDURE Init (system: TEXT; in_OS_name: TEXT; backend_mode: M3BackendMode_t): 
       Sigsetjmp := FALSE;
     END;
 
+    IF backend_mode = M3BackendMode_t.C THEN
+      Typenames := TRUE;          (* on declare_param, etc. *)
+    END;
+
     (* There is no portable stack walker, and therefore few systems have one.
        Having a stack walker theoretically speeds up everything nicely.  If
        you are familiar with NT exception handling, all but x86 have a stack


### PR DESCRIPTION
…81)"

This partially reverts commit 8e964360cb8c87a31e879669647c9347717ca2aa.

It removed only about one too many lines, causing
the C backend to lose its contextual typenames and regressing
the single file bootsrap (found trying Windows, which isn't yet complete,
but I'd break Unix).