### PR TITLE
m3core: Remove residue of stack direction detection.

### DIFF
--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
@@ -30,7 +30,7 @@ VAR SIG_SUSPEND: const_int;
 (*---------------------------------------------------------------------------*)
 
 <*EXTERNAL "ThreadPThread__InitC"*>
-PROCEDURE InitC(top: ADDRESS);
+PROCEDURE InitC();
 
 (*---------------------------------------------------------------------------*)
 

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.m3
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.m3
@@ -1488,7 +1488,7 @@ PROCEDURE InitWithStackBase (stackbase: ADDRESS) =
     self: T;
     me: Activation;
   BEGIN
-    InitC(stackbase);
+    InitC();
 
     me := NEW(Activation,
               mutex := pthread_mutex_new(),

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -529,11 +529,9 @@ ThreadPThread__pthread_mutex_unlock(pthread_mutex_t* mutex)
   return a;
 }
 
-// Do not inline to help ensure stack range is understandable.
-M3_NO_INLINE
 void
 __cdecl
-InitC(ADDRESS top)
+InitC(void)
 {
   int r = { 0 };
 


### PR DESCRIPTION
InitC does not use its parameter.