### PR TITLE
m3core: Fix startup problem.

### DIFF
--- a/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
+++ b/m3-libs/m3core/src/thread/PTHREAD/ThreadPThread.i3
@@ -209,6 +209,12 @@ PROCEDURE AtForkPrepareOutsideFork(); (* called from C *)
 <*EXTERNAL "ThreadPThread__FlushRegisterWindows0"*>
 PROCEDURE FlushRegisterWindows0 () : ADDRESS;
 
+(* This cannot be imported from Coroutine, due its effects on initialization order.
+ * That is, ThreadPThread must initialize before Coroutine.
+ *)
+<* EXTERNAL Coroutine__Supported *>
+PROCEDURE CoroutineSupported(): BOOLEAN;
+
 (*---------------------------------------------------------------------------*)
 
 END ThreadPThread.


### PR DESCRIPTION
The problem is that ThreadPThread cannot import from Coroutine.
Doing so changes the initialization order. ThreadPThread must
initialize before Coroutine.
The solution is just to declare CoroutineSupported in ThreadPThread,
since it extern, it can be anywhere.