### PR TITLE
m3-sys: Assert that nested functions are not exported.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -5942,6 +5942,8 @@ BEGIN
         self.comment("declare_procedure");
     END;
 
+    <* ASSERT level = 0 OR NOT exported *> (* nested functions cannot be exported *)
+
     ReplaceName (self, name);
     ReplaceName (self, return_typename);
 

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -1391,6 +1391,9 @@ PROCEDURE Declare_procedure (n: Name;  n_params: INTEGER;  ret_type: Type;
   VAR p: Proc;
   BEGIN
     IF (procedures = NIL) THEN procedures := NewNameTbl() END;
+
+    <* ASSERT lev = 0 OR NOT exported *> (* nested functions cannot be exported *)
+
     p := cg.declare_procedure (n, n_params, ret_type,
                                lev, cc, exported, parent,
                                return_typeid, return_typename);


### PR DESCRIPTION
I am assuming "exported" here means directly callable,
and does not include address-taken and passed outside.