### PR TITLE
Drain legacy-named targets.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -308,16 +308,6 @@ def _ClearEnvironmentVariable(Name):
 
 def _GetAllTargets():
 
-    # legacy naming
-
-    Targets = { }
-    for target in [ "NT386", "LINUXLIBC6", "SOLsun", "SOLgnu", "FreeBSD4" ]:
-        Targets[target] = target
-        Targets[target.lower()] = target
-        Targets[target.upper()] = target
-
-    # systematic naming
-
     for proc in ["ALPHA", "ALPHA32", "ALPHA64", "AMD64", "ARM", "ARMEL",
                  "ARM64", "IA64", "I386", "PPC", "PPC32", "PPC64", "SPARC",
                  "SPARC32", "SPARC64", "MIPS32", "MIPS64EL", "MIPS64", "PA32",
@@ -2252,9 +2242,6 @@ def RestoreSkel(prefix):
 # see http://www.debian.org/doc/debian-policy/footnotes.html#f73
 
 DebianArchitecture = {
-  "LINUXLIBC6" : "i386",
-  "FreeBSD4" : "i386",
-  "NT386" : "i386",
   "I386" : "i386",
   "IA64" : "ia64",
   "ALPHA" : "alpha",
@@ -2268,8 +2255,6 @@ DebianArchitecture = {
   "PPC" : "powerpc",
   "PPC32" : "powerpc",
   "PPC64" : "ppc",
-  "SOLsun" : "sparc",
-  "SOLgnu" : "sparc",
   "SPARC" : "sparc",
   "SPARC32" : "sparc",
   "SPARC64" : "sparc",


### PR DESCRIPTION
This could take many steps and remain unfinished.
Everyone by now should have switched:
 LINUXLIBC6 => I386_LINUX
 NT386 => I386_NT
 NT386GNU => I386_CYGWIN    probably no user of former
 NT386MINGNU => I386_MINGW  ditto
 SOLsun => SPARC32_SOLARIS  possibly one line edit of config to favor Sun compiler
 SOLgnu => SPARC32_SOLARIS  possibly one line edit of config to favor Gnu compiler
 FreeBSD4 => I386_FREEBSD

Of course these are all 32bit so falling out of use as well.