### PR TITLE
I386_HAIKU: Fix MxConfigC__HOST.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -936,6 +936,8 @@ Process__RegisterExitor(void (__cdecl*)(void));
 #elif defined(__i386__)
 #define GET_PC(context) ((context)->uc_mcontext.eip)
 #define M3_HOST "I386_HAIKU"
+// uname says the architecture is "BePC", skip it
+#define M3_HOST_SKIP_UNAME 1
 #else
 #error Unsupported Haiku
 #endif

--- a/m3-sys/m3quake/src/MxConfigC.c
+++ b/m3-sys/m3quake/src/MxConfigC.c
@@ -87,7 +87,9 @@ const char*
 __cdecl
 MxConfigC__HOST(void)
 {
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#ifdef M3_HOST_SKIP_UNAME
+    return strdup(M3_HOST);
+#elif defined(_WIN32) && !defined(__CYGWIN__)
     char name[256];
 
     if (GetEnvironmentVariableA("PROCESSOR_ARCHITECTURE", name, sizeof(name) - 10) > 200)


### PR DESCRIPTION
I386_HAIKU says architecture is "BePC".
Just return M3_HOST and skip uname.
The entire uname path is mostly a waste.
This entire function is mostly a waste.

We can skip uname via ifdef, but sometimes endian is not clear,
and uname lets us stop maintaining per-system code.
i.e. now that M3_HOST has been show to checkout against uname,
we can remove M3_HOST and only use uname.
Both mechanisms remain though, to continue testing.

We can skip this function (MxConfigC__HOST) entirely once config is "auto" or "cmake" or "autotools".
When the notion of a multi-arch install is above bin/lib/pkg, instead of embedded in pkg.
Or when the output directory is "out" or "obj" our outside of the entire git tree and user
creates it arbitrarily.

MxConfigC__HOST exists just to default TARGET, but most targets are kinda the same.