### PR TITLE
OSF1: Fix alloca for Tru64/OSF1 with native cc.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -1258,8 +1258,9 @@ typedef unsigned long                           WinNT__SECURITY_INFORMATION;
 #ifndef alloca
 # ifdef __GNUC__
 #  define alloca __builtin_alloca
-# elif defined(__DECC) || defined(__DECCXX)
-#  define alloca(x) __ALLOCA(x)
+//This was thought to handle VMS but has never been tested.
+//# elif !defined(__osf__) && (defined(__DECC) || defined(__DECCXX))
+//#  define alloca(x) __ALLOCA(x)
 # elif defined(_MSC_VER)
 #ifdef __cplusplus
 extern "C" {
@@ -1270,6 +1271,7 @@ extern "C" {
 #endif
 #  define alloca _alloca
 # else
+/* This is verified correct for Solaris, Tru64/OSF1, documented correct for AIX. TODO: Irix, HP-UX, etc. */
 #  include <alloca.h>
 # endif
 #endif

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2551,8 +2551,10 @@ CONST Prefix = ARRAY OF TEXT {
 "#ifndef alloca",
 "# ifdef __GNUC__",
 "#  define alloca __builtin_alloca",
-"# elif defined(__DECC) || defined(__DECCXX)",
-"#  define alloca(x) __ALLOCA(x)",
+(* This was thought to handle VMS but has never been tested.
+"# elif !defined(__osf__) && (defined(__DECC) || defined(__DECCXX))",
+"#  define alloca(x) __ALLOCA(x)", VMS?
+*)
 "# elif defined(_MSC_VER)",
 
 "#ifdef __cplusplus",
@@ -2567,7 +2569,7 @@ CONST Prefix = ARRAY OF TEXT {
 
 "#  define alloca _alloca",
 "# else",
-(* This is verified correct for Solaris, documented correct for AIX. TODO: Irix, HP-UX, etc. *)
+(* This is verified correct for Solaris, Tru64/OSF1, documented correct for AIX. TODO: Irix, HP-UX, etc. *)
 "#  include <alloca.h>",
 "# endif",
 "#endif",


### PR DESCRIPTION
Hypothetical alloca for OpenVMS was breaking it. Disable that "for now".
It was already working for gcc.