### PR TITLE
fix bootstrapping on arm64 linux

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/ARM64_LINUX
+++ b/m3-sys/cminstall/src/config-no-install/ARM64_LINUX
@@ -1,0 +1,10 @@
+readonly TARGET = "ARM64_LINUX" % code generation target
+readonly GNU_PLATFORM = "arm64-linux" % "cpu-os" string for GNU
+
+SYSTEM_CC = "gcc -g -fPIC" % C compiler
+SYSTEM_CXXC = "g++ -g -fPIC" % C++ compiler
+
+readonly SYSTEM_ASM = "as" % Assembler
+
+include("ARM64.common")
+include("Linux.common")

--- a/m3-sys/m3quake/src/MxConfigC.c
+++ b/m3-sys/m3quake/src/MxConfigC.c
@@ -206,6 +206,10 @@ MxConfigC__HOST(void)
         amd64 = TRUE;
         uname_machine = "AMD64";
     }
+    else if (arm64) // aarch64 => arm64
+    {
+        uname_machine = "ARM64";
+    }
     else if (hppa) // hppa/parisc => pa (too short?)
         uname_machine = "PA";
 


### PR DESCRIPTION
Allows the build to (at least) progress further on arm64 linux. fixes #756  (?)