### PR TITLE
m3c: Disable warning 4146 unary minus is still unsigned.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2494,6 +2494,7 @@ CONST Prefix = ARRAY OF TEXT {
 "#pragma warning(disable:4100) /* unused parameter */",
 "#pragma warning(disable:4115) /* named type definition in parentheses */",
 "#pragma warning(disable:4127) /* conditional expression is constant */",
+"#pragma warning(disable:4146) /* unary minus operator applied to unsigned type, result still unsigned */",
 "#pragma warning(disable:4201) /* nonstandard extension: nameless struct/union */",
 "#pragma warning(disable:4214) /* nonstandard extension: bitfield other than int */",
 "#pragma warning(disable:4209) /* nonstandard extension: benign re-typedef */",


### PR DESCRIPTION
D:\a\cm3\bootstrap\m3back\M3x86.m3.cpp(6884,1): warning C4146: unary
minus operator applied to unsigned type, result still unsigned