### PR TITLE
scripts: Linking with -oldcxx breaks compiling Main on OSF.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1189,14 +1189,15 @@ def Boot():
         #CCompilerFlags = " -g -mt -xldscope=symbolic "
         CCompiler = "./c_compiler"
         CopyFile("./c_compiler", BootDir)
+        CCompilerOut = " -o $@ "
     elif osf:
         # There is a problem on my install such that linking with cxx fails, unless I use oldcxx.
         # This really should be fixed otherwise.
-        # TODO separate compile from link
         CCompiler = "/usr/bin/cxx" # g++ should also work all work, but change -ieee to -mieee
         CCompilerFlags = " -g -pthread -x cxx -c99 -fprm d "
         #CCompiler = "g++"
         #CCompilerFlags = " -g -pthread -mfp-rounding-mode=d "
+        CCompilerOut = " -o $@ "
     else:
         # gcc and other platforms
         CCompiler = {
@@ -1216,6 +1217,9 @@ def Boot():
 
         CCompilerOut = {
             "AMD64_NT"      : "-Fo./",
+            "I386_NT"       : "-Fo./",
+            "ARM32_NT"      : "-Fo./",
+            "ARM64_NT"      : "-Fo./",
             }.get(Config) or "-o $@"
 
     CCompilerFlags = CCompilerFlags + ({
@@ -1538,7 +1542,7 @@ def Boot():
 
     maino_ext = "o"
     if CBackend:
-        maino_ext = "m3.c"
+        maino_ext = "m3.o"
     elif AssembleOnTarget:
         for pkg in main_packages:
             Makefile.write(pkg + ".d/Main.o: " + pkg + ".d/" + mainS + NL)


### PR DESCRIPTION
It has no long long, or no int64, or something. Probably neither.
Workaround by having .o as dependency.

This depends on -o being restored.
And add the equivalent -Fo to the other NT platforms.
Add -o for OSF and Solaris.

This begs the question of portability to older compilers.

Really we should use autoconf and check sizef(long) == 8.
long long is not really needed on most 64bit targets.

Or maybe we should just require C99/stdint.h and be done
with a lot of cruft. We can still link with -oldcxx.