### PR TITLE
scripts: Remove ShipBack from python.

### DIFF
--- a/scripts/python/install-back.py
+++ b/scripts/python/install-back.py
@@ -1,6 +1,0 @@
-#! /usr/bin/env python
-
-import sys
-from pylib import *
-
-ShipBack() or sys.exit(1)

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1521,12 +1521,6 @@ def PickBuildDir(a):
     #FatalError("no BuildDir:" + a)
     return a
 
-def ShipBack():
-    if  not GCC_BACKEND:
-        return True
-    return _CopyCompiler(os.path.join(Root, "m3-sys", "m3cc", PickBuildDir(BuildDir)),
-                         os.path.join(InstallRoot, "bin"))
-
 #-----------------------------------------------------------------------------
 
 def ShipFront():
@@ -1536,7 +1530,7 @@ def ShipFront():
 #-----------------------------------------------------------------------------
 
 def ShipCompiler():
-    return (skipgcc or ShipBack()) and ShipFront()
+    return ShipFront()
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
I might come to regret this, but this is ongoing
removal of m3cc support from scripts\python,
esp. to trim scripts\python.
m3cc is supported by new concierge, and the .sh files,
and the scripts ultimately don't do much.
Three sets of scripts is excessive, for what
I do not use and does not support "a lot" of platforms.