### PR TITLE
scripts: More Python3 compatibility.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1000,7 +1000,7 @@ PackageDB = None
 def ReadPackageDB():
     MakePackageDB()
     global PackageDB
-    PackageDB = (PackageDB or map(lambda a: a.replace("\n", "").replace('\\', '/').replace("\r", ""), open(PKGSDB)))
+    PackageDB = PackageDB or list(map(lambda a: a.replace("\n", "").replace('\\', '/').replace("\r", ""), open(PKGSDB)))
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
This makes the code Python2 and Python3 and have the same meaning.
Previously it would run under Python3 but have much
different meaning and fail early.