### PR TITLE
e006 Add compiler output to stderr.build and add "dot" and fix orfo and remove two lines in m3-sys\m3tests\src\r0\e006\stdout.build

### DIFF
--- a/m3-sys/m3tests/src/e0/e006/stderr.build
+++ b/m3-sys/m3tests/src/e0/e006/stderr.build
@@ -1,0 +1,1 @@
+m3front failed compiling: ../Main.m3

--- a/m3-sys/m3tests/src/e0/e006/stdout.build
+++ b/m3-sys/m3tests/src/e0/e006/stdout.build
@@ -5,10 +5,8 @@
 "../Main.m3", line 21: undefined (Wr.Failure)
 "../Main.m3", line 21: undefined (Rd.Failure)
 "../Main.m3", line 20: exception(s) don't have a return argument
-"../Main.m3", line 20: variable has no type (reason)
-"../Main.m3", line 20: incompatible types (x)
+"../Main.m3", line 20: Variable has no type. (reason)
 "../Main.m3", line 21: exception(s) don't have a return argument
-"../Main.m3", line 21: variable has no type (reason)
-"../Main.m3", line 21: incompatible types (x)
-12 errors encountered
+"../Main.m3", line 21: Variable has no type. (reason)
+10 errors encountered
 Fatal Error: package build failed


### PR DESCRIPTION
e006 Add compiler output to stderr.build and add "dot" and fix orfo and remove two lines in m3-sys\m3tests\src\r0\e006\stdout.build
 +

Fix this:

--- ../src/e0/e006/stderr.build	2021-10-19 18:48:36.320244691 +0000
+++ ../src/e0/e006/AMD64_LINUX/stderr.build	2021-10-19 19:06:34.151545047 +0000
@@ -0,0 +1 @@
+m3front failed compiling: ../Main.m3
