### PR TITLE
m3makefile: Remove old comment about adding Win32 on Cygwin.

### DIFF
--- a/m3-libs/libm3/src/os/WIN32/m3makefile
+++ b/m3-libs/libm3/src/os/WIN32/m3makefile
@@ -8,26 +8,6 @@
 
 Module("OSErrorWin32")
 
-%
-% This leads to revealing File.T twice, which
-% the compiler only seems to sometimes notice.
-% Not having this breaks NT386GNU serial but
-% for now that is ok.
-%
-% Ideally we restructure this somewhat
-% so that FileWin32 can be used without
-% revealing the portable parts.
-%
-% As to why the multiple revelations are only
-% sometimes noticed deserves further investigation.
-% In particular, the compiler noticed when I continued
-% to try to have more Win32 code available on NT386GNU,
-% particularly ProcessWin32 in trying to avoid problems
-% with ProcessPosix on NT386GNU/Cygwin.
-%
-% Module("FileWin32")
-%
-
 if not equal (OS_TYPE, "POSIX")
 
 implementation("PathnameWin32")


### PR DESCRIPTION
The matter could still use some investigation, as to why only sometimes
are multiple revelations of the same type noticed and cause errors.

Given a desire for converged win32/posix bootstrap or even full source I don't
love that pattern anyway. I'd rather switch in the C with ifdef
win32 than pick and chose m3 files, with stubs on the other side's dependencies,
until/unless there is another idea.

As well then user threads could be a command line parameter on systems that support user and not.
Win32 gui vs. X gui could be a command line parameter on Cygwin.
Pthreads vs. Win32 threads ditto.
system vs. spawn vs. fork/exec ditto.
etc.