### PR TITLE
config: AlphaOsf: Pass -o object to C compiler so it

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
+++ b/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
@@ -71,7 +71,7 @@ m3back_optimize = ""
 
 proc compile_c (source, object, options, optimize, debug) is
   configure_c_compiler()
-  return try_exec ("@" & SYSTEM_CC, options, "-c", source)
+  return try_exec ("@" & SYSTEM_CC, options, "-c", source, "-o", object)
 end
 
 %---------------------------------------------------------------- assembler ---


### PR DESCRIPTION
honors naming convention, which we probably have too
many of as well. Else ar commnds fail.