### PR TITLE
scripts: No longer delete config files in bin.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1422,14 +1422,7 @@ def CopyFileIfExist(From, To):
 #-----------------------------------------------------------------------------
 
 def DeleteConfig(To):
-    a = os.path.join(Root, "m3-sys", "cminstall", "src")
-    Bin  = os.path.join(To, "bin")
-    RemoveDirectoryRecursive(os.path.join(Bin, "config"))
-
-    for b in ["config"]:
-        for File in glob.glob(os.path.join(a, b, "*")):
-            if isfile(File):
-                DeleteFile(os.path.join(Bin, os.path.basename(File)))
+    RemoveDirectoryRecursive(os.path.join(os.path.join(To, "bin"), "config"))
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
There appears to be a notion of deleting config files from the bin
directory (vs. the bin/config directory). I do not remember
where this came from, but I suspect it was to repair a brief
mistake long ago. Remove it.
Larger goal is to cleanup python scripts some and elevate
out of python directory.