### PR TITLE
m3core: Remove M3_DLL_EXPORT M3_DLL_IMPORT M3_HAS_VISIBILITY etc.

### DIFF
--- a/m3-libs/m3core/src/C/Common/CerrnoC.c
+++ b/m3-libs/m3core/src/C/Common/CerrnoC.c
@@ -10,7 +10,6 @@
 extern "C" {
 #endif
 
-M3_DLL_EXPORT
 int
 __cdecl
 Cerrno__GetErrno(void)
@@ -18,7 +17,6 @@ Cerrno__GetErrno(void)
     return errno;
 }
 
-M3_DLL_EXPORT
 void
 __cdecl
 Cerrno__SetErrno(int e)

--- a/m3-libs/m3core/src/C/Common/CstdioC.c
+++ b/m3-libs/m3core/src/C/Common/CstdioC.c
@@ -74,8 +74,8 @@ M3WRAP2_RETURN_VOID(setbuf, FILE*, char*)
 
 #undef X
 #undef X_
-#define X(a) M3_DLL_EXPORT EXTERN_CONST int Cstdio__##a = a;
-#define X_(a) M3_DLL_EXPORT EXTERN_CONST int Cstdio__##a = _##a;
+#define X(a) EXTERN_CONST int Cstdio__##a = a;
+#define X_(a) EXTERN_CONST int Cstdio__##a = _##a;
 
 X(BUFSIZ)
 X(FILENAME_MAX)
@@ -91,7 +91,7 @@ X(TMP_MAX)
 X(EOF)
 
 #undef X
-#define X(a) M3_DLL_EXPORT FILE* __cdecl Cstdio__get_##a(void) { return a; }
+#define X(a) FILE* __cdecl Cstdio__get_##a(void) { return a; }
 
 X(stdin)
 X(stdout)

--- a/m3-libs/m3core/src/Csupport/dtoa.c
+++ b/m3-libs/m3core/src/Csupport/dtoa.c
@@ -239,25 +239,6 @@ static double private_mem[PRIVATE_mem], *pmem_next = private_mem;
 
 #include <float.h>
 
-// This is disabled.
-// There are warnings about inconsistencies.
-// There is not all that much code that it affects.
-// We should be more worried the m3c output than the hand written C.
-// It is not clearly worth the platform-specificity.
-#if 0 /* __GNUC__ >= 4 && !defined(__osf__) && !defined(__CYGWIN__) */
-#define M3_HAS_VISIBILITY 1
-#else
-#define M3_HAS_VISIBILITY 0
-#endif
-
-#if M3_HAS_VISIBILITY
-#ifdef __APPLE__
-#pragma GCC visibility push(default)
-#else
-#pragma GCC visibility push(protected)
-#endif
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -3323,10 +3304,6 @@ m3_dtoa
 	}
 #ifdef __cplusplus
 }
-#endif
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
 #endif
 
 #undef Bias

--- a/m3-libs/m3core/src/Csupport/hand.c
+++ b/m3-libs/m3core/src/Csupport/hand.c
@@ -18,14 +18,6 @@
 
 #include <string.h>
 
-#if M3_HAS_VISIBILITY
-#ifdef __APPLE__
-#pragma GCC visibility push(default)
-#else
-#pragma GCC visibility push(protected)
-#endif
-#endif
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -354,8 +346,4 @@ int __cdecl m3_memcmp(const void* a, const void* b, size_t n)
 
 #ifdef __cplusplus
 } /* extern "C" */
-#endif
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
 #endif

--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -47,17 +47,6 @@ typedef int BOOL;
 #define TRUE 1
 #define FALSE 0
 
-// This is disabled.
-// There are warnings about inconsistencies.
-// There is not all that much code that it affects.
-// We should be more worried the m3c output than the hand written C.
-// It is not clearly worth the platform-specificity.
-#if 0 /* __GNUC__ >= 4 && !defined(__osf__) && !defined(__CYGWIN__) */
-#define M3_HAS_VISIBILITY 1
-#else
-#define M3_HAS_VISIBILITY 0
-#endif
-
 /* __DARWIN_UNIX03 defaults to 1 on older and newer headers,
  * but older headers still have context "ss" instead of "__ss"
  * and such, so we have to force 0.
@@ -99,20 +88,6 @@ typedef int BOOL;
 #define _TIME64_T
 #endif
 #endif /* osf */
-
-/* http://gcc.gnu.org/wiki/Visibility */
-/* Helpers for shared library support */
-#if M3_HAS_VISIBILITY
-#ifdef __APPLE__
-#define M3_DLL_EXPORT __attribute__ ((visibility("default")))
-#else
-#define M3_DLL_EXPORT __attribute__ ((visibility("protected")))
-#endif
-#define M3_DLL_LOCAL  __attribute__ ((visibility("hidden")))
-#else
-#define M3_DLL_EXPORT /* nothing */
-#define M3_DLL_LOCAL  /* nothing */
-#endif
 
 /* Autoconf: AC_SYS_LARGEFILE
  */
@@ -280,7 +255,7 @@ M3EXTERNC_END
 #define M3PASTE3(a, b, c) M3PASTE3_(a, b, c)
 
 #define M3WRAP(ret, m3name, cname, in, out)                                 \
-    M3EXTERNC_BEGIN M3_DLL_EXPORT ret __cdecl M3PASTE(M3MODULE, m3name) in  \
+    M3EXTERNC_BEGIN ret __cdecl M3PASTE(M3MODULE, m3name) in                \
     {                                                                       \
         ret return_value;                                                   \
         return_value = cname out;                                           \
@@ -288,7 +263,7 @@ M3EXTERNC_END
     } M3EXTERNC_END
 
 #define M3WRAP_NO_SWITCHING(ret, m3name, cname, in, out) \
-    M3EXTERNC_BEGIN M3_DLL_EXPORT ret __cdecl m3name in  \
+    M3EXTERNC_BEGIN ret __cdecl m3name in                \
     {                                                    \
         ret return_value;                                \
         Scheduler__DisableSwitching ();                  \
@@ -298,13 +273,13 @@ M3EXTERNC_END
     } M3EXTERNC_END
 
 #define M3WRAP_RETURN_VOID(m3name, cname, in, out)       \
-    M3EXTERNC_BEGIN M3_DLL_EXPORT void __cdecl m3name in \
+    M3EXTERNC_BEGIN void __cdecl m3name in               \
     {                                                    \
         cname out;                                       \
     } M3EXTERNC_END
 
 #define M3WRAP_RETURN_VOID_NO_SWITCHING(m3name, cname, in, out) \
-    M3EXTERNC_BEGIN M3_DLL_EXPORT void __cdecl m3name in        \
+    M3EXTERNC_BEGIN void __cdecl m3name in                      \
     {                                                           \
         Scheduler__DisableSwitching ();                         \
         cname out;                                              \

--- a/m3-libs/m3core/src/runtime/common/RTProcessC.c
+++ b/m3-libs/m3core/src/runtime/common/RTProcessC.c
@@ -25,7 +25,6 @@ typedef struct _vector_t {
 #define fork_handlers RTProcess__fork_handlers
 static vector_t fork_handlers;
 
-M3_DLL_EXPORT
 INTEGER
 __cdecl
 RTProcess__RegisterForkHandlers(ForkHandler prepare,
@@ -75,7 +74,6 @@ Exit:
 
 #else /* M3_USER_THREADS */
 
-M3_DLL_EXPORT
 INTEGER
 __cdecl
 RTProcess__RegisterForkHandlers(ForkHandler prepare,
@@ -113,7 +111,6 @@ void
 __cdecl
 ThreadPThread__AtForkPrepareOutsideFork(void);
 
-M3_DLL_EXPORT
 INTEGER
 __cdecl
 RTProcess__Fork(void)

--- a/m3-libs/m3core/src/thread/Common/ThreadInternal.c
+++ b/m3-libs/m3core/src/thread/Common/ThreadInternal.c
@@ -9,10 +9,6 @@
 
 M3_EXTERNC_BEGIN
 
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility push(hidden)
-#endif
-
 #ifndef _WIN32
 
 enum {WaitResult_Ready, WaitResult_Error, WaitResult_FDError, WaitResult_Timeout};
@@ -23,7 +19,6 @@ enum {WaitResult_Ready, WaitResult_Error, WaitResult_FDError, WaitResult_Timeout
 #define THOUSAND (1000)
 #define MILLION (1000 * 1000)
 
-M3_DLL_LOCAL
 int
 __cdecl
 ThreadInternal__Poll(int fd,
@@ -49,7 +44,6 @@ ThreadInternal__Poll(int fd,
         return WaitResult_FDError;
 }
 
-M3_DLL_LOCAL
 int
 __cdecl
 ThreadInternal__Select(int nfds,
@@ -73,7 +67,3 @@ ThreadInternal__Select(int nfds,
 #endif
 
 M3_EXTERNC_END
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
-#endif

--- a/m3-libs/m3core/src/thread/POSIX/ThreadPosixC.c
+++ b/m3-libs/m3core/src/thread/POSIX/ThreadPosixC.c
@@ -44,10 +44,6 @@
 #endif
 #include <ucontext.h>
 
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility push(hidden)
-#endif
-
 M3_EXTERNC_BEGIN
 
 typedef void (*SignalHandler1)(int signo);
@@ -350,7 +346,3 @@ ThreadPosix__SetVirtualTimer(void)
 }
 
 M3_EXTERNC_END
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
-#endif

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadApple.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadApple.c
@@ -13,10 +13,6 @@
 #endif
 #endif /* Apple */
 
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility push(hidden)
-#endif
-
 M3_EXTERNC_BEGIN
 
 #ifndef __APPLE__
@@ -156,7 +152,3 @@ ThreadPThread__ProcessStopped (m3_pthread_t mt, ADDRESS top, ADDRESS context,
 #endif /* Apple */
 
 M3_EXTERNC_END
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
-#endif

--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThreadC.c
@@ -57,10 +57,6 @@ M3_EXTERNC_BEGIN
 
 void __cdecl SignalHandler(int signo, ADDRESS context);
 
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility push(hidden)
-#endif
-
 /* expected values for compat, if compat matters:
     Solaris: 17 (at least 32bit SPARC?)
     Cygwin: 19 -- er, but maybe that's wrong
@@ -658,7 +654,3 @@ BOOLEAN ThreadPThread__IA64 (void)
 }
 
 M3_EXTERNC_END
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
-#endif

--- a/m3-libs/m3core/src/time/POSIX/DatePosixC.c
+++ b/m3-libs/m3core/src/time/POSIX/DatePosixC.c
@@ -3,10 +3,6 @@
 #include "m3core.h"
 #endif
 
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility push(hidden)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/m3-libs/m3core/src/time/POSIX/TimePosixC.c
+++ b/m3-libs/m3core/src/time/POSIX/TimePosixC.c
@@ -11,10 +11,6 @@ We use gettimeofday() which returns seconds and microseconds.
 #include "m3core.h"
 #endif
 
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility push(hidden)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -137,8 +133,4 @@ TimePosix__ComputeGrain(void)
 
 #ifdef __cplusplus
 } /* extern C */
-#endif
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
 #endif

--- a/m3-libs/m3core/src/unix/Common/Uconstants.c
+++ b/m3-libs/m3core/src/unix/Common/Uconstants.c
@@ -28,14 +28,6 @@
 extern "C" {
 #endif
 
-#if M3_HAS_VISIBILITY
-#ifdef __APPLE__
-#pragma GCC visibility push(default)
-#else
-#pragma GCC visibility push(protected)
-#endif
-#endif
-
 // Check that Uerror.Max=255 is enough; if you get an error here, raise it in Uerror.i3 and here.
 //
 // FreeBSD (12.2/amd64) compiling with clang++ has some numbers between 9000 and 10000.
@@ -1745,8 +1737,4 @@ X(XTABS)
 
 #ifdef __cplusplus
 }
-#endif
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
 #endif

--- a/m3-libs/m3core/src/unix/Common/Uexec.c
+++ b/m3-libs/m3core/src/unix/Common/Uexec.c
@@ -14,7 +14,7 @@ extern "C" {
 
 #ifndef _WIN32
 
-M3_DLL_EXPORT void __cdecl
+void __cdecl
 Uexec__RepackStatus(int* var_status)
 {
     int status = { 0 };

--- a/m3-libs/m3core/src/unix/Common/Ugrp.c
+++ b/m3-libs/m3core/src/unix/Common/Ugrp.c
@@ -39,34 +39,34 @@ static m3_group_t* native_to_m3group(const struct group* native, m3_group_t* m3)
     return m3;
 }
 
-M3_DLL_EXPORT m3_group_t* __cdecl
+m3_group_t* __cdecl
 Ugrp__getgrent(m3_group_t* m3group)
 {
     Scheduler__DisableSwitching();
     return native_to_m3group(getgrent(), m3group);
 }
 
-M3_DLL_EXPORT m3_group_t* __cdecl
+m3_group_t* __cdecl
 Ugrp__getgrgid(m3_group_t* m3group, m3_gid_t gid)
 {
     Scheduler__DisableSwitching();
     return native_to_m3group(getgrgid(gid), m3group);
 }
 
-M3_DLL_EXPORT m3_group_t* __cdecl
+m3_group_t* __cdecl
 Ugrp__getgrnam(m3_group_t* m3group, const char* name)
 {
     Scheduler__DisableSwitching();
     return native_to_m3group(getgrnam(name), m3group);
 }
 
-M3_DLL_EXPORT void __cdecl
+void __cdecl
 Ugrp__setgrent(void)
 {
     setgrent();
 }
 
-M3_DLL_EXPORT void __cdecl
+void __cdecl
 Ugrp__endgrent(void)
 {
     endgrent();

--- a/m3-libs/m3core/src/unix/Common/Uin.c
+++ b/m3-libs/m3core/src/unix/Common/Uin.c
@@ -15,10 +15,10 @@ extern "C" {
 
 /* ntohl are sometimes macros (FreeBSD 4) so we don't use M3WRAP1 */
 
-M3_DLL_EXPORT UINT32 __cdecl Uin__ntohl(UINT32 x) { return ntohl(x); }
-M3_DLL_EXPORT UINT16 __cdecl Uin__ntohs(UINT16 x) { return ntohs(x); }
-M3_DLL_EXPORT UINT32 __cdecl Uin__htonl(UINT32 x) { return htonl(x); }
-M3_DLL_EXPORT UINT16 __cdecl Uin__htons(UINT16 x) { return htons(x); }
+UINT32 __cdecl Uin__ntohl(UINT32 x) { return ntohl(x); }
+UINT16 __cdecl Uin__ntohs(UINT16 x) { return ntohs(x); }
+UINT32 __cdecl Uin__htonl(UINT32 x) { return htonl(x); }
+UINT16 __cdecl Uin__htons(UINT16 x) { return htons(x); }
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/m3-libs/m3core/src/unix/Common/Unetdb.c
+++ b/m3-libs/m3core/src/unix/Common/Unetdb.c
@@ -43,14 +43,14 @@ static m3_hostent_t* native_to_m3hostent(const struct hostent* native, m3_hosten
     return m3;
 }
 
-M3_DLL_EXPORT m3_hostent_t* __cdecl
+m3_hostent_t* __cdecl
 Unetdb__gethostbyname(const char* name, m3_hostent_t* m3)
 {
     Scheduler__DisableSwitching();
     return native_to_m3hostent(gethostbyname(name), m3);
 }
 
-M3_DLL_EXPORT m3_hostent_t* __cdecl
+m3_hostent_t* __cdecl
 Unetdb__gethostbyaddr(const char* addr, int len, int type, m3_hostent_t* m3)
 {
     Scheduler__DisableSwitching();

--- a/m3-libs/m3core/src/unix/Common/UnixC.c
+++ b/m3-libs/m3core/src/unix/Common/UnixC.c
@@ -131,7 +131,7 @@ M3WRAP2(int, fchmod, int, m3_mode_t)
 M3WRAP3(int, mknod, const char*, m3_mode_t, m3_dev_t)
 
 #if 0 /* See RTProcess.Fork. */
-M3_DLL_EXPORT m3_pid_t __cdecl
+m3_pid_t __cdecl
 Unix__fork(void)
 {
 #ifdef __sun
@@ -150,13 +150,13 @@ Unix__fork(void)
 #endif /* vms */
 #endif /* win32 */
 
-M3_DLL_EXPORT void __cdecl
+void __cdecl
 Unix__underscore_exit(int exit_code)
 {
     _exit(exit_code);
 }
 
-M3_DLL_EXPORT void __cdecl
+void __cdecl
 Unix__exit(int i)
 {
     exit(i);
@@ -165,14 +165,14 @@ Unix__exit(int i)
 #ifdef _WIN32
 
 #if 0
-M3_DLL_EXPORT char* __cdecl
+char* __cdecl
 Unix__getcwd(char* name, size_t len)
 {
     assert(len < INT_MAX);
     return _getcwd(name, (int)len);
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Unix__gethostname(char* name, size_t len)
 {
     assert(len < INT_MAX);
@@ -180,13 +180,13 @@ Unix__gethostname(char* name, size_t len)
 }
 #endif
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Unix__mkdir(const char* path, m3_mode_t mode)
 {
     return _mkdir(path);
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 UnixC__pipe (int* files)
 {
     return _pipe(files, 0, _O_BINARY);
@@ -194,13 +194,13 @@ UnixC__pipe (int* files)
 
 #if _MSC_VER >= 1000
 
-M3_DLL_EXPORT m3_off_t __cdecl
+m3_off_t __cdecl
 Unix__lseek(int fd, m3_off_t offset, int whence)
 {
     return _lseeki64(fd, offset, whence);
 }
 
-M3_DLL_EXPORT m3_off_t __cdecl
+m3_off_t __cdecl
 Unix__tell(int fd)
 {
     return _telli64(fd);
@@ -220,7 +220,7 @@ typedef struct m3_flock_t {
   INTEGER whence;
 } m3_flock_t;
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Unix__fcntl(int fd, INTEGER request, INTEGER m3_arg)
 /* fcntl is actually fcntl(fd, request, ...).
  * Wrapper is needed on some systems to handle varargs.
@@ -269,7 +269,7 @@ Unix__fcntl(int fd, INTEGER request, INTEGER m3_arg)
     return r;
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Unix__ioctl(int fd, INTEGER request, ADDRESS argp)
 /* ioctl is varargs. See fcntl. */
 {

--- a/m3-libs/m3core/src/unix/Common/UnixLink.c
+++ b/m3-libs/m3core/src/unix/Common/UnixLink.c
@@ -9,20 +9,12 @@
 #include <windows.h>
 #endif
 
-#if M3_HAS_VISIBILITY
-#ifdef __APPLE__
-#pragma GCC visibility push(default)
-#else
-#pragma GCC visibility push(protected)
-#endif
-#endif
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Unix__link(const char* ExistingFile, const char* NewLink)
 {
 #ifdef _WIN32
@@ -39,8 +31,4 @@ Error:
 
 #ifdef __cplusplus
 } /* extern C */
-#endif
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
 #endif

--- a/m3-libs/m3core/src/unix/Common/Usocket.c
+++ b/m3-libs/m3core/src/unix/Common/Usocket.c
@@ -299,7 +299,7 @@ Usocket__plen_out(m3_socklen_t* plen, m3c_socklen_t len)
 #define ASSERT_LEN \
     assert(len <= (1UL << 30));
 
-M3_DLL_LOCAL void __cdecl
+void __cdecl
 Usocket__Assertions(void)
 {
     /* assert that struct linger is literally { int l_onoff, l_linger },
@@ -339,7 +339,7 @@ M3WRAP2(int, listen, int, int)
 M3WRAP2(int, shutdown, int, int)
 M3WRAP3(int, socket, int, int, int)
 
-M3_DLL_EXPORT ssize_t __cdecl
+ssize_t __cdecl
 Usocket__send (int a, const void* b, size_t c, int d)
 {
     ssize_t r;
@@ -351,7 +351,7 @@ Usocket__send (int a, const void* b, size_t c, int d)
     return r;
 }
 
-M3_DLL_EXPORT ssize_t __cdecl
+ssize_t __cdecl
 Usocket__recv (int a, void* b, size_t c, int d)
 {
     ssize_t r;
@@ -404,7 +404,7 @@ Usocket__recv (int a, void* b, size_t c, int d)
     }                                                       \
     return result;
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Usocket__bind(int s, const M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t len)
 {
     WRAP_SOCKADDR_INPUT1
@@ -414,7 +414,7 @@ Usocket__bind(int s, const M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t len)
     WRAP_SOCKADDR_INPUT2
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Usocket__connect(int s, const M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t len)
 {
     WRAP_SOCKADDR_INPUT1
@@ -424,7 +424,7 @@ Usocket__connect(int s, const M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t len
     WRAP_SOCKADDR_INPUT2
 }
 
-M3_DLL_EXPORT ssize_t __cdecl
+ssize_t __cdecl
 Usocket__sendto(int s, const void* msg, size_t length, int flags, const M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t len)
 {
     WRAP_SOCKADDR_INPUT1
@@ -435,7 +435,7 @@ Usocket__sendto(int s, const void* msg, size_t length, int flags, const M3SockAd
     WRAP_SOCKADDR_INPUT2
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Usocket__setsockopt(int s, int level, int optname, const void* optval, m3_socklen_t len)
 {
     ASSERT_LEN
@@ -456,7 +456,7 @@ Usocket__setsockopt(int s, int level, int optname, const void* optval, m3_sockle
 
 /* wrap everything taking input/output m3c_socklen_t */
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Usocket__getpeername(int s, M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t* plen)
 {
     WRAP_SOCKADDR_OUTPUT1
@@ -466,7 +466,7 @@ Usocket__getpeername(int s, M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t* plen
     WRAP_SOCKADDR_OUTPUT2
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Usocket__getsockname(int s, M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t* plen)
 {
     WRAP_SOCKADDR_OUTPUT1
@@ -476,7 +476,7 @@ Usocket__getsockname(int s, M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t* plen
     WRAP_SOCKADDR_OUTPUT2
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Usocket__accept(int s, M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t* plen)
 {
     WRAP_SOCKADDR_OUTPUT1
@@ -486,7 +486,7 @@ Usocket__accept(int s, M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t* plen)
     WRAP_SOCKADDR_OUTPUT2
 }
 
-M3_DLL_EXPORT int __cdecl
+int __cdecl
 Usocket__getsockopt(int s, int level, int optname, void* optval, m3_socklen_t* plen)
 /*
 Posix says l_onoff and l_linger are int, but they aren't on Cygwin.
@@ -531,7 +531,7 @@ the same order. This is checked in Usocket__Assertions.
     }
 }
 
-M3_DLL_EXPORT ssize_t __cdecl
+ssize_t __cdecl
 Usocket__recvfrom(int s, void* buf, size_t length, int flags, M3SockAddrUnionAll* pm3_sockaddr, m3_socklen_t* plen)
 {
     WRAP_SOCKADDR_OUTPUT1
@@ -568,7 +568,6 @@ Usocket__un(
     return err;
 }
 
-M3_DLL_EXPORT
 int
 __cdecl
 Usocket_accept_un(int fd)
@@ -580,7 +579,6 @@ Usocket_accept_un(int fd)
     return accept(fd, (sockaddr*)&addr, &socklen);
 }
 
-M3_DLL_EXPORT
 int
 __cdecl
 Usocket__bind_un(
@@ -591,7 +589,6 @@ Usocket__bind_un(
     return Usocket__un(&addr, path) ? -1 : bind(fd, (sockaddr*)&addr, sizeof(addr));
 }
 
-M3_DLL_EXPORT
 int
 __cdecl
 Usocket__connect_un(

--- a/m3-libs/m3core/src/unix/Common/UstatC.c
+++ b/m3-libs/m3core/src/unix/Common/UstatC.c
@@ -2,14 +2,6 @@
 #include "m3core.h"
 #endif
 
-#if M3_HAS_VISIBILITY
-#ifdef __APPLE__
-#pragma GCC visibility push(default)
-#else
-#pragma GCC visibility push(protected)
-#endif
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -71,7 +63,6 @@ static int __cdecl m3stat_from_stat(int result, m3_stat_t* m3st, struct stat* st
     return result;
 }
 
-M3_DLL_EXPORT
 int
 __cdecl
 Ustat__stat(const char* path, m3_stat_t* m3st)
@@ -80,7 +71,6 @@ Ustat__stat(const char* path, m3_stat_t* m3st)
     return m3stat_from_stat(stat(path, &st), m3st, &st);
 }
 
-M3_DLL_EXPORT
 int
 __cdecl
 Ustat__lstat(const char* path, m3_stat_t* m3st)
@@ -89,7 +79,6 @@ Ustat__lstat(const char* path, m3_stat_t* m3st)
     return m3stat_from_stat(lstat(path, &st), m3st, &st);
 }
 
-M3_DLL_EXPORT
 int
 __cdecl
 Ustat__fstat(int fd, m3_stat_t* m3st)
@@ -107,8 +96,4 @@ M3WRAP2(int, fchflags, int, unsigned long)
 
 #ifdef __cplusplus
 } /* extern "C" */
-#endif
-
-#if M3_HAS_VISIBILITY
-#pragma GCC visibility pop
 #endif

--- a/m3-libs/m3core/src/unix/Common/UtimeC.c
+++ b/m3-libs/m3core/src/unix/Common/UtimeC.c
@@ -13,7 +13,6 @@ extern "C" {
  */
 M3_STATIC_ASSERT(sizeof(m3_time_t) <= sizeof(m3_time64_t));
 
-M3_DLL_EXPORT
 m3_time64_t
 __cdecl
 Utime__time(m3_time64_t* tloc)
@@ -28,7 +27,6 @@ Utime__time(m3_time64_t* tloc)
     return a;
 }
 
-M3_DLL_EXPORT
 char*
 __cdecl
 Utime__ctime(/*TODO const*/ m3_time64_t* m)
@@ -41,7 +39,6 @@ Utime__ctime(/*TODO const*/ m3_time64_t* m)
 #endif
 }
 
-M3_DLL_EXPORT
 void
 __cdecl
 Utime__tzset(void)


### PR DESCRIPTION
It is not a terrible idea, but:
 - I disabled it a few months ago. Nobody was bothered.

 - It is a small mess in the code.

 - It is not "portable"..but it is widely supported by gcc, clang, msvc.

 - I disabled it because it was not being used consistently,
   or _perhaps_ correctly. The inconsistencies were found
   by concatening all the files ("single file bootstrap").

 - While there is value in reducing dynamic link metadata,
   it does not seem super valuable to focus on the small amount o
   hand written C++. It is more interesting to handle things in the compier maybe.

 - There might be yet other ways to handle this, though they
   are not super likely to be implemented any time soon: lists
   of functions linker-specific text files, like Msvc .def; again
   nicely done for most code in compiler, but again target-specific