### PR TITLE
m3c: Temporarily expand llroundl workaround to Win32 not just Win64.

### DIFF
--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -4757,7 +4757,7 @@ PROCEDURE HelperFunctions_cvt_int(self: HelperFunctions_t; <*UNUSED*>rtype: RTyp
 CONST text = ARRAY ConvertOp OF TEXT{
 
     "#ifndef m3_round\n#define m3_round m3_round\n"
-    & "#ifdef _WIN64 /* temporary workaround */\n"
+    & "#ifdef _WIN32 /* temporary workaround */\n"
     & "static INT64 __stdcall m3_round(EXTENDED f) { return (INT64)f; }\n"
     & "#else\n"
     & "INT64 __cdecl llroundl(long double);\nstatic INT64 __stdcall m3_round(EXTENDED f) { return (INT64)llroundl(f); }\n"


### PR DESCRIPTION
This needs more work, but the answer is probably to depend on C99.
Most targets already do (Alpha/OSF being an exception).
See https://github.com/modula3/cm3/issues/962
Found this using Visual C++ 2008/x86, which will probably end up not supported.