### PR TITLE
libm3: djgpp: Check if S_IFSOCK # 0.

### DIFF
--- a/m3-libs/libm3/src/os/POSIX/FilePosix.m3
+++ b/m3-libs/libm3/src/os/POSIX/FilePosix.m3
@@ -44,7 +44,8 @@ PROCEDURE FileTypeFromStatbuf(READONLY statbuf: Ustat.struct_stat)
           THEN RETURN RegularFile.FileType
           ELSE RETURN Terminal.FileType
         END;
-      ELSIF (type = Ustat.S_IFIFO) OR (type = Ustat.S_IFSOCK) THEN
+      (* S_IFSOCK can be zero on systems without socket support *)
+      ELSIF (type = Ustat.S_IFIFO) OR (Ustat.S_IFSOCK # 0 AND type = Ustat.S_IFSOCK) THEN
         RETURN Pipe.FileType;
       ELSIF type = Ustat.S_IFDIR THEN
         RETURN FS.DirectoryFileType


### PR DESCRIPTION
And so return RegularFile.FileType instead of Pipe.FileType.