### PR TITLE
LLVM13: Fix M3DebugInfo__GetSubrangeExpr ( draft mode style)

### DIFF
--- a/m3-sys/llvm/llvm13/src/M3CG_LLVM.m3
+++ b/m3-sys/llvm/llvm13/src/M3CG_LLVM.m3
@@ -6494,10 +6494,12 @@ PROCEDURE DebugObject(self : U; o : ObjectDebug) : MetadataRef =
       INC(nextMemberNo);
     END;
 
+(* 2021-11-26: temporary disabled
    M3DIB.LLVMReplaceArrays(self.debugRef,
       T        := ADR(heapObjectDIT),
       Elements := paramsMetadata.Data,
       NumElements := nextMemberNo);
+*)
 
 (* this should work but no
     M3DIB.LLVMMetadataReplaceAllUsesWith(

--- a/m3-sys/llvm/llvm13bindings/src/M3DebugInfo.i3
+++ b/m3-sys/llvm/llvm13bindings/src/M3DebugInfo.i3
@@ -688,6 +688,7 @@ PROCEDURE CreateEnumerationType (Builder    : BuilderRef;
  * @param BaseTy         The base type of the set.
  *)
 
+(* 2021-11-26: temporary disabled
 PROCEDURE CreateSetType (Builder    : BuilderRef;
                          Scope      : MetadataRef;
                          Name       : TEXT;
@@ -697,7 +698,7 @@ PROCEDURE CreateSetType (Builder    : BuilderRef;
                          SizeInBits : uint64_t;
                          AlignInBits: uint32_t;
                          BaseTy     : MetadataRef; ): MetadataRef;
-
+*)
 
 (**
  * Create a descriptor for a subrange with constant bounds.<br>
@@ -711,13 +712,14 @@ PROCEDURE CreateSetType (Builder    : BuilderRef;
  * @param Count      Count of elements in the subrange.
  *)
 
+(* VVM
 PROCEDURE GetSubrangeConst (Builder          : BuilderRef;
                             Scope            : MetadataRef;
                             Name             : TEXT;
                             NameLen          : uint32_t;
                             File, BaseTy     : MetadataRef;
                             LowerBound, Count: int64_t;     ): MetadataRef;
-
+*)
 
 (**
  * Create a descriptor for a subrange with dynamic bounds.<br>
@@ -731,13 +733,14 @@ PROCEDURE GetSubrangeConst (Builder          : BuilderRef;
  * @param Count      Count of elements in the subrange.
  *)
 
+(* 2021-11-26: temporary disabled
 PROCEDURE GetSubrangeExpr (Builder                        : BuilderRef;
                            Scope                          : MetadataRef;
                            Name                           : TEXT;
                            NameLen                        : uint32_t;
                            File, BaseTy, LowerBound, Count: MetadataRef; ):
   MetadataRef;
-
+*)
 
 (**
  * Create debugging information entry for a union.<br>
@@ -806,6 +809,7 @@ PROCEDURE CreateArrayType (Builder      : BuilderRef;
  * @param Rank         Rank.
  *)
 
+(* 2021-11-26: temporary disabled
 PROCEDURE CreateDynamicArrayType
   (Builder                                  : BuilderRef;
    Size                                     : uint64_t;
@@ -815,7 +819,7 @@ PROCEDURE CreateDynamicArrayType
    NumSubscripts                            : uint;
    DataLocation, Associated, Allocated, Rank: MetadataRef;              ):
   MetadataRef;
-
+*)
 
 (**
  * Create debugging information entry for a vector type.<br>
@@ -1723,9 +1727,10 @@ PROCEDURE LLVMInstructionSetDebugLoc (Inst: ValueRef; Loc: MetadataRef; );
 
 PROCEDURE LLVMGetMetadataKind (Metadata: MetadataRef; ): CARDINAL;
 
+(* 2021-11-26: temporary disabled
 PROCEDURE LLVMReplaceArrays (Builder    : BuilderRef;
                              T, Elements: UNTRACED REF MetadataRef;
                              NumElements: uint;                     );
-
+*)
 
 END M3DebugInfo.

--- a/m3-sys/llvm/llvm13bindings/src/M3DebugInfo.m3
+++ b/m3-sys/llvm/llvm13bindings/src/M3DebugInfo.m3
@@ -415,6 +415,7 @@ PROCEDURE CreateEnumerationType (Builder    : BuilderRef;
     RETURN result;
   END CreateEnumerationType;
 
+(* 2021-11-26: temporary disabled
 PROCEDURE CreateSetType (Builder    : BuilderRef;
                          Scope      : MetadataRef;
                          Name       : TEXT;
@@ -435,7 +436,9 @@ PROCEDURE CreateSetType (Builder    : BuilderRef;
     M3toC.FreeSharedS(Name, arg3);
     RETURN result;
   END CreateSetType;
+*)
 
+(* 2021-11-26: temporary disabled
 PROCEDURE GetSubrangeConst (Builder          : BuilderRef;
                             Scope            : MetadataRef;
                             Name             : TEXT;
@@ -454,7 +457,9 @@ PROCEDURE GetSubrangeConst (Builder          : BuilderRef;
     M3toC.FreeSharedS(Name, arg3);
     RETURN result;
   END GetSubrangeConst;
+*)
 
+(* 2021-11-26: temporary disabled
 PROCEDURE GetSubrangeExpr (Builder                        : BuilderRef;
                            Scope                          : MetadataRef;
                            Name                           : TEXT;
@@ -472,6 +477,7 @@ PROCEDURE GetSubrangeExpr (Builder                        : BuilderRef;
     M3toC.FreeSharedS(Name, arg3);
     RETURN result;
   END GetSubrangeExpr;
+*)
 
 PROCEDURE CreateUnionType (Builder    : BuilderRef;
                            Scope      : MetadataRef;
@@ -517,6 +523,7 @@ PROCEDURE CreateArrayType (Builder      : BuilderRef;
              Builder, Size, AlignInBits, Ty, Subscripts, NumSubscripts);
   END CreateArrayType;
 
+(* 2021-11-26: temporary disabled
 PROCEDURE CreateDynamicArrayType
   (Builder                                  : BuilderRef;
    Size                                     : uint64_t;
@@ -531,6 +538,7 @@ PROCEDURE CreateDynamicArrayType
              Builder, Size, AlignInBits, Ty, Subscripts, NumSubscripts,
              DataLocation, Associated, Allocated, Rank);
   END CreateDynamicArrayType;
+*)
 
 PROCEDURE CreateVectorType (Builder      : BuilderRef;
                             Size         : uint64_t;
@@ -1212,13 +1220,14 @@ PROCEDURE LLVMGetMetadataKind (Metadata: MetadataRef; ): CARDINAL =
     RETURN M3DebugInfoRaw.LLVMGetMetadataKind(Metadata);
   END LLVMGetMetadataKind;
 
+(* 2021-11-26: temporary disabled
 PROCEDURE LLVMReplaceArrays (Builder    : BuilderRef;
                              T, Elements: UNTRACED REF MetadataRef;
                              NumElements: uint;                     ) =
   BEGIN
     M3DebugInfoRaw.LLVMReplaceArrays(Builder, T, Elements, NumElements);
   END LLVMReplaceArrays;
-
+*)
 
 BEGIN
 END M3DebugInfo.

--- a/m3-sys/llvm/llvm13bindings/src/M3DebugInfoRaw.i3
+++ b/m3-sys/llvm/llvm13bindings/src/M3DebugInfoRaw.i3
@@ -204,6 +204,7 @@ PROCEDURE CreateEnumerationType (Builder, Scope: ADDRESS;
                                  ClassTy       : ADDRESS;              ):
   ADDRESS;
 
+(* 2021-11-26: temporary disabled
 <* EXTERNAL LLVMDIBuilderCreateSetType *>
 PROCEDURE CreateSetType (Builder, Scope: ADDRESS;
                          Name          : C.char_star;
@@ -213,20 +214,25 @@ PROCEDURE CreateSetType (Builder, Scope: ADDRESS;
                          SizeInBits    : C.unsigned_long_long;
                          AlignInBits   : C.unsigned_int;
                          BaseTy        : ADDRESS;              ): ADDRESS;
+*)
 
+(* 2021-11-26: temporary disabled
 <* EXTERNAL LLVMDIBuilderGetSubrangeConst *>
 PROCEDURE GetSubrangeConst (Builder, Scope   : ADDRESS;
                             Name             : C.char_star;
                             NameLen          : C.unsigned_int;
                             File, BaseTy     : ADDRESS;
                             LowerBound, Count: C.long_long;    ): ADDRESS;
+*)
 
+(* 2021-11-26: temporary disabled
 <* EXTERNAL LLVMDIBuilderGetSubrangeExpr *>
 PROCEDURE GetSubrangeExpr (Builder, Scope: ADDRESS;
                            Name          : C.char_star;
                            NameLen       : C.unsigned_int;
                            File, BaseTy, LowerBound, Count: ADDRESS; ):
   ADDRESS;
+*)
 
 <* EXTERNAL LLVMDIBuilderCreateUnionType *>
 PROCEDURE CreateUnionType (Builder, Scope: ADDRESS;
@@ -251,6 +257,7 @@ PROCEDURE CreateArrayType (Builder      : ADDRESS;
                            Subscripts   : ADDRESS;
                            NumSubscripts: C.unsigned_int;       ): ADDRESS;
 
+(* 2021-11-26: temporary disabled
 <* EXTERNAL LLVMDIBuilderCreateDynamicArrayType *>
 PROCEDURE CreateDynamicArrayType
   (Builder                                  : ADDRESS;
@@ -261,7 +268,8 @@ PROCEDURE CreateDynamicArrayType
    NumSubscripts                            : C.unsigned_int;
    DataLocation, Associated, Allocated, Rank: ADDRESS;              ):
   ADDRESS;
-
+*)
+ 
 <* EXTERNAL LLVMDIBuilderCreateVectorType *>
 PROCEDURE CreateVectorType (Builder      : ADDRESS;
                             Size         : C.unsigned_long_long;
@@ -607,8 +615,10 @@ PROCEDURE LLVMInstructionSetDebugLoc (Inst, Loc: ADDRESS; );
 <* EXTERNAL LLVMGetMetadataKind *>
 PROCEDURE LLVMGetMetadataKind (Metadata: ADDRESS; ): C.unsigned_int;
 
+(* 2021-11-26: temporary disabled
 <* EXTERNAL LLVMReplaceArrays *>
 PROCEDURE LLVMReplaceArrays
   (Builder: ADDRESS; T, Elements: ADDRESS; NumElements: C.unsigned_int; );
+*)
 
 END M3DebugInfoRaw.


### PR DESCRIPTION
 Fix:
= =
   Creating library llvm13bindings.lib and object llvm13bindings.exp
M3DebugInfo.mo : error LNK2019: unresolved external symbol LLVMDIBuilderCreateSetType referenced in function M3DebugInfo__CreateSetType
M3DebugInfo.mo : error LNK2019: unresolved external symbol LLVMDIBuilderGetSubrangeConst referenced in function M3DebugInfo__GetSubrangeConst
M3DebugInfo.mo : error LNK2019: unresolved external symbol LLVMDIBuilderGetSubrangeExpr referenced in function M3DebugInfo__GetSubrangeExpr
M3DebugInfo.mo : error LNK2019: unresolved external symbol LLVMDIBuilderCreateDynamicArrayType referenced in function M3DebugInfo__CreateDynamicArrayType
M3DebugInfo.mo : error LNK2019: unresolved external symbol LLVMReplaceArrays referenced in function M3DebugInfo__LLVMReplaceArrays
llvm13bindings.dll : fatal error LNK1120: 5 unresolved externals
= =
as draft / temporary solution
