### PR TITLE
scripts: import-libs is no longer needed

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -66,7 +66,7 @@ done
 # Build the compiler with the installed version of the runtime;
 # do _not_ compile m3core and libm3 here.
 # Start with the front end.
-P="import-libs sysutils set m3middle m3objfile m3linker m3back \
+P="sysutils set m3middle m3objfile m3linker m3back \
    m3front m3quake cm3 mklib m3cggen"
 "$root/scripts/do-pkg.sh" "$@" "realclean" ${P} || exit 1
 "$root/scripts/do-pkg.sh" "$@" "buildship" ${P} || exit 1

--- a/scripts/win/pkginfo.cmd
+++ b/scripts/win/pkginfo.cmd
@@ -32,11 +32,10 @@ goto :eof
 
 :FilterOnePackage
     @rem goto :FilterOnePackage_%1
-    for %%a in (import_libs tcl serial X11R4 m3cc m3gdb) do if /i "%1" == "%%a" goto :FilterOnePackage_%1
+    for %%a in (tcl serial X11R4 m3cc m3gdb) do if /i "%1" == "%%a" goto :FilterOnePackage_%1
     exit /b 0
     goto :eof
 
-:FilterOnePackage_import-libs
 :FilterOnePackage_tapi
     if /i "%M3OSTYPE%" == "WIN32" exit /b 0
     exit /b 1


### PR DESCRIPTION
It was to accomodate old bad libs in very old distributions, replace them,
or missing libs in some Windows SDKs.
Building it has done nothing since March 2021 and was long prior obsolete.