### PR TITLE
Minor fixes in pylib.py GetObjectName(a, obj)

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -146,7 +146,7 @@ def RemovePathExtension(a):
     return a[:a.rfind(".")]
 
 def _GetObjectName(a, obj):
-    return GetPathBaseName(a) + "." + {"c" : obj, "s" : obj, "ms" : "mo", "is" : "io"}[GetPathExtension(a)]
+    return GetPathBaseName(a) + "." + {"cpp" : obj, "c" : obj, "s" : obj, "ms" : "mo", "is" : "io"}[GetPathExtension(a)]
 
 def GetPathBaseName(a):
     a = GetLastPathElement(a)


### PR DESCRIPTION
Add ".cpp" support to GetObjectName(a, obj) from pylib.py