### PR TITLE
Vagrant boxes for the BSDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.7z
 *.tar.xz
+.vagrant/
 ALPHA32_VMS/
 ALPHA64_VMS/
 ALPHA_LINUX/

--- a/m3-sys/cminstall/src/config-no-install/AMD64_FREEBSD
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_FREEBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "AMD64_FREEBSD"
 readonly GNU_PLATFORM = "amd64-freebsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -g -m64 -fPIC"
+SYSTEM_CC = "c++ -fPIC"
 readonly SYSTEM_ASM = "as -64"
 
 include("AMD64.common")

--- a/m3-sys/cminstall/src/config-no-install/AMD64_OPENBSD
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_OPENBSD
@@ -1,7 +1,7 @@
 readonly TARGET = "AMD64_OPENBSD"
 readonly GNU_PLATFORM = "amd64-openbsd" % "cpu-os" string for GNU
 
-SYSTEM_CC = "g++ -g -m64 -fPIC"
+SYSTEM_CC = "c++ -fPIC"
 readonly SYSTEM_ASM = "as -64"
 
 include("AMD64.common")

--- a/vagrant/freebsd13/Vagrantfile
+++ b/vagrant/freebsd13/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "freebsd/FreeBSD-13.0-RELEASE"
+  config.vm.box_version = "2021.04.09"
+
+  config.vm.provider("virtualbox") do |vb|
+    vb.gui = false
+    vb.memory = "2048"
+  end
+
+  config.vm.synced_folder("../..", "/vagrant_src")
+
+  config.vm.provision "shell", inline: <<-SHELL
+    pkg install --yes cmake gtar python3 unixODBC wget
+  SHELL
+end

--- a/vagrant/freebsd13/check-release.sh
+++ b/vagrant/freebsd13/check-release.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+VERSION=d5.11.4
+DISTRIBUTION="cm3-dist-AMD64_LINUX-${VERSION}"
+
+mkdir work
+cd work
+wget "https://github.com/modula3/cm3/releases/download/${VERSION}/${DISTRIBUTION}.tar.xz"
+gtar Jxf "${DISTRIBUTION}.tar.xz"
+sed -i -e 's/^SYSTEM_CC.*/SYSTEM_CC = "c++ -fPIC"/' "${DISTRIBUTION}/m3-sys/cminstall/src/config-no-install/AMD64_FREEBSD"
+mkdir build
+cd build
+"../${DISTRIBUTION}/scripts/concierge.py" install --prefix "${HOME}/cm3" --target AMD64_FREEBSD
+PATH="${HOME}/cm3/bin:${PATH}"
+cd "../${DISTRIBUTION}/m3-sys/m3tests"
+cm3 -DHTML
+head -1 m3tests-results.xml

--- a/vagrant/netbsd9.1/Vagrantfile
+++ b/vagrant/netbsd9.1/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "NetBSD/NetBSD-9.1"
+  config.vm.box_version = "1.0.0"
+
+  config.vm.provider("virtualbox")  do |vb|
+    vb.gui = false
+    vb.memory = "2048"
+  end
+
+  config.vm.synced_folder(".", "/vagrant", disabled: true)
+
+  config.vm.provision "shell", inline: <<-SHELL
+    pkgin -y install cmake gtar python38 unixodbc
+  SHELL
+end

--- a/vagrant/netbsd9.1/check-release.sh
+++ b/vagrant/netbsd9.1/check-release.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+VERSION=d5.11.4
+DISTRIBUTION="cm3-dist-AMD64_LINUX-${VERSION}"
+
+sudo ln -s /usr/pkg/bin/python3.8 /usr/pkg/bin/python3
+
+mkdir work
+cd work
+wget --no-check-certificate "https://github.com/modula3/cm3/releases/download/${VERSION}/${DISTRIBUTION}.tar.xz"
+gtar Jxf "${DISTRIBUTION}.tar.xz"
+mkdir build
+cd build
+"../${DISTRIBUTION}/scripts/concierge.py" install --prefix "${HOME}/cm3" --target AMD64_NETBSD
+PATH="${HOME}/cm3/bin:${PATH}"
+cd "../${DISTRIBUTION}/m3-sys/m3tests"
+cm3 -DHTML
+head -1 m3tests-results.xml

--- a/vagrant/openbsd7/Vagrantfile
+++ b/vagrant/openbsd7/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/openbsd7"
+
+  config.vm.provider("virtualbox") do |vb|
+    vb.gui = false
+    vb.memory = "2048"
+  end
+
+  config.vm.synced_folder(".", "/vagrant", disabled: true)
+
+  config.vm.provision "shell", inline: <<-SHELL
+    pkg_add cmake gtar-1.34 python3
+  SHELL
+end

--- a/vagrant/openbsd7/check-release.sh
+++ b/vagrant/openbsd7/check-release.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+VERSION=d5.11.4
+DISTRIBUTION="cm3-dist-AMD64_LINUX-${VERSION}"
+
+mkdir work
+cd work
+wget "https://github.com/modula3/cm3/releases/download/${VERSION}/${DISTRIBUTION}.tar.xz"
+gtar Jxf "${DISTRIBUTION}.tar.xz"
+sed -i -e 's/^SYSTEM_CC.*/SYSTEM_CC = "c++ -fPIC"/' "${DISTRIBUTION}/m3-sys/cminstall/src/config-no-install/AMD64_OPENBSD"
+mkdir build
+cd build
+"../${DISTRIBUTION}/scripts/concierge.py" install --prefix "${HOME}/cm3" --target AMD64_OPENBSD
+PATH="${HOME}/cm3/bin:${PATH}"
+cd "../${DISTRIBUTION}/m3-sys/m3tests"
+cm3 -DHTML
+head -1 m3tests-results.xml


### PR DESCRIPTION
These commits together build and test cm3 on FreeBSD and NetBSD, attempting to compensate for the lack of BSD CI/CD.