### PR TITLE
m3core/unix: Restore lost return from fstat.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/UnixC.c
+++ b/m3-libs/m3core/src/unix/Common/UnixC.c
@@ -185,6 +185,7 @@ int __cdecl Unix__chdir (const char* path)
 }
 
 M3WRAP1_(m3_mode_t, umask, m3_mode_t)
+M3WRAP2_(int, chmod, const char*, m3_mode_t)
 M3WRAP1_(int, dup, int)
 M3WRAP1(int, system, const char*)
 M3WRAP1_(int, isatty, int)

--- a/m3-libs/m3core/src/unix/Common/UstatC.c
+++ b/m3-libs/m3core/src/unix/Common/UstatC.c
@@ -81,8 +81,7 @@ Ustat__stat(const char* path, m3_stat_t* m3st)
         write (1, buf, len);
     }
 #endif
-    result = m3stat_from_stat(result, m3st, &st);
-    return result;
+    return m3stat_from_stat(result, m3st, &st);
 }
 
 int
@@ -111,7 +110,7 @@ Ustat__fstat(int fd, m3_stat_t* m3st)
         write (1, buf, len);
     }
 #endif
-    result = m3stat_from_stat(result, m3st, &st);
+    return m3stat_from_stat(result, m3st, &st);
 }
 
 #ifdef HAS_STAT_FLAGS


### PR DESCRIPTION
Restore lost wrapper for chmod.