### PR TITLE
m3core: Remove most checks of stack growth direction.

### DIFF
--- a/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.c
+++ b/m3-libs/m3core/src/coroutine/UCONTEXT/ContextC.c
@@ -414,7 +414,7 @@ void
 ContextC__InitC(int* stack)
 {
   int r = { 0 };
-  stack_grows_downward = (stack > &r);
+  stack_grows_downward = (stack > (int*)alloca(sizeof(int)));
 #if defined(__APPLE__)   || \
     defined(__FreeBSD__) || \
     defined(__INTERIX)   || \

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadApple.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadApple.c
@@ -144,9 +144,6 @@ ThreadPThread__ProcessStopped (m3_pthread_t mt, ADDRESS bottom, ADDRESS context,
 #endif
   sp -= M3_STACK_ADJUST;
   /* process the stack */
-#if 0
-  assert(stack_grows_down); /* See ThreadPThreadC.c */
-#endif
   assert(context == 0);
   p(sp, bottom);
   /* process the registers */

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadFreeBSD.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadFreeBSD.c
@@ -68,9 +68,6 @@ ThreadPThread__ProcessStopped (m3_pthread_t mt, char *bottom, char *context,
   ThreadFreeBSD__Fatal(pthread_attr_get_np(PTHREAD_FROM_M3(mt), &attr), "pthread_attr_get_np");
   ThreadFreeBSD__Fatal(pthread_attr_getstack(&attr, (void **)&stackaddr, &stacksize), "pthread_attr_getstack");
   ThreadFreeBSD__Fatal(pthread_attr_destroy(&attr), "pthread_attr_destroy");
-#if 0
-  assert(stack_grows_down); /* See ThreadPThreadC.c */
-#endif
   assert(context == 0);
   assert(bottom >= stackaddr);
   assert(bottom <= (stackaddr + stacksize));


### PR DESCRIPTION
It is about as well to just check the direction of the given range.

Restore checking of register context, especially on grow-up stack.

Use alloca for stack pointer instead of address of local, to
better tolerate inlining. Platforms for which alloca is heap
instead of stack will "silently" not work -- they will likely
be very slow and/or free live data.

Put jmpbuf consistently in struct.

Gradually use unwrapped standard memset(0) idiom.