### PR TITLE
NT config: Make static libs with native link /lib.

### DIFF
--- a/m3-sys/cminstall/src/config-no-install/NT.common
+++ b/m3-sys/cminstall/src/config-no-install/NT.common
@@ -972,35 +972,47 @@ proc make_lib(lib, options, objects, imported_libs, shared) is
     DeleteFiles(Outputs)
     deriveds("", Outputs)
 
-    local m3_lib_flags = [ ]
-    if equal(LINKER, "MS")
-        % m3_lib_flags = ["-debugtype:cv", "-machine:i386"]
-        m3_lib_flags = ["-ign:__real"]
-    end
-
-    % build the static library
-
-    ret_code = try_exec(
-        "@mklib",
-        WriteResponseFile(
-            LibResponseFile,
-            " ",
-            [
-                m3_lib_flags,
-                "-out:" & lib_file,
-                options,
-                objects,
-            ]))
-    if not equal(ret_code, 0) or not FileExists(lib_file)
-        error("library creation failed" & EOL)
-        if not equal(ret_code, 0)
-            return ret_code
-        end
-        return 1
-    end
+    % build a static library and .def
+    % The static library here is historical and unused.
+    % mklib is transitioning away: write the .def file elsewhere
+    % if dynamic linking is supported
 
     if shared
 
+        local m3_lib_flags = [ ]
+        if equal(LINKER, "MS")
+            % m3_lib_flags = ["-debugtype:cv", "-machine:i386"]
+            m3_lib_flags = ["-ign:__real"]
+        end
+
+        ret_code = try_exec(
+            "@mklib",
+            WriteResponseFile(
+                LibResponseFile,
+                " ",
+                [
+                    m3_lib_flags,
+                    "-out:" & lib_file,
+                    options,
+                    objects,
+                ]))
+        if not equal(ret_code, 0) or not FileExists(lib_file)
+            error("library creation failed" & EOL)
+            if not equal(ret_code, 0)
+                return ret_code
+            end
+            return 1
+        end
+    end
+
+    % build static library without mklib
+
+    delete_file (lib_file)
+    exec("link /lib /out:" & lib_file, arglist("@", [options, objects]))
+
+    if not shared
+        return 0
+    else
         % build an import library & DLL
 
         MoveFile(lib_file, lib0_file)

--- a/scripts/python/boot1.py
+++ b/scripts/python/boot1.py
@@ -5,7 +5,7 @@
 # This produces an archive that can be copied to the target,
 # extract, run make, producing a cm3.
 #
-# Copy that into place and proceed with boot2.py or boot2min.
+# Copy that into place and proceed with boot2.py or boot2min.py.
 #
 # The source trees on the two systems must be "compatible",
 # essentially cm3/m3core/m3middle/etc. have to match.
@@ -32,7 +32,6 @@ def Boot():
 # TODO build a directory tree, one directory per package
 # TODO as a result, support building separate libraries and possibly shared libraries
 # TODO and out-of-tree builds
-# Maybe something autotools or cmake-laden
 
     global BuildLocal
     BuildLocal += " -boot -no-m3ship-resolution -group-writable -keep -DM3CC_TARGET=" + Config


### PR DESCRIPTION
After making them with mklib and deleting it.
This is a step toward not using this functionality
in mklib, and writing the .def files elsewhere, either moving
the mklib code to cm3, or in m3front or m3back for exported functions,
possibly even discerning the three kinds: lowercase interface(.i3),
uppercase Interface(.i3), or no .i3 at all.