### PR TITLE
config: OSF: Suppress a few warnings.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
+++ b/m3-sys/cminstall/src/config-no-install/ALPHA_OSF
@@ -46,10 +46,18 @@ SYSTEM_LIBORDER = [ "OPENGL", "DECPEX", "MOTIF", "X11", "TCP", "ODBC",
 
 % -fprm d: floating point rounding mode dynamic
 % -msg_display_tag: display the short strings used to disable warnings
-SYSTEM_CC = "/usr/bin/cxx -x cxx -fprm d -O3 -g3 -c99 -pthread -readonly_strings -ieee_with_no_inexact -error_unresolved -msg_display_tag"
+% fprldonot: IEEE dynamic rounding mode is not supported for long doubles on this platform
+% badansialias1: This statement uses the type to reference a storage location.
+% badansialias2: This statement uses the type to reference the same storage location.
+% codeunreachable: statement is unreachable
+% labelnotreach: code can never be executed at label
+% missingreturn: missing return statement at end of non-void function
+% underflow: underflow occurs in evaluating this expression
+SYSTEM_CC = "/usr/bin/cxx -x cxx -fprm d -O3 -g3 -c99 -pthread -readonly_strings -ieee_with_no_inexact -error_unresolved -msg_display_tag -msg_disable badansialias1,badansialias2,codeunreachable,fprldonot,labelnotreach,missingreturn,underflow"
 % gcc near equivalent: SYSTEM_CC = "g++ -xc++ -mieee -mfp-rounding-mode=d -pthread "
 
 % There is a problem on my install such that linking with cxx fails, unless I use oldcxx.
+% One of the startup .o files is missing.
 % This really should be fixed otherwise.
 LINK_OLDCXX = " -oldcxx "
 


### PR DESCRIPTION
C backend produces these:
 codeunreachable: statement is unreachable
 badansialias1: This statement uses the type to reference a storage location.
 badansialias2: This statement uses the type to reference the same storage location.
 fprldonot: IEEE dynamic rounding mode is not supported for long doubles on this platform
 labelnotreach: code can never be executed at label
 missingreturn: missing return statement at end of non-void function
 underflow: underflow occurs in evaluating this expression

Ideally we would work toward producing code that does not produce
any of these warnings, but it can be a fair amount of work,
for later/never.

Regarding underflow, we should generate IEEE754 bytes, not floats.
Including both endian and runtime selection.

Regarding rounding: We do not even use long doubles.
We get this warning because we are being even kind of advanced
and anticipating putting in the C99 support to change rounding mode,
which probably nobody calls.

missing return is probably in functions with infinite loops.

Augment comment about -oldcxx linking.