### PR TITLE
m3core: Layout out IPv6 for OSF/1 compatibility.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Uin.i3
+++ b/m3-libs/m3core/src/unix/Common/Uin.i3
@@ -24,18 +24,19 @@ TYPE
   END;
 
   struct_in6_addr = RECORD
-    u6_addr8 : ARRAY[0..15] OF char;
+    u6_addr8 : ARRAY[0..15] OF char; (* but 8-aligned e.g. for OSF/1 *)
   END;
 
  (* On some platforms family is 8 bits and there is another 8 bits next to it
   * but you do not have read or write it.
   *)
   struct_sockaddr_in6 = RECORD
-    sin6_family : unsigned_short;   (* AF_INET6 *)
-    sin6_port   : unsigned_short;   (* port number *)
-    sin6_flowinfo : unsigned;       (* IPv6 flow information *)
-    sin6_addr : struct_in6_addr;    (* IPv6 address *)
-    sin6_scope_id : unsigned;       (* Scope ID (new in 2.4) *)
+    sin6_family                : unsigned_short;  (* AF_INET6 *)
+    sin6_port                  : unsigned_short;  (* port number *)
+    sin6_flowinfo              : unsigned;        (* IPv6 flow information *)
+    sin6_scope_id              : unsigned;        (* Scope ID (new in 2.4) *)
+    sin6_padding_for_alignment : unsigned;        (* sin6_addr is 8-aligned on OSF/1 *)
+    sin6_addr                  : struct_in6_addr; (* IPv6 address *)
   END;
 
  (* The size of sun_path here is made up.

--- a/m3-libs/m3core/src/unix/Common/Usocket.c
+++ b/m3-libs/m3core/src/unix/Common/Usocket.c
@@ -50,10 +50,13 @@ struct m3_sockaddr_in6
     unsigned short family;
     unsigned short port;
     unsigned int   flowinfo;
-    in6_addr       addr;
     unsigned int   scope_id;
+    // in6_addr is 16 bytes. On OSF/1 it is 8-aligned.
+    // Ideally the largest elements are first, but keep family/port first to fit other protocols.
+    unsigned int   padding_for_alignment; // 4 more bytes so addr is 8-aligned.
+    in6_addr       addr;
 };
-M3_STATIC_ASSERT(sizeof(m3_sockaddr_in6) == 28);
+M3_STATIC_ASSERT(sizeof(m3_sockaddr_in6) == 32);
 
 // Idealized Modula3 Unix socket address.
 // This is likely slightly larger than all native forms.


### PR DESCRIPTION
In particular in6_addr has 8-alignment.
Move unsigned int to before it, and add another for explicit padding for alignment.

Otherwise OSF/1 fails static assert here.