### PR TITLE
tests: Fix p211 to compile, warning/error unused value.

### DIFF
--- a/m3-sys/m3tests/src/p2/p211/C.c
+++ b/m3-sys/m3tests/src/p2/p211/C.c
@@ -100,7 +100,7 @@ void Check(unsigned Type, void* Float, void* Text)
             return;
         }
     }
-    printf("string not found %s\n", (Type ? "double" : "float", String));
+    printf("%s string not found %s\n", Type ? "double" : "float", String);
     exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
C.c:103:56: error: expression result unused [-Werror,-Wunused-value]
printf("string not found %s/n", (Type ? "double" : "float", String));