### PR TITLE
Haiku: Skip pthread_atfork, it causes problems -- pthread_mutex_unloc…

### DIFF
--- a/m3-libs/m3core/src/runtime/common/RTProcessC.c
+++ b/m3-libs/m3core/src/runtime/common/RTProcessC.c
@@ -83,6 +83,7 @@ RTProcess__RegisterForkHandlers(ForkHandler prepare,
 /* FreeBSD < 6 lacks pthread_atfork. Would be good to use autoconf.
  * VMS lacks pthread_atfork? Would be good to use autoconf.
  * Win32 lacks pthread_atfork and fork. OK.
+ * Haiku pthread_atfork does not seem to work, pthread_mutex_unlock fails with EPERM.
  *
  * As well, for all Posix systems, we could implement
  * atfork ourselves, as long as we provide a fork()
@@ -90,6 +91,7 @@ RTProcess__RegisterForkHandlers(ForkHandler prepare,
  */
 #if defined(_WIN32) \
         || defined(__vms) \
+        || defined(__HAIKU__) \
         || (defined(__FreeBSD__) && (__FreeBSD__ < 6))
     return 0;
 #else

--- a/m3-sys/cminstall/src/config-no-install/Haiku.common
+++ b/m3-sys/cminstall/src/config-no-install/Haiku.common
@@ -24,12 +24,14 @@ proc m3_link(prog, options, objects, imported_libs, shared) is
 end
 
 proc skip_lib(lib, shared) is
-  deriveds ("", format("lib%s.a", lib))
+  deriveds ("", [format("lib%s.a", lib)])
   return 0
 end
 
 proc make_lib(lib, options, objects, imported_libs, shared) is
-  exec("ar", "cs", format("lib%s.a", lib), objects)
+  local a = format("lib%s.a", lib)
+  delete_file (a)
+  exec ("ar rs", a, objects)
   return 0
 end
 


### PR DESCRIPTION
…k fails with EPERM.

Fix array vs. value in config file.
Delete libs before creation.
Fix ar command to create libs.

With this "everything" seems to work, well cm3 can move along
building itself. There seems to be no X server.