### PR TITLE
OSF1: Switch Tru64 / OSF1 to C backend "only".

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
+++ b/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
@@ -13,6 +13,8 @@ readonly WORD_SIZE    = "64BITS"
 readonly TARGET_ENDIAN = "LITTLE" % { "BIG" OR "LITTLE" }
 readonly GNU_PLATFORM = "alpha-dec-osf5.1"
 
+M3_BACKEND_MODE = "C" % Gcc backend does work but default to C.
+
 %------------------------------------------------ external system libraries ---
 % SYSTEM_LIBS provides a mapping from Modula-3 names for the common
 % external libraries to site-dependent information about how they

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -386,7 +386,8 @@ def TargetOnlyHasCBackend(a):
     if a == "i386_nt":
         return false
     return (a.endswith("_nt") or a.startswith("arm") or a.find("riscv") != -1
-        or a.find("solaris") != -1 or a.startswith("sol")
+        or a.find("solaris") != -1 or a.startswith("sol") # gcc backend does work
+        or a.find("alpha") or a.find("osf") # gcc backend does work
         or a.find("mingw") != -1 or a.find("cygwin") != -1)
 
 _PossibleCm3Flags = ["boot", "keep", "override", "commands", "verbose", "why", "debug", "trace"]
@@ -1189,7 +1190,7 @@ def Boot():
         CCompiler = "./c_compiler"
         CopyFile("./c_compiler", BootDir)
     elif osf:
-        CCompiler = "/usr/bin/c++"
+        CCompiler = "cc" # cxx, gcc, g++ all work
         CCompilerFlags = " -g -pthread "
     else:
         # gcc and other platforms


### PR DESCRIPTION
This is config and scripts.
The gcc backend did work a long time ago, and very recently also.
All of native cc, native cxx, gcc (3.4.6? 4.7?) and g++ should all work.
With native cxx, our install is slightly broken and linking requires -oldcxx,
just because one copy of one of the startup files is missing.
From a frontend point of view, old is likely Digital-authored
and "new" is EDG.

Fix path of C compiler in bootstrap.