### PR TITLE
Fix m3gdb documentation for build on MacOs and on I386_MinGW

### DIFF
--- a/m3-sys/m3gdb/gdb/bfd/doc/elf.texi
+++ b/m3-sys/m3gdb/gdb/bfd/doc/elf.texi
@@ -8,7 +8,7 @@ to be written.  The code is changing quickly enough that we
 haven't bothered yet.
 
 @findex bfd_elf_find_section
-@subsubsection @code{bfd_elf_find_section}
+@subsection @code{bfd_elf_find_section}
 @strong{Synopsis}
 @example
 struct elf_internal_shdr *bfd_elf_find_section (bfd *abfd, char *name);


### PR DESCRIPTION
 Fix this:
https://github.com/modula3/cm3/issues/41#issuecomment-435185755
= =
./elf.texi:11: raising the section level of @subsubsection which is too low
make[3]: *** [Makefile:360: ../.././bfd/doc/bfd.info] Error 1
= =
