### PR TITLE
HP-UX: Fix more socklen_t to m3c_socklen_t.

### DIFF
--- a/m3-comm/tcp/src/common/IP_c.c
+++ b/m3-comm/tcp/src/common/IP_c.c
@@ -225,7 +225,7 @@ IPInternal__GetNameInfo(int family, int port, const void* addr, TEXT* hostText, 
     char host[NI_MAXHOST];
     char service[NI_MAXSERV];
     SockAddrUnionAll sa = {0};
-    socklen_t size = sizeof(sa.sa4);
+    m3c_socklen_t size = sizeof(sa.sa4);
     int err = {0};
 
     M3_STATIC_ASSERT(sizeof(in_addr) == 4);
@@ -306,7 +306,7 @@ IPInternal__getsockname_in(INTEGER fd, char* address, INTEGER* port)
 {
     INTEGER err;
     struct sockaddr_in sa;
-    socklen_t size = sizeof(sa);
+    m3c_socklen_t size = sizeof(sa);
 
     ZERO_MEMORY(sa);
     err = getsockname(fd, (struct sockaddr*)&sa, &size);

--- a/m3-comm/udp/src/Common/UDP_c.c
+++ b/m3-comm/udp/src/Common/UDP_c.c
@@ -67,7 +67,7 @@ UDPInternal__Receive(
 // addr is array of char so we cannot assume alignment.
 {
     sockaddr_in sa = {0};
-    socklen_t addr_len = sizeof(sa);
+    m3c_socklen_t addr_len = sizeof(sa);
 
     ZERO_MEMORY(sa);
 


### PR DESCRIPTION
HP-UX defines socklen_t to size_t always, but then
uses socklen_t or int depending on defines.