### PR TITLE
add bibliography link to SPwM3 on the internet archive

### DIFF
--- a/docs/help/bib.html
+++ b/docs/help/bib.html
@@ -844,6 +844,8 @@ This book is the definitive language reference. It includes the
 language reference manual and papers on the I/O library,
 threads, and the Trestle window system. It is also known as "SPwM3".
 <P>
+<A HREF="https://archive.org/details/systems-programming-with-modula-3">on the internet archive</A>
+<P>
 Here is its table of contents:
 <P>
 <OL>


### PR DESCRIPTION
I figure linking to archive.org is safe, since they tend to be pretty aware of copyright issues.