### PR TITLE
m3front: Change RecordTypes stack type from Addr to Struct.

### DIFF
--- a/m3-sys/m3front/src/types/RecordType.m3
+++ b/m3-sys/m3front/src/types/RecordType.m3
@@ -169,7 +169,7 @@ PROCEDURE Check (p: P) =
     p.info.min_size  := min_size;
     p.info.alignment := p.align;
     p.info.mem_type  := CG.Type.Struct;
-    p.info.stk_type  := CG.Type.Addr;
+    p.info.stk_type  := CG.Type.Struct;
     p.info.class     := Type.Class.Record;
   END Check;
 


### PR DESCRIPTION
This addresses this problem:
C:\s\cm3\scripts\python\src\hash\MD5.m3(277) : warning C4739: reference
to variable 'MD5_m_212_L_213' exceeds its storage space

    len64 := LOOPHOLE(VAL(ctrl.length + ctrl.bufLen,LONGINT) *
    8L,Int64On32);

m3front was creating a temporary here of type Addr and size 8.
If we ignore the size and take the type, we overflow the variable
on 32bit systems.

On the premise that you can loophole to arbitrarily sized record values,
this problem extends to arbitary overflow on all targets.

By changing the type to Struct, we then pay attention to the size
and make a temporary of any specified size.