### PR TITLE
djgpp/dos: Use Win32 Pathname implementation.

### DIFF
--- a/m3-libs/libm3/src/os/POSIX/m3makefile
+++ b/m3-libs/libm3/src/os/POSIX/m3makefile
@@ -17,12 +17,13 @@ Module("FilePosix")
 
 implementation("FSPosix")
 implementation("PipePosix")
-implementation("PathnamePosix")
 
-if equal (TARGET, "I386_DJGPP")
+if equal (TARGET_OS, "DJGPP")
+  % Path is like c:/foo so use ../Win32/PathnameWin32
   implementation("SocketNone")
 else
   implementation("SocketPosix")
+  implementation("PathnamePosix")
 end
 
 implementation("OSConfigPosix")

--- a/m3-libs/libm3/src/os/WIN32/m3makefile
+++ b/m3-libs/libm3/src/os/WIN32/m3makefile
@@ -6,11 +6,15 @@
 %      modified on Thu Nov 10 15:17:04 PST 1994 by kalsow
 %      modified on Tue May  4 10:15:15 PDT 1993 by mjordan
 
-Module("OSErrorWin32")
-
-if not equal (OS_TYPE, "POSIX")
+if equal (TARGET_OS, "DJGPP") or equal (OS_TYPE, "WIN32")
 
 implementation("PathnameWin32")
+
+end
+
+if equal (OS_TYPE, "WIN32")
+
+Module("OSErrorWin32")
 
 import_sys_lib ("TCP")
 

--- a/m3-libs/libm3/src/os/m3makefile
+++ b/m3-libs/libm3/src/os/m3makefile
@@ -6,5 +6,5 @@
 %      modified on Tue May  4 10:15:15 PDT 1993 by mjordan
 
 include_dir ("Common")
-include_dir (OS_TYPE)
+include_dir ("WIN32")
 include_dir ("POSIX")


### PR DESCRIPTION
DJGPP paths are like c:/foo and maybe c:/foo\bar.
Win32 is that.
Posix is only /foo/bar.