### PR TITLE
m3c: Avoid duplicate typedefs of REAL, LONGREAL, EXTENDED.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2568,6 +2568,10 @@ CONST Prefix = ARRAY OF TEXT {
 "# endif",
 "#endif",
 
+"#define REAL REAL",
+"#define LONGREAL LONGREAL",
+"#define EXTENDED EXTENDED",
+
 "typedef float REAL;",
 "typedef double LONGREAL;",
 "typedef /*long*/ double EXTENDED;",


### PR DESCRIPTION
This in particular fails with native cc on OSF/1.