### PR TITLE
libm3: Split extension at last dot (after slash), not first.

### DIFF
--- a/m3-libs/libm3/src/os/WIN32/PathnameWin32.m3
+++ b/m3-libs/libm3/src/os/WIN32/PathnameWin32.m3
@@ -248,7 +248,7 @@ PROCEDURE NameSections(
              of the last component of pn, or Length(pn) if there is no
              extension;
   extUpb  := Length(pn) *)
-  VAR pos: CARDINAL; ch: CHAR;
+  VAR pos: CARDINAL; ch: CHAR; extSepSeen := FALSE;
   BEGIN
     extUpb := Text.Length(pn);
     pos := extUpb;
@@ -261,7 +261,9 @@ PROCEDURE NameSections(
           baseLwb := pos + 1;
           EXIT
         ELSIF ch = ExtSepChar THEN
-          baseUpb := pos
+          IF NOT extSepSeen THEN
+            baseUpb := pos; extSepSeen := TRUE
+          END
         END
       ELSE
         baseLwb := 0;

--- a/m3-sys/cminstall/src/config/I386_DJGPP
+++ b/m3-sys/cminstall/src/config/I386_DJGPP
@@ -44,8 +44,6 @@ proc compile_c(source, object, options, optimize, debug) is
 % without switches for either. This only affects hand written C++ in m3core,
 % not C++ backend output. Granted, by running cc1plus we are also affecting language choice.
 %
-% base(foo.m3.cpp) should be foo.m3 but is foo (https://github.com/modula3/cm3/issues/937)
-% This is ok since it is only a temorary file, single threaded, collisions are ok.
   base = pn_lastbase (source)
   local cpp = base & ".cpp"
   if not equal (source, pn_last (source))


### PR DESCRIPTION
Matches Posix and matches being reasonable.
now:
  base(foo.cpp.obj) == foo.cpp
  extension(foo.cpp.obj) == obj
prior:
  base(foo.cpp.obj) == foo
  extension(foo.cpp.obj) == cpp.obj

Fixes https://github.com/modula3/cm3/issues/937

Remove DOS config comment mentioning this bug.
Note that DOS is mostly Posix, but uses Win32 paths.