### PR TITLE
Cygwin support.

### DIFF
--- a/scripts/python/boot1autotools.py
+++ b/scripts/python/boot1autotools.py
@@ -126,6 +126,10 @@ AS_CASE([$host],
            [CXXFLAGS="$CXXFLAGS -mfp-rounding-mode=d -mieee"],
            [CXXFLAGS="$CXXFLAGS -fprm d -readonly_strings -ieee_with_no_inexact"])])
 
+<<<<<<< HEAD
+=======
+# AS_CASE can mostly be removed, but it speeds up configure
+>>>>>>> 02d99512d (Cygwin support.)
 AS_CASE([$host],
     [*-*-darwin*], [ ],
     [*haiku], [


### PR DESCRIPTION
I ported to I386_CYGWIN years ago:
 Hybrid of Win32 threads and Posix, because pthreads didn't work adequately.
 gcc backend.
 target=NT386, ostype=posix, and carefully select pieces of libraries
 NT386 config intertwined between native Msvc and Cygwin/GNU.

Current work aims to separate NT.common from Cygwin.
 i.e. to remove dependency on mklib and make the config easier to read
Add AMD64.
C++ backend.
Don't implement dynamic linking this time.
PThreads still did not work, so again tease together parts of Win32 and Posix.
 This is really unfortunate as it really makes the system messy and confusing.

cm3 builds, gives the usual error, and can start to build itself but
then gets:
new source -> compiling TimePosixC.c
****  PARALLEL BACK-END BUILD, M3_PARALLEL_BACK = 20

Fatal Error:       0 [waitproc] cm3 11028 proc_waiter: error on read of child wait pipe 0x0, Win32 error 6
quake error in parallel build    7143 [waitproc] cm3 11028 proc_waiter: error on read of child wait pipe 0x0, Win32 error 6
  19912 [waitproc] cm3 11028 proc_waiter: error on read of child wait pipe 0x0, Win32 error 6
  20509 [waitproc] cm3 11028 proc_waiter: error on read of child wait pipe 0x0, Win32 error 6
"/cygdrive/c/s/cm3/m3-libs/m3core/src/m3makefile", line 77: quake runtime error: exec failed: errno=7 *** g++ -g -xc++ -c  Convert.i3.cpp -o Convert_i.o

Try again w/o parallelism or simplify the spawn path.
You'd think we could just run system() here.

Disabling parallel backend works.

Cygwin is odd in that it barely justifies itself any longer.
There is mingw, msys, and wsl.
I386_CYGWIN is deprecated as well and has seen its last major release.

Due to the Win32/Posix hybrid, Cygwin bootstraps do not match any other.
I used boot1autotools.py i386_cygwin && boot1autotools.py amd64_cygwin.