### PR TITLE
m3core: EWOULDBLOCK is not defined on older Windows.

### DIFF
--- a/m3-libs/m3core/src/unix/Common/Uconstants.c
+++ b/m3-libs/m3core/src/unix/Common/Uconstants.c
@@ -98,7 +98,7 @@ X(ENOTSOCK)
 X(ETIMEDOUT)
 #endif
 
-#if !defined (__DJGPP__) || defined (EWOULDBLOCK)
+#if !(defined (__DJGPP__) || defined(_WIN32)) || defined (EWOULDBLOCK)
 X(EWOULDBLOCK)
 M3_STATIC_ASSERT (EWOULDBLOCK != 0);
 #else


### PR DESCRIPTION
Make it conditional, like DJGPP.
Found this using Visual C++ 2008/x86.