### PR TITLE
quake: Use forward slashes more.

### DIFF
--- a/m3-sys/m3quake/src/M3Path.m3
+++ b/m3-sys/m3quake/src/M3Path.m3
@@ -56,7 +56,7 @@ CONST
 VAR target_os := ARRAY Compiler.OS OF OSKind{OSKind.Unix, OSKind.Win32}[Compiler.ThisOS];
 CONST d_sep = ARRAY Compiler.OS OF CHAR{Slash, BackSlash}[Compiler.ThisOS];
 CONST v_sep = ARRAY Compiler.OS OF CHAR{Null, Colon}[Compiler.ThisOS];
-CONST DirSepText = ARRAY Compiler.OS OF TEXT{"/", "\\"}[Compiler.ThisOS];
+(*CONST DirSepText = ARRAY Compiler.OS OF TEXT{"/", "\\"}[Compiler.ThisOS];*)
 
 PROCEDURE SetTargetOS (kind: OSKind) =
   BEGIN
@@ -124,7 +124,7 @@ PROCEDURE Join (dir, base: TEXT;  k: Kind): TEXT =
         IF dir_len # 0 THEN
           len := Append (buf, len, dir, dir_len);
           IF add_sep THEN
-            buf[len] := d_sep;
+            buf[len] := Slash; (*d_sep*)
             INC (len);
           END;
         END;
@@ -191,7 +191,7 @@ PROCEDURE DoParse (nm_txt: TEXT; len: CARDINAL; VAR nm: ARRAY OF CHAR): T =
       t.dir := NIL;
       start := 0;
     ELSIF (d_index = 0) THEN
-      t.dir := DirSepText;
+      t.dir := "/"; (*DirSepText*)
       start := 1;
     ELSE
       t.dir := Text.FromChars (SUBARRAY (nm, 0, d_index));
@@ -496,7 +496,7 @@ PROCEDURE PathRemoveDots (VAR p: ARRAY OF CHAR; READONLY start: CARDINAL; VAR le
     (* if there were more ".."s than preceding elements, add back some ".."s *)
     WHILE level # 0 DO
       IF (to # start) AND (NOT IsDirSep (p[to - 1])) THEN
-        p[to] := d_sep;
+        p[to] := Slash; (*d_sep*)
         INC (to);
       END;
       p[to] := '.';
@@ -511,12 +511,12 @@ PROCEDURE PathRemoveDots (VAR p: ARRAY OF CHAR; READONLY start: CARDINAL; VAR le
 
     (* if input started with a separator or two, then so must output *)
     IF IsDirSep (p[from - 1]) AND (len = 0 OR NOT IsDirSep (p[to - 1])) THEN
-      p[to] := d_sep;
+      p[to] := Slash; (*d_sep*)
       INC (to);
       INC (end);
       INC (len);
       IF IsDirSep (p[from - 2]) AND (len = 1 OR NOT IsDirSep (p[to - 2])) THEN
-        p[to] := d_sep;
+        p[to] := Slash; (*d_sep*)
         INC (to);
         INC (end);
         INC (len);


### PR DESCRIPTION
Forward slashes work almost but not quite everywhere on Windows.
Maybe this will help MinGW.
We cannot use forward slashes everywhere though, as that broke something.