### PR TITLE
m3core/m3c: If _LONGLONG is defined, use long long and LL/ULL.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -431,7 +431,7 @@ typedef unsigned long      UINT32;
 #endif
 
 // Support pre-C99 for Windows and VMS and any system with an __int64 macro.
-#if defined(_MSC_VER) || defined(__DECC) || defined(__DECCXX) || defined(__int64)
+#if !defined(_LONGLONG) && (defined(_MSC_VER) || defined(__DECC) || defined(__DECCXX) || defined(__int64))
 typedef          __int64    INT64;
 typedef unsigned __int64   UINT64;
 #else

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2508,7 +2508,7 @@ CONST Prefix = ARRAY OF TEXT {
 "typedef unsigned short UINT16;",
 "typedef int INT32;",
 "typedef unsigned int UINT32;",
-"#if defined(_MSC_VER) || defined(__DECC) || defined(__DECCXX) || defined(__int64)", (* matches m3core.h *)
+"#if !defined(_LONGLONG) && (defined(_MSC_VER) || defined(__DECC) || defined(__DECCXX) || defined(__int64))", (* matches m3core.h *)
 "typedef __int64 INT64;",
 "typedef unsigned __int64 UINT64;",
 "#define  INT64_(x) x##I64",


### PR DESCRIPTION
This fixes OSF/1 which defines __DECC.