### PR TITLE
patch voronoi library to build on macos

### DIFF
--- a/caltech-other/voronoi/src/geometry.c
+++ b/caltech-other/voronoi/src/geometry.c
@@ -10,7 +10,6 @@ extern "C" {
 void
 geominit(void)
 {
-Edge e;
 float sn;
 
 	nvertices = 0;
@@ -124,8 +123,8 @@ if (e->a == 1.0)
 {	dyp = p->y - topsite->coord.y;
 	dxp = p->x - topsite->coord.x;
 	fast = 0;
-	if ((!right_of_site &e->b<0.0) | (right_of_site&e->b>=0.0) )
-	{	above = dyp>= e->b*dxp;	
+	if ((!right_of_site && e->b<0.0) || (right_of_site && e->b>=0.0) )
+	{	above = dyp>= e->b*dxp;
 		fast = above;
 	}
 	else 

--- a/caltech-other/voronoi/src/heap.c
+++ b/caltech-other/voronoi/src/heap.c
@@ -75,7 +75,7 @@ Halfedge *curr;
 void
 PQinitialize(void)
 {
-int i; Point *s;
+int i;
 
 	PQcount = 0;
 	PQmin = 0;

--- a/caltech-other/voronoi/src/mod3_main.c
+++ b/caltech-other/voronoi/src/mod3_main.c
@@ -102,9 +102,7 @@ ymax = sites[nsites-1].coord.y;
 
 void
 mod3_delaunay(void)
-{	
-int c;
- int i;
+{
 Site *(*next)(void);
 
  assert(setup); 
@@ -127,7 +125,6 @@ clear_triples(void)
   triples=NULL;
 
   while (t!=NULL) {
-    Triple *u=t;
     t=t->next;
   }
 
@@ -151,8 +148,7 @@ int mod3_gettriple(TripleArg *t)
 
 void
 mod3_voronoi(void)
-{	
-int c;
+{
 Site *(*next)(void);
 
  assert(setup); 

--- a/caltech-other/voronoi/src/output.c
+++ b/caltech-other/voronoi/src/output.c
@@ -37,9 +37,9 @@ if(debug)
 void
 out_ep(Edge *e)
 {
-if(!triangulate & plot) 
+if(!triangulate && plot)
 	clip_line(e);
-if(!triangulate & !plot)
+if(!triangulate && !plot)
 {	printf("e %d", e->edgenbr);
 	printf(" %d ", e->ep[le] != NULL ? e->ep[le]->sitenbr : -1);
 	printf("%d\n", e->ep[re] != NULL ? e->ep[re]->sitenbr : -1);
@@ -58,9 +58,9 @@ if(debug)
 void
 out_site(Site *s)
 {
-if(!triangulate & plot & !debug)
+if(!triangulate && plot && !debug)
 	circle (s->coord.x, s->coord.y, cradius);
-if(!triangulate & !plot & !debug)
+if(!triangulate && !plot && !debug)
 	printf("s %f %f\n", s->coord.x, s->coord.y);
 if(debug)
 	printf("site (%d) at %f %f\n", s->sitenbr, s->coord.x, s->coord.y);


### PR DESCRIPTION
Removed unused variables and converted gratuitous bitwise operators to
boolean operators.  #justclangthings

Note that this depends on my other MacOS patches to build correctly.
