### PR TITLE
AMD64_LINUX - build with -no-pie

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_LINUX
@@ -6,5 +6,9 @@ SYSTEM_CXXC = "g++ -g -m64 -fPIC" % C++ compiler
 
 readonly SYSTEM_ASM = "as --64" % Assembler
 
+% PIE debugging requires gdb 7.1 or newer, even for C
+% see http://www.gnu.org/software/gdb/download/ANNOUNCEMENT
+readonly POSITION_INDEPENDENT_EXECUTABLE = "-no-pie"
+
 include("AMD64.common")
 include("Linux.common")


### PR DESCRIPTION
Tested on Debian 10.8.0 amd64 with m3gdb builded on Debian 8.11.1 amd64