### PR TITLE
scripts: Remove various Cygwin special cases.

### DIFF
--- a/scripts/python/make-dist.py
+++ b/scripts/python/make-dist.py
@@ -266,7 +266,7 @@ def Setup(ExistingCompilerRoot, NewRoot):
 
     CopyConfigForDistribution(NewRoot) or sys.exit(1)
 
-    os.environ["CM3_INSTALL"] = ConvertToCygwinPath(NewRoot)
+    os.environ["CM3_INSTALL"] = NewRoot
 
 Setup(InstallRoot, InstallRoot_CompilerWithPrevious)
 RealClean(Packages) or FatalError()


### PR DESCRIPTION
The scripts had the notion that cm3 might
be Cygwin or not, and Python might be Cygwin or not,
and convert paths to the form expected by the reciever,
supporting all combinations through a general approach.
Possibly even catering to gcc, wix, and other tools.

The new approach is:
 - cm3 and python should be the same "type"
   Maybe not everything works, like building MSIs for
   or in Cygwin environment.
 - Cygwin is not very interesting.
 - If there are problems we can restore this code or try something else
 - No one minor variant of a minor project is likely worth that much code.
   Likely nobody has used this except me, and that was over 10 years
   ago.

Some nearby Interix removal.
Possibly breaking the invocation of link.exe by cm3 from Cygwin environment. (Cygwin has a completely unrelated link.exe that if it comes ahead of Visual C++ link.exe in %path% causes problems.).
Cm3 should possibly avoid running link.exe directly and rely on cl.exe as the linker driver, todo.