### PR TITLE
Revert "Bootstrap: Remove the -o and -Fo./ flags as we are"

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1214,9 +1214,9 @@ def Boot():
             "AMD64_NT"      : " -Zi -Gy ", # hack some problem with exception handling and alignment otherwise
             }.get(Config) or " -pthread -g "
 
-        #CCompilerOut = {
-        #    "AMD64_NT"      : "-Fo./",
-        #    }.get(Config) or "-o $@"
+        CCompilerOut = {
+            "AMD64_NT"      : "-Fo./",
+            }.get(Config) or "-o $@"
 
     CCompilerFlags = CCompilerFlags + ({
         "AMD64_LINUX"     : " -m64 ",


### PR DESCRIPTION
This reverts commit 42a53c5514ae5492048496123536b7df584b0762.

This will be built upon shortly.
The only reason was seemingly cosmetic, but now the
opposite has a purpose.