### PR TITLE
scripts: Config updates.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1468,7 +1468,13 @@ def CopyConfigForDistribution(To):
         if isfile(File):
             CopyFile(File, dir)
     open(os.path.join(Bin, "cm3.cfg"), "w").write("\
+%-------------------------------------------------------------------
+% defined by cm3, but not the other MxConfig users\n\
+if not defined(\"CR\") CR = \"\\n\" end\n\
+if not defined(\"EOL\") EOL = \"\\n\" end\n\
+if not defined(\"M3_PROFILING\") M3_PROFILING = FALSE end\n\
 if not defined(\"SL\") SL = \"/\" end\n\
+%-------------------------------------------------------------------
 if not defined(\"HOST\") HOST = \"" + Config + "\" end\n\
 if not defined(\"TARGET\") TARGET = HOST end\n\
 INSTALL_ROOT = (path() & SL & \"..\")\n\


### PR DESCRIPTION
Before deleting the config that reaches back to source tree,
put more of its MxConfig non-cm3 user support into the distribution form.
 if not defined("CR") CR = "\n" end
 if not defined("EOL") EOL = "\n" end
 if not defined("M3_PROFILING") M3_PROFILING = FALSE end
 if not defined("SL") SL = "/" end
vs. only
 if not defined("SL") SL = "/" end