### PR TITLE
p265: fix stderr.build

### DIFF
--- a/m3-sys/m3tests/src/p2/p265/stderr.build
+++ b/m3-sys/m3tests/src/p2/p265/stderr.build
@@ -1,1 +1,0 @@
-m3front failed compiling: ../Main.m3


### PR DESCRIPTION
Fix this:

= = =
--- ../src/p2/p265/stderr.build
+++ ../src/p2/p265/AMD64_LINUX/stderr.build
@@ -1 +0,0 @@
-m3front failed compiling: ../Main.m3
= = =
