### PR TITLE
add X11 library config for AMD64_DARWIN

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/AMD64_DARWIN
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_DARWIN
@@ -18,3 +18,5 @@ DarwinArch = "x86_64"
 
 include("AMD64.common")
 include("Darwin.common")
+
+SYSTEM_LIBS{"X11"} = ["-L/opt/X11/lib", "-lXft", "-lfontconfig", "-lXaw", "-lXmu", "-lXext", "-lXt", "-lSM", "-lICE", "-lX11" ]


### PR DESCRIPTION
Defines SYSTEM_LIBS{"X11"} for MacOS/Intel platforms.  This is not
required for basic functionality, but only so that the full build can
generate the UI libraries.