### PR TITLE
m3core: Remove C99 math support for OSF/1.

### DIFF
--- a/m3-libs/m3core/src/float/m3makefile
+++ b/m3-libs/m3core/src/float/m3makefile
@@ -18,8 +18,11 @@ _FloatPieces = {
 
 % C99 might require Solaris 2.10 or newer for {I386,SPARC32,SPARC64}_SOLARIS.
 % AMD64_SOLARIS presumably requires Solaris 2.10.
+%
+% OSF/1 C99 support appears incomplete, but maybe can be built upon, later
 _FloatPiecesNoC99 = {
     "NT",
+    "OSF",
 }
 
 _FloatPiecesC99 = {
@@ -32,7 +35,6 @@ _FloatPiecesC99 = {
     "MINGW",
     "NETBSD",
     "OPENBSD",
-    "OSF",
     "SOLARIS",
     "VMS",
 }


### PR DESCRIPTION
OSF/1 C99 math support is incomplete.
We should be able to provide most/all of it on top of nonstandard names.
See:
 read_rnd, write_rnd (and compiler flags)
 ieee_get_fp_control