### PR TITLE
Haiku/amd64 support.

### DIFF
--- a/m3-libs/libm3/src/uid/POSIX/MachineIDPosixC.c
+++ b/m3-libs/libm3/src/uid/POSIX/MachineIDPosixC.c
@@ -21,7 +21,9 @@ typedef unsigned UINT32;
 #include <limits.h>
 #include <math.h>
 #include <net/if.h>
+#ifndef __HAIKU__
 #include <net/if_arp.h>
+#endif
 #include <net/if_dl.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -54,7 +56,9 @@ typedef unsigned UINT32;
 #endif
 #ifndef __CYGWIN__
 #include <net/if.h>
+#ifndef __HAIKU__
 #include <net/if_arp.h>
+#endif
 #endif
 #ifdef __hpux
 #include "dce/uuid.h"
@@ -62,6 +66,7 @@ typedef unsigned UINT32;
 
 #if !(defined(__APPLE__)    \
    || defined(__CYGWIN__)   \
+   || defined(__HAIKU__)    \
    || defined(__FreeBSD__)  \
    || defined(__linux__)    \
    || defined(__NetBSD__)   \
@@ -72,7 +77,7 @@ typedef unsigned UINT32;
 #error Please test/port this.
 #endif
 
-#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__HAIKU__)
 #define HAS_GETIFADDRS
 #endif
 
@@ -345,6 +350,7 @@ int main()
     system("/sbin/ifconfig -a | grep addr");
     system("/sbin/ifconfig -a | grep ether");
 #endif
+    system("python3 -c \"import uuid;print(\\\"%x\\\" % uuid.getnode())\"");
     return 0;
 }
 

--- a/m3-sys/cminstall/src/config-no-install/AMD64_HAIKU
+++ b/m3-sys/cminstall/src/config-no-install/AMD64_HAIKU
@@ -1,0 +1,38 @@
+M3_BACKEND_MODE = "C"
+
+readonly TARGET_ENDIAN = "LITTLE" % { "BIG" OR "LITTLE" }
+readonly TARGET_ARCH = "AMD64"    %
+readonly WORD_SIZE = "64BITS"     % { "32BITS" or "64BITS" }
+readonly TARGET_OS = "HAIKU"      %
+readonly OS_TYPE = "POSIX"        % { "WIN32" or "POSIX" }
+readonly TARGET = "AMD64_HAIKU"   %
+
+M3_PARALLEL_BACK = 20
+
+include ("cm3cfg.common")
+
+SYSTEM_LIBS =
+{
+  "LIBC" : [ "-lnetwork" ],
+  "TCP" : [ ],
+}
+
+proc compile_c(source, object, options, optimize, debug) is
+  exec ("g++ -g -fPIC -m64 -xc++ -c", options, source, "-o", object)
+  return 0
+end
+
+proc m3_link(prog, options, objects, imported_libs, shared) is
+  exec ("g++ -o", prog, options, objects, imported_libs)
+  return 0
+end
+
+proc skip_lib(lib, shared) is
+  deriveds ("", format("lib%s.a", lib))
+  return 0
+end
+
+proc make_lib(lib, options, objects, imported_libs, shared) is
+  exec("ar", "cs", format("lib%s.a", lib), objects)
+  return 0
+end

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -2577,13 +2577,13 @@ CONST Prefix = ARRAY OF TEXT {
 "extern \"C\" {",
 "#endif",
 
-"#if !defined(_MSC_VER) && !defined(__cdecl)",
+(* see m3core.h for more about cdecl/stdcall *)
+"#if defined(_WIN32) && !defined(_WIN64)",
+"#undef __cdecl",
+"#undef __stdcall",
 "#define __cdecl /* nothing */",
-"#endif",
-"#if !defined(_MSC_VER) && !defined(__stdcall)",
 "#define __stdcall /* nothing */",
 "#endif",
-
 "#define STRUCT(n) struct_##n##_t", (* TODO prune if not used *)
 (* TODO struct1 and struct2 should not be needed.
    struct4 and struct8 can go away when we make open arrays and jmpbufs

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1098,6 +1098,7 @@ def Boot():
     cygwin = StringContainsI(Target, "Cygwin")
     linux = StringContainsI(Target, "Linux")
     bsd = StringContainsI(Target, "BSD")
+    haiku = StringContainsI(Target, "haiku")
 
     CBackend = True
 
@@ -1132,6 +1133,9 @@ def Boot():
         #CCompilerFlags = " -g -pthread -mfp-rounding-mode=d "
     elif nt:
         CCompiler = "cl"
+    elif haiku:
+        CCompiler = "g++"
+        CCompilerFlags = "-g -m64 -fPIC" # -pthread not allowed
     else: # gcc and other platforms
         CCompiler = {
             "SOLgnu" : "/usr/sfw/bin/g++",
@@ -1177,7 +1181,7 @@ def Boot():
     Link = "$(CC) $(CFLAGS) *." + obj + " "
     #Link = "$(CC) $(CFLAGS)"
 
-    # link flags
+    # link flags TODO merge compile and link sections
 
     # TBD: add more and retest, e.g. Irix, AIX, HPUX, Android
     # http://www.openldap.org/lists/openldap-bugs/200006/msg00070.html
@@ -1188,6 +1192,8 @@ def Boot():
 
     if darwin:
         pass
+    elif haiku:
+        Link = Link + " -lnetwork "
     elif mingw:
         Link = Link  +  " -liphlpapi -lrpcrt4 -lcomctl32 -lws2_32 -lgdi32 -luser32 -ladvapi32 "
     elif solaris or sol:


### PR DESCRIPTION
 - GET_PC
 - MachineIDPosix is one of the preexisting ones and add Python uuid.getnode() test.
 - minimal config w/o dynamic linking to Modula3 code
 - boot1 and boot1autools (redundant)
 - Rework __cdecl/__stdcall slightly to avoid many warnings.
   This might need revisiting for Haiku/x86.
 - Remove putw/getw under ifdef.
 - Skip context.h under ifdef.
 - Some networking static_assert fixes went in prior.
 - Errno fixes went in prior.

This is enough for boot1autotools.py amd64_linux to build cm3 and not find cm3.cfg, a typical milestone.

Thanks to DKnoto for nudging this along.
https://github.com/modula3/cm3/discussions/833
