### PR TITLE
OpenBSD config update.

### DIFF
--- a/m3-sys/cminstall/src/config/OpenBSD-old.common
+++ b/m3-sys/cminstall/src/config/OpenBSD-old.common
@@ -1,14 +1,13 @@
-% see also OpenBSD-old
-
 readonly TARGET_OS = "OPENBSD"
 
 SYSTEM_LD = SYSTEM_CC
   & " -Wl,-z,now"
-  & " -Wl,-z,origin"
+% & " -Wl,-z,origin"               % no $ORIGIN support up to/including 4.7
   & " -Bsymbolic"
-  & " -Wl,--fatal-warnings"
-  & " -Wl,-rpath,\\$ORIGIN"
-  & " -Wl,-rpath,\\$ORIGIN/../lib"
+% too many warnings e.g. about strcpy, sprintf, common, in X libraries
+% & " -Wl,--fatal-warnings"
+% & " -Wl,-rpath,\\$ORIGIN"        % no $ORIGIN support up to/including 4.7
+% & " -Wl,-rpath,\\$ORIGIN/../lib" % no $ORIGIN support up to/including 4.7
   & " -Wl,--warn-common"
 
 GNU_MAKE = "gmake"


### PR DESCRIPTION
Save -old, many years old.
Current systems supports origin
Fatal-warnings seem ok.
Add comments for odbc/postgres.

OpenBSD was crashing until recently but it is fixed. It was somehow the coroutine code in threads.