### PR TITLE
m3core: WinTabCon and WinListView implementation are

### DIFF
--- a/m3-libs/m3core/src/win32/m3makefile
+++ b/m3-libs/m3core/src/win32/m3makefile
@@ -52,8 +52,10 @@ Interface  ("TlHelp32")
 % New interfaces added March 2003 by darkov
 Interface  ("WinMidi")
 Interface  ("WinCommCtrl")
-Interface  ("WinTabCon")
-Interface  ("WinListView")
+if equal(WORD_SIZE, "32BITS") % temporary hack
+  Interface ("WinTabCon")
+  Interface ("WinListView")
+end
 Interface  ("WinImageList")
 
 if IsTargetNT() or IsTargetCygwin()


### PR DESCRIPTION
only provided for 32bit; make the interface also limited the same.
This is a "temporary" hack, but has lived long (since 2013).

The point of this is so we can export what is declared.
So we do not declare stuff that does not exist.