### PR TITLE
scripts: Reduce the notion of installed config that reaches to source…

### DIFF
--- a/m3-sys/cminstall/src/config/cm3.cfg
+++ b/m3-sys/cminstall/src/config/cm3.cfg
@@ -1,4 +1,10 @@
+% This file is not generally used but might be useful
+% during development of config files to avoid having two copies
+% to keep synchronized.
 %
+% Given a target, it tries to reach into the git clone for the configuration.
+%
+
 % Unfortunately, command line defines are not currently
 % available to the toplevel cm3.cfg.
 %

--- a/scripts/python/boot1.py
+++ b/scripts/python/boot1.py
@@ -371,6 +371,6 @@ $(LinkFlags: =
     else:
         pylib._MakeTGZ(BootDir[2:])
 
-CopyConfigForDevelopment() or sys.exit(1)
+CopyConfigForDistribution() or sys.exit(1)
 
 Boot()

--- a/scripts/python/boot1autotools.py
+++ b/scripts/python/boot1autotools.py
@@ -23,7 +23,7 @@ from pylib import *
 # Target need not be precise, only word size and endian matter.
 # In future hopefully they will not.
 #
-CopyConfigForDevelopment() or sys.exit(1)
+CopyConfigForDistribution() or sys.exit(1)
 
 def BootAutoTools():
 

--- a/scripts/python/install-cm3-compiler.py
+++ b/scripts/python/install-cm3-compiler.py
@@ -4,4 +4,4 @@ import sys
 from pylib import *
 
 ShipFront() or sys.exit(1)
-CopyConfigForDevelopment() or sys.exit(1)
+CopyConfigForDistribution() or sys.exit(1)

--- a/scripts/python/install-config.py
+++ b/scripts/python/install-config.py
@@ -4,4 +4,4 @@ import sys
 import pylib
 from pylib import *
 
-CopyConfigForDevelopment() or sys.exit(1)
+CopyConfigForDistribution() or sys.exit(1)

--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -1426,29 +1426,6 @@ def DeleteConfig(To):
 
 #-----------------------------------------------------------------------------
 
-# TODO: Remove this. It was convenient but it is not really needed.
-def CopyConfigForDevelopment():
-    #
-    # The development environment is easily reconfigured
-    # for different targets based on environment variables and `uname`.
-    # The use of `uname` is not fully fleshed out (yet).
-    #
-    # The development environment depends on having a source tree, at least the cminstall\src\config directory.
-    #
-
-    To = os.path.join(InstallRoot, "bin")
-    a = os.path.join(Root, "m3-sys", "cminstall", "src")
-
-    #
-    # First delete all the config files.
-    #
-    DeleteConfig(InstallRoot)
-
-    CopyFile(os.path.join(Root, a, "config", "cm3.cfg"), To) or FatalError()
-    return True
-
-#-----------------------------------------------------------------------------
-
 #def CopyDirectoryNonRecursive(From, To):
 #    CreateDirectory(To)
 #    for File in glob.glob(os.path.join(From, "*")):
@@ -2330,7 +2307,7 @@ if __name__ == "__main__":
     #os.system("set")
     sys.exit(1)
 
-    CopyConfigForDevelopment()
+    CopyConfigForDistribution()
     sys.exit(1)
 
     CheckForLinkSwitch("DELAYLOAD")


### PR DESCRIPTION
… tree.

This was convenient to me long ago, to avoid copying over and over
but probably nobody else. Other automation is more heavily used now,
config files are more stable and simpler(fewer workarounds for older cm3),
it is not clearly as worthwhile. The reaching config remains if
someone wants to copy it manually. Hopefully people can keep
separate the installed vs. uninstalled tree.