### PR TITLE
m3c: Skip some duplicate typedefs.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -947,7 +947,11 @@ END;
 PROCEDURE type_typedef(type: Type_t; self: T) =
 (* A reusable value for Type_Define. *)
 BEGIN
+  IF NOT self.typedef_defined.insert(type.text) THEN
+    ifndef (self, type.text);
     print(self, "/*type_typedef*/typedef " & cgtypeToText[type.cgtype] & " " & type.text & ";\n");
+    endif (self);
+  END;
 END type_typedef;
 
 PROCEDURE type_canBeDefined_true(<*UNUSED*>type: Type_CanBeDefinedTrue_t; <*UNUSED*>self: T): BOOLEAN =


### PR DESCRIPTION
gcc on OSF/1 in particular errors wrt WIDECHAR.
Though g++ and native cc and cxx were ok.