### PR TITLE
m3core: Default host to ALPHA_OSF, not ALPHA_OSF1.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -920,6 +920,10 @@ Process__RegisterExitor(void (__cdecl*)(void));
 
 #define GET_PC(context) ((context)->uc_mcontext.sc_pc)
 
+#if defined(__alpha__)
+#define M3_HOST "ALPHA_OSF"
+#endif
+
 #elif defined(__OpenBSD__)
 
 #if defined(__amd64)

--- a/m3-sys/m3quake/src/MxConfigC.c
+++ b/m3-sys/m3quake/src/MxConfigC.c
@@ -190,6 +190,9 @@ MxConfigC__HOST(void)
     if (solaris)
         uname_system = "SOLARIS";
 
+    else if (osf)
+        uname_system = "OSF"; // instead of OSF1 with the 1
+
     // AMD64_SOLARIS is i86pc; we must use local sizeof(void*).
     if (x86 && size32) // x86 => i386
     {


### PR DESCRIPTION
It is hard to see where the "1" comes from.
It is probably from calling uname() in MxConfigC.c.

Granted, uname does come so close, maybe we should let it
be the decider, thereby getting platform names automatically.
Or rather output directory names and no platforms per se,
just Posixish.