### PR TITLE
m3c: Use class and C-style casts.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2479,8 +2479,12 @@ CONST Prefix = ARRAY OF TEXT {
 "#define m3_xor(T, x, y) (((T)(x)) ^ ((T)(y)))",
 
 (* Helper needed by `loophole` because m3front does not guarantee that
-`u` will be an rvalue. *)
-"template<typename T, typename U> inline T m3_loophole(U u) { return *reinterpret_cast<T*>(&u); }",
+ * `u` will be an rvalue.
+ * Class vs. typename, C-style cast vs. reinterpret_cast to cater
+ * to older compilers. (The main value of targeting C++ instead of C
+ * is portable optimized exception handling.)
+ *)
+"template<class T, class U> inline T m3_loophole(U u) { return *(T*)&u; }",
 
 "#ifdef _MSC_VER",
 "#define _CRT_SECURE_NO_DEPRECATE 1",


### PR DESCRIPTION
Instead of typename and reinterpret_cast.
It seems both of these are needed for older OSF compiler
and that is ok. The template should maybe be removed (see AllocateTemps).
C++ is most desirable, by far, for portable optimized exception handling.
It *might* be desirable for other niceties like { }, C99
locals at not-top of scope before 99, math/fenv, bool, inline, etc.