### PR TITLE
m3core: Add optional fstat logging, like stat.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -1323,6 +1323,7 @@ typedef union m3core_trace_t
         unsigned chdir : 1;
         unsigned close : 1;
         unsigned creat : 1;
+        unsigned fstat : 1;
         unsigned open : 1;
         unsigned readdir : 1;
         unsigned stat : 1;

--- a/m3-libs/m3core/src/unix/Common/UstatC.c
+++ b/m3-libs/m3core/src/unix/Common/UstatC.c
@@ -98,9 +98,20 @@ int
 __cdecl
 Ustat__fstat(int fd, m3_stat_t* m3st)
 {
+    int result;
     struct stat st;
+
     Scheduler__DisableSwitching ();
-    return m3stat_from_stat(fstat(fd, &st), m3st, &st);
+    result = fstat (fd, &st);
+#ifndef _WIN32
+    if (m3core_trace.fstat)
+    {
+        char* buf = (char*)alloca (256);
+        int len = sprintf (buf, "fstat (%d):mode:%X,%d\n", fd, (unsigned)st.st_mode, result);
+        write (1, buf, len);
+    }
+#endif
+    result = m3stat_from_stat(result, m3st, &st);
 }
 
 #ifdef HAS_STAT_FLAGS


### PR DESCRIPTION
This is closer to where djgpp problem was (since sock==0,
djgpp thought all files were sockets, i.e. pipes, and turning
on flags for IntermittenRead would fail since djgpp does not support nonblocking.)