### PR TITLE
djgpp/dos: Treat paths more like Windows (or vice versa).

### DIFF
--- a/m3-sys/m3quake/src/M3Path.m3
+++ b/m3-sys/m3quake/src/M3Path.m3
@@ -9,11 +9,10 @@
 
 MODULE M3Path;
 
-IMPORT Pathname, Text, ASCII, Compiler;
+IMPORT Pathname, Text, ASCII, Compiler, MxConfigC;
 
 CONST
   Null      = '\000';
-  Colon     = ':';
   Slash     = '/';
   BackSlash = '\\';
 
@@ -62,8 +61,8 @@ CONST
   Default_pgm = ARRAY OSKind OF TEXT { "a.out", "a.out", "NONAME.EXE", "a.out" };
 
 VAR target_os := ARRAY Compiler.OS OF OSKind{OSKind.Unix, OSKind.Win32}[Compiler.ThisOS];
-CONST d_sep = ARRAY Compiler.OS OF CHAR{Slash, BackSlash}[Compiler.ThisOS];
-CONST v_sep = ARRAY Compiler.OS OF CHAR{Null, Colon}[Compiler.ThisOS];
+VAR d_sep := MxConfigC.DirectorySeparator (); (* forward or backward slash *)
+VAR v_sep := MxConfigC.DeviceSeparator (); (* zero or colon *)
 (*CONST DirSepText = ARRAY Compiler.OS OF TEXT{"/", "\\"}[Compiler.ThisOS];*)
 
 PROCEDURE SetTargetOS (kind: OSKind) =
@@ -248,8 +247,8 @@ PROCEDURE RegionMatch (a: TEXT;  start_a: CARDINAL;
                        b: TEXT;  start_b: CARDINAL;
                        len: CARDINAL): BOOLEAN =
   CONST N = 128;
-        ignore_case = (Compiler.ThisOS = Compiler.OS.WIN32);
   VAR
+    ignore_case := MxConfigC.CaseInsensitive ();
     len_a : CARDINAL;
     len_b : CARDINAL;
     buf_a, buf_b : ARRAY [0..N-1] OF CHAR;

--- a/m3-sys/m3quake/src/MxConfigC.c
+++ b/m3-sys/m3quake/src/MxConfigC.c
@@ -303,6 +303,40 @@ MxConfigC__HOST(void)
 #endif
 }
 
+BOOLEAN
+__cdecl
+MxConfigC__CaseInsensitive(void)
+{
+#if defined(_WIN32) || defined(__MSDOS) || defined(__CYGWIN__)
+	return TRUE;
+#else
+	return FALSE;
+#endif
+}
+
+char
+__cdecl
+MxConfigC__DeviceSeparator(void)
+{
+#if defined(_WIN32) || defined(__MSDOS)
+	return ':';
+#else
+	return 0;
+#endif
+}
+
+char
+__cdecl
+MxConfigC__DirectorySeparator(void)
+{
+#if defined(_WIN32) || defined(__MSDOS)
+	// Caller can and does also accept '/'.
+	return '\\';
+#else
+	return '/';
+#endif
+}
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/m3-sys/m3quake/src/MxConfigC.i3
+++ b/m3-sys/m3quake/src/MxConfigC.i3
@@ -4,4 +4,8 @@ IMPORT Ctypes;
 <*EXTERNAL "MxConfigC__ifdef_win32"*> PROCEDURE ifdef_win32(): BOOLEAN;
 <*EXTERNAL "MxConfigC__HOST"*> PROCEDURE HOST(): Ctypes.const_char_star;
 
+<*EXTERNAL "MxConfigC__CaseInsensitive"*> PROCEDURE CaseInsensitive(): BOOLEAN;
+<*EXTERNAL "MxConfigC__DeviceSeparator"*> PROCEDURE DeviceSeparator(): CHAR;
+<*EXTERNAL "MxConfigC__DirectorySeparator"*> PROCEDURE DirectorySeparator(): CHAR;
+
 END MxConfigC.

--- a/m3-sys/m3quake/src/QMachine.m3
+++ b/m3-sys/m3quake/src/QMachine.m3
@@ -14,10 +14,7 @@ IMPORT QIdent, QValue, QVal, QCode, QCompiler, QVTbl, QVSeq, QScanner;
 FROM Quake IMPORT Error, ID, IDMap, NoID;
 IMPORT Date, Time;
 IMPORT TextUtils, FSUtils, System, DirStack; (* sysutils *)
-IMPORT Compiler;
-IMPORT M3Path;
-IMPORT QPromise, QPromiseSeq;
-IMPORT ETimer;
+IMPORT Compiler, M3Path, MxConfigC, QPromise, QPromiseSeq, ETimer;
 
 CONST
   OnUnix = (Compiler.ThisOS = Compiler.OS.POSIX);
@@ -3064,15 +3061,11 @@ PROCEDURE StripPrefix (t: T;  prefix, path: Pathname.Arcs): Pathname.Arcs
   END StripPrefix;
 
 PROCEDURE PathEqual (a, b: TEXT): BOOLEAN =
-  VAR len: CARDINAL;
+  VAR len := Text.Length (a);
   BEGIN
-    len := Text.Length (a);
-    IF len # Text.Length (b) THEN
-      RETURN FALSE;
-    END;
-    IF Text.Equal (a, b) THEN RETURN TRUE; END;
-    IF OnUnix THEN RETURN FALSE; END;
-    RETURN CIEqual (a, b, len);  
+    RETURN len = Text.Length (b)
+        AND (Text.Equal (a, b)
+             OR (MxConfigC.CaseInsensitive () AND CIEqual (a, b, len)));
   END PathEqual;
 
 PROCEDURE CIEqual (a, b: TEXT; len: CARDINAL): BOOLEAN =


### PR DESCRIPTION
Allow colon for device/volume separator.
Allow forward and backward slashes.
Also Cygwin case insensitivity here.
Rework PathEqual using expression.
We have too much path handling code and it is likely all not right.