### PR TITLE
caltech OpenBSD: No malloc.h

### DIFF
--- a/caltech-other/bool/src/misc.h
+++ b/caltech-other/bool/src/misc.h
@@ -13,7 +13,7 @@
 
 #include <stdlib.h>
 
-#if !defined(__FreeBSD__) && !defined(__APPLE__)
+#if !(defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__))
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
I am guessing, we do not actually ever need this.