### PR TITLE
Scripts: Start of autotools bootstrap.

### DIFF
--- a/scripts/python/ax_pthread.m4
+++ b/scripts/python/ax_pthread.m4
@@ -1,0 +1,522 @@
+# ===========================================================================
+#        https://www.gnu.org/software/autoconf-archive/ax_pthread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
+#
+# DESCRIPTION
+#
+#   This macro figures out how to build C programs using POSIX threads. It
+#   sets the PTHREAD_LIBS output variable to the threads library and linker
+#   flags, and the PTHREAD_CFLAGS output variable to any special C compiler
+#   flags that are needed. (The user can also force certain compiler
+#   flags/libs to be tested by setting these environment variables.)
+#
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
+#
+#   NOTE: You are assumed to not only compile your program with these flags,
+#   but also to link with them as well. For example, you might link with
+#   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#
+#   If you are only building threaded programs, you may wish to use these
+#   variables in your default LIBS, CFLAGS, and CC:
+#
+#     LIBS="$PTHREAD_LIBS $LIBS"
+#     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
+#     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
+#
+#   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
+#   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
+#   that name (e.g. PTHREAD_CREATE_UNDETACHED on AIX).
+#
+#   Also HAVE_PTHREAD_PRIO_INHERIT is defined if pthread is found and the
+#   PTHREAD_PRIO_INHERIT symbol is defined when compiling with
+#   PTHREAD_CFLAGS.
+#
+#   ACTION-IF-FOUND is a list of shell commands to run if a threads library
+#   is found, and ACTION-IF-NOT-FOUND is a list of commands to run it if it
+#   is not found. If ACTION-IF-FOUND is not specified, the default action
+#   will define HAVE_PTHREAD.
+#
+#   Please let the authors know if this macro fails on any platform, or if
+#   you have any other suggestions or comments. This macro was based on work
+#   by SGJ on autoconf scripts for FFTW (http://www.fftw.org/) (with help
+#   from M. Frigo), as well as ac_pthread and hb_pthread macros posted by
+#   Alejandro Forero Cuervo to the autoconf macro repository. We are also
+#   grateful for the helpful feedback of numerous users.
+#
+#   Updated for Autoconf 2.68 by Daniel Richard G.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   Copyright (c) 2019 Marc Stevens <marc.stevens@cwi.nl>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 31
+
+AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
+AC_DEFUN([AX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_REQUIRE([AC_PROG_CC])
+AC_REQUIRE([AC_PROG_SED])
+AC_LANG_PUSH([C])
+ax_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on Tru64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
+        ax_pthread_save_CC="$CC"
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test "x$ax_pthread_ok" = "xno"; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        CC="$ax_pthread_save_CC"
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try. Items with a "," contain both
+# C compiler flags (before ",") and linker flags (after ","). Other items
+# starting with a "-" are C compiler flags, and remaining items are
+# library names, except for "none" which indicates that we try without
+# any flags at all, and "pthread-config" which is a program returning
+# the flags for the Pth emulation library.
+
+ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads), Tru64
+#           (Note: HP C rejects this with "bad form for `-t' option")
+# -pthreads: Solaris/gcc (Note: HP C also rejects)
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads and
+#      -D_REENTRANT too), HP C (must be checked before -lpthread, which
+#      is present but should not be used directly; and before -mthreads,
+#      because the compiler interprets this as "-mt" + "-hreads")
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case $host_os in
+
+        freebsd*)
+
+        # -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+        # lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+
+        ax_pthread_flags="-kthread lthread $ax_pthread_flags"
+        ;;
+
+        hpux*)
+
+        # From the cc(1) man page: "[-mt] Sets various -D flags to enable
+        # multi-threading and also sets -lpthread."
+
+        ax_pthread_flags="-mt -pthread pthread $ax_pthread_flags"
+        ;;
+
+        openedition*)
+
+        # IBM z/OS requires a feature-test macro to be defined in order to
+        # enable POSIX threads at all, so give the user a hint if this is
+        # not set. (We don't define these ourselves, as they can affect
+        # other portions of the system API in unpredictable ways.)
+
+        AC_EGREP_CPP([AX_PTHREAD_ZOS_MISSING],
+            [
+#            if !defined(_OPEN_THREADS) && !defined(_UNIX03_THREADS)
+             AX_PTHREAD_ZOS_MISSING
+#            endif
+            ],
+            [AC_MSG_WARN([IBM z/OS requires -D_OPEN_THREADS or -D_UNIX03_THREADS to enable pthreads support.])])
+        ;;
+
+        solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed. (N.B.: The stubs are missing
+        # pthread_cleanup_push, or rather a function called by this macro,
+        # so we could check for that, but who knows whether they'll stub
+        # that too in a future libc.)  So we'll check first for the
+        # standard Solaris way of linking pthreads (-mt -lpthread).
+
+        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
+        ;;
+esac
+
+# Are we compiling with Clang?
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [ax_cv_PTHREAD_CLANG],
+    [ax_cv_PTHREAD_CLANG=no
+     # Note that Autoconf sets GCC=yes for Clang as well as GCC
+     if test "x$GCC" = "xyes"; then
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
+     fi
+    ])
+ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
+
+
+# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
+
+# Note that for GCC and Clang -pthread generally implies -lpthread,
+# except when -nostdlib is passed.
+# This is problematic using libtool to build C++ shared libraries with pthread:
+# [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25460
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=661333
+# [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
+# To solve this, first try -pthread together with -lpthread for GCC
+
+AS_IF([test "x$GCC" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
+
+# Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
+
+AS_IF([test "x$ax_pthread_clang" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread"])
+
+
+# The presence of a feature test macro requesting re-entrant function
+# definitions is, on some systems, a strong hint that pthreads support is
+# correctly enabled
+
+case $host_os in
+        darwin* | hpux* | linux* | osf* | solaris*)
+        ax_pthread_check_macro="_REENTRANT"
+        ;;
+
+        aix*)
+        ax_pthread_check_macro="_THREAD_SAFE"
+        ;;
+
+        *)
+        ax_pthread_check_macro="--"
+        ;;
+esac
+AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+      [ax_pthread_check_cond=0],
+      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
+
+
+if test "x$ax_pthread_ok" = "xno"; then
+for ax_pthread_try_flag in $ax_pthread_flags; do
+
+        case $ax_pthread_try_flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                *,*)
+                PTHREAD_CFLAGS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\1/"`
+                PTHREAD_LIBS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\2/"`
+                AC_MSG_CHECKING([whether pthreads work with "$PTHREAD_CFLAGS" and "$PTHREAD_LIBS"])
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $ax_pthread_try_flag])
+                PTHREAD_CFLAGS="$ax_pthread_try_flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
+                AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$ax_pthread_try_flag])
+                PTHREAD_LIBS="-l$ax_pthread_try_flag"
+                ;;
+        esac
+
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+#                       if $ax_pthread_check_cond
+#                        error "$ax_pthread_check_macro must be defined"
+#                       endif
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+            [ax_pthread_ok=yes],
+            [])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        AC_MSG_RESULT([$ax_pthread_ok])
+        AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+
+
+# Various other checks:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_CACHE_CHECK([for joinable pthread attribute],
+            [ax_cv_PTHREAD_JOINABLE_ATTR],
+            [ax_cv_PTHREAD_JOINABLE_ATTR=unknown
+             for ax_pthread_attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+                 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                                                 [int attr = $ax_pthread_attr; return attr /* ; */])],
+                                [ax_cv_PTHREAD_JOINABLE_ATTR=$ax_pthread_attr; break],
+                                [])
+             done
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
+               test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
+               test "x$ax_pthread_joinable_attr_defined" != "xyes"],
+              [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
+                                  [$ax_cv_PTHREAD_JOINABLE_ATTR],
+                                  [Define to necessary symbol if this constant
+                                   uses a non-standard name on your system.])
+               ax_pthread_joinable_attr_defined=yes
+              ])
+
+        AC_CACHE_CHECK([whether more special flags are required for pthreads],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS=no
+             case $host_os in
+             solaris*)
+             ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
+             ;;
+             esac
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
+               test "x$ax_pthread_special_flags_added" != "xyes"],
+              [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
+               ax_pthread_special_flags_added=yes])
+
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            [ax_cv_PTHREAD_PRIO_INHERIT],
+            [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
+                                             [[int i = PTHREAD_PRIO_INHERIT;
+                                               return i;]])],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
+               test "x$ax_pthread_prio_inherit_defined" != "xyes"],
+              [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
+               ax_pthread_prio_inherit_defined=yes
+              ])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        # More AIX lossage: compile with *_r variant
+        if test "x$GCC" != "xyes"; then
+            case $host_os in
+                aix*)
+                AS_CASE(["x/$CC"],
+                    [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
+                    [#handle absolute path differently from PATH based program lookup
+                     AS_CASE(["x$CC"],
+                         [x/*],
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
+                ;;
+            esac
+        fi
+fi
+
+test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
+
+AC_SUBST([PTHREAD_LIBS])
+AC_SUBST([PTHREAD_CFLAGS])
+AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
+        :
+else
+        ax_pthread_ok=no
+        $2
+fi
+AC_LANG_POP
+])dnl AX_PTHREAD

--- a/scripts/python/boot1autotools.py
+++ b/scripts/python/boot1autotools.py
@@ -1,0 +1,209 @@
+#! /usr/bin/env python
+
+import sys
+import os.path
+import pylib
+from pylib import *
+
+# usage: ./boot1autotools.py target
+#
+# tar xf xx.tgz
+# chmod +x xx/*
+# mkdir build
+# cd build
+# ../xx/configure
+# make
+# mkdir -p $HOME/cm3/bin
+# mv cm3 $HOME/cm3/bin
+# PATH=$HOME/cm3/bin/bin:$PATH
+# cd ..
+# ../boot2.py
+#
+# Target need not be precise, only word size and endian matter.
+# In future hopefully they will not.
+#
+CopyConfigForDevelopment() or sys.exit(1)
+
+def BootAutoTools():
+
+    pylib.BuildLocal += " -boot -no-m3ship-resolution -group-writable -keep -DM3_BACKEND_MODE=C"
+
+    Version = CM3VERSION + "-" + time.strftime("%Y%m%d")
+    BootDir = "./cm3-boot-" + BuildDir + "-" + Version
+
+    #RemoveDirectoryRecursive(BootDir)
+    CreateDirectory(BootDir)
+
+    P = FilterPackages(["m3core", "libm3", "sysutils", "set", "m3middle", "m3quake", "m3objfile", "m3linker", "m3back", "m3front"])
+    main_packages = ["cm3"]
+
+    P += main_packages
+
+    #DoPackage(["", "realclean"] + P) or sys.exit(1)
+    DoPackage(["", "buildlocal"] + P) or sys.exit(1)
+
+    Am = open(os.path.join(BootDir, "Makefile.am"), "wb")
+    Ac = open(os.path.join(BootDir, "configure.ac"), "wb")
+
+    # TODO: Make one bootstrap for 32bits and 64bits.
+
+    if Config.find("32") != -1:
+        hpux_gcc_wordsize = "-milp32"
+        hpux_cc_bits = "+DD32"
+        solaris86_arch = "pentium_pro"
+    else:
+        hpux_gcc_wordsize = "-mlp64"
+        hpux_cc_bits = "+DD64"
+        solaris86_arch = "amd64"
+
+    Ac.write("""
+AC_INIT(cm3,1.0)
+AC_CANONICAL_HOST
+AM_INIT_AUTOMAKE([-Wportability -Wall -Werror foreign])
+AC_PROG_CXX
+AX_PTHREAD
+LIBS="$PTHREAD_LIBS $LIBS"
+CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
+CC="$PTHREAD_CXX"
+CXX="$PTHREAD_CXX"
+
+# Carry forward historical CFLAGS, but this is probably entirely over-specified.
+case "$host" in
+    x86_64*darwin*) CXXFLAGS="$CXXFLAGS -arch x86_64";;
+    i?86*darwin*) CXXFLAGS="$CXXFLAGS -arch i386";;
+    powerpc64*darwin*) CXXFLAGS="$CXXFLAGS -arch ppc64";;
+    powerpc*darwin*) CXXFLAGS="$CXXFLAGS -arch ppc";;
+    mips64*) CXXFLAGS="$CXXFLAGS -mabi=64";;
+    i?86-*-solaris2*) CXXFLAGS="$CXXFLAGS -xarch=""" + solaris86_arch + """ -Kpic";;
+    sparc64*solaris2* | sparcv9*solaris2*) CXXFLAGS="$CXXFLAGS -xarch=v9 -xcode=pic32 -xregs=no%appl";;
+    sparc*solaris2*) CXXFLAGS="$CXXFLAGS -xarch=v8plus -xcode=pic32 -xregs=no%appl";;
+    sparc64* | sparcv9*) CXXFLAGS="$CXXFLAGS -m64 -mno-app-regs";;
+    sparc*) CXXFLAGS="$CXXFLAGS -m32 -mcpu=v9 -mno-app-regs";;
+    x86_64-* | amd64-*) CXXFLAGS="$CXXFLAGS -m64";;
+    i?86-*) CXXFLAGS="$CXXFLAGS -m32";;
+    aarch64*darwin*_ilp32) CXXFLAGS="$CXXFLAGS -m32";;
+    aarch64*darwin* | arm64*darwin*) CXXFLAGS="$CXXFLAGS -m64";;
+    # Old unfinished 32bit iPhone support
+    arm*-darwin*) CXXFLAGS="$CXXFLAGS -march=armv6 -mcpu=arm1176jzf-s";;
+esac
+
+# Specify likely required compiler/linker flags where defaults
+# do not likely suffice or really are not great (e.g. HPUX null deref, Alpha arounding mode).
+case "$host" in
+    *-*-osf*)
+        # Set rounding mode.
+        # TODO loop over the choices and chose which works.
+        if test "$GXX" = yes; then
+            CXXFLAGS="$CXXFLAGS -mfp-rounding-mode=d -pthread -mieee"
+        else
+            CXXFLAGS="$CXXFLAGS -fprm d -pthread -readonly_strings -ieee_with_no_inexact"
+        fi
+        ;;
+    # Must be gcc or compatible. TODO: probe
+    alpha*) CXXFLAGS="$CXXFLAGS -mfp-rounding-mode=d";;
+esac
+case "$host" in
+    *-*-darwin*);;
+    # TODO Higher level syntax for libraries?
+    *-*-linux* | *-*-*bsd* | *-*-cygwin*) CXXFLAGS="$CXXFLAGS -lm -pthread";;
+    *-*-mingw*) CXXFLAGS="$CXXFLAGS -liphlpapi -lrpcrt4 -lcomctl32 -lws2_32 -lgdi32 -luser32 -ladvapi32";;
+    *-*-solaris*) CXXFLAGS="$CXXFLAGS -lpthread -lrt -lm -lnsl -lsocket -lc -pthread";;
+    *-*-osf*)
+        CXXFLAGS="$CXXFLAGS -lrt -lm -pthread"
+
+        # There is a problem on some installs such that linking with cxx fails, unless oldcxx is used.
+        # One of the startup .o files is missing.
+        # This really should be fixed otherwise.
+        # Compiling with oldcxx fails, because it does not
+        # define _LONGLONG and then INT64_ appends i64 or ui64 and that fails.
+        # Fix the installs. Autoconf to detect problem.
+        # and only workaround if needed (and remove gcc check).
+        if test "$GXX" != yes; then
+            LDFLAGS="$LDFLAGS -oldcxx"
+            CXXFLAGS="$CXXFLAGS -x cxx" # when applied to .c files
+        fi
+        ;;
+    *-*-hpux*)
+        # -ldcekt is for uuid_create in MachineIDPosixC.c
+        # -pthread is not allowed
+        # -z so null derefence fails (vs. returns zero).
+        CXXFLAGS="$CXXFLAGS -mt -z -lrt -lm -lpthread -ldcekt"
+
+        # TODO: Make one bootstrap for 32bits and 64bits.
+
+        if test "$GCC" = yes; then
+            CXXFLAGS="$CXXFLAGS """ + hpux_gcc_wordsize + """ "
+        else
+            CXXFLAGS="$CXXFLAGS """ + hpux_cc_bits + """ "
+        fi
+        ;;
+    *)  CXXFLAGS="$CXXFLAGS -lm";;
+esac
+case "$host" in
+    ia64-*-hpux*) # -luca is for getting IP from context in RTSignalC.c
+                  CXXFLAGS="$CXXFLAGS -luca";;
+esac
+
+CFLAGS="$CFLAGS $CXXFLAGS"
+
+# Compile as C++.
+# This is not very important now that C++ backend outputs .cpp files,
+# but it does affect m3core, etc.
+if test "$GCC" = yes; then
+    CFLAGS="$CFLAGS -x c++"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+""")
+
+# For now we just build cm3 all at once and provide no install.
+# In future we will build each library, selectively shared,
+# and install, and cm3 will output such files,
+# via a new generic target named autotools.
+
+    Am.write("noinst_PROGRAMS = cm3\n")
+    Am.write("cm3_SOURCES = ")
+ 
+    for q in P:
+        dir = GetPackagePath(q)
+        for a in os.listdir(os.path.join(Root, dir, BuildDir)):
+            ext = GetPathExtension(a)
+            ext_c = (ext == "c")
+            ext_cpp = (ext == "cpp")
+            ext_h = (ext == "h")
+            if not (ext_c or ext_cpp or ext_h):
+                continue
+            b = 0
+            if False: # subdirs
+                b = os.path.join(BootDir, q)
+                CreateDirectory(b)
+                Am.write(" \\\n " + q + "/" + a)
+            else:
+                b = BootDir
+                Am.write(" \\\n " + a)
+            CopyFile(os.path.join(Root, dir, BuildDir, a), b) # TODO async
+
+    Am.close()
+    Ac.close()
+    CopyFile("./ax_pthread.m4", BootDir)
+
+    os.chdir(BootDir)
+    #?? a = "autoreconf -i " + BootDir
+    #  Does not let AX_PTHREAD work. What is the right way?
+    for a in [
+            "aclocal -I .",
+            "autoconf -f",
+            "automake --add-missing --copy --foreign",
+            "rm -rf autom4te.cache",
+            "chmod +x *"]:
+        print(a)
+        os.system(a)
+        a = "wsl " + a
+        print(a)
+        os.system(a)
+    os.chdir("..")
+
+    pylib._MakeTGZ(BootDir[2:])
+
+BootAutoTools();

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1122,8 +1122,10 @@ def Boot():
         CCompiler = "./c_compiler"
         CopyFile("./c_compiler", BootDir)
     elif osf:
-        # There is a problem on my install such that linking with cxx fails, unless I use oldcxx.
-        # This really should be fixed otherwise.
+        # There is a problem on some installs such that linking with cxx fails, unless oldcxx is used.
+        # This really should be fixed otherwise. Compiling with oldcxx fails due to
+        # integer constants from INT64_ with trailing i64 or ui64.
+        # Not-oldcxx defines _LONGLONG to skip that.
         CCompiler = "/usr/bin/cxx" # g++ should also work all work, but change -ieee to -mieee
         CCompilerFlags = " -g -pthread -x cxx -c99 -fprm d "
         #CCompiler = "g++"
@@ -1190,6 +1192,7 @@ def Boot():
     # http://www.gnu.org/software/autoconf-archive/ax_pthread.html#ax_pthread
 
     # TODO: All this logic should be in the Makefile so we can make one distribution.
+    # See BootAutoTools.
 
     if darwin:
         pass
@@ -1203,8 +1206,10 @@ def Boot():
         # -pthread is not allowed
         Link = Link + " -lrt -lm -lpthread -ldcekt -luca "
     elif osf:
-        # There is a problem on my install such that linking with cxx fails, unless I use oldcxx.
+        # There is a problem on some installs such that linking with cxx fails, unless oldcxx is used.
         # This really should be fixed otherwise.
+        # Compiling with oldcxx fails, because it does not
+        # define _LONGLONG and then INT64_ appends i64 or ui64 and that fails.
         Link = Link + " -lrt -lm -pthread -oldcxx "
     elif interix:
         Link = Link + " -lm -pthread "


### PR DESCRIPTION
This adds boot1autotools.py.

Presently this just builds cm3, static.
No libs. No install. Not the entire system.
Same as prior boot1.py.
Presently you have to ensure endian and word size match, like the cmake
bootstrap.
In time we should be able to improve all those factors.
In this initial version, cflags are over specified, at configure-time,
like the prior boot1.py does at bootstrap construction time.
Note that for bootstrap construction it makes more sense, as it can
match word size to bootstrap (i.e. on multiarch systems like x86/amd64,
sparc32/spar64, darwin).

Also in time the configure.ac here should be a separate file,
output by cm3 for each package. Similarly in time we should use libtool.

There is nothing really blocking progress here, but the initial version
just mimics what we had before, but replacing a manually written
Makefile with configure.ac + Makefile.am.

While a manually written Makefile can go further, and in some ways
do better, the value of autoconf/automake does add up. For example,
the manual Makefile did not support out of tree builds, and again,
this approach can easily extend to dirs, libs, shared, install, etc.
One mystery remains pkgs and m3x but these can probably come along
as "data".

A manual Makefile will likely go forward, for NT bootstrap only.
(It is too bad that running automake does not also produce that,
with limited functionality at least.)

The primary advantage over the cmake bootstrap is that this easily
runs on unusual targets like HP-UX and OSF/1, where cmake is difficult
to acquire, at least current cmake. (OSF/1 being very old
and out of support and only runs on slow Alpha hardware, HP-UX being
probably on the way out but lasted much longer and runs on much
faster IA64 hardware (and older PA-RISC)).

This approach definitely is not as good as the new cmake approach,
in that it just produces the static cm3 and stops there.

This approach does not presently build mklib, but that does not matter
as mklib is NT-only, and should go away at that.

This approach also is lacking on NT entirely..though is probably
good in a mingwin/msys environment.