### PR TITLE
config: Remove OSF 4 vs. 5 SYSTEM_CC configuration.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
+++ b/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
@@ -50,11 +50,6 @@ proc configure_c_compiler() is
   end
   SYSTEM_CC = "/usr/bin/cc -O3 -g3 -pthread -readonly_strings"
             & " -ieee_with_no_inexact -error_unresolved "
-  if IsTargetOSF1v4()
-    SYSTEM_CC = SYSTEM_CC & "-Wl,-B,symbolic"
-  else
-    SYSTEM_CC = SYSTEM_CC & "-B symbolic"
-  end
 end
 readonly SYSTEM_AR  = "/usr/bin/ar"
 readonly SYSTEM_ASM = "/usr/bin/as -nocpp -g -oldas -c -O0" % same as gcc


### PR DESCRIPTION
This is not to drop OSF 4 support per se,
but the logic looks wrong and I suspect moot.

That is:
 - I don't think OSF has the bad default ELF interposability
   inefficient semantics.
 - It does have something, but I think not as bad.
 - I don't think this syntax is related.
 - Even if it does, so many other people survive with it,
   we probably can do.

And OSF4 vs. 5 was only about controlling that.

I don't remember if I tested on OSF 4 but lately I am using OSF 5.