### PR TITLE
scripts/python: Restore some support for integrated backend.

### DIFF
--- a/scripts/python/pylib.py
+++ b/scripts/python/pylib.py
@@ -340,7 +340,7 @@ def TargetOnlyHasCBackend(a):
     #
     # Nevertheless:
     #
-    return true
+    return a.lower() != "i386_nt"
 
 _PossibleCm3Flags = ["boot", "keep", "override", "commands", "verbose", "why", "debug", "trace"]
 _SkipGccFlags = ["nogcc", "skipgcc", "omitgcc"]


### PR DESCRIPTION
Before retiring it someone needs to compare
I386_NT w/ and w/o it more thoroughly, i.e.
the gui apps cube solataire tetris etc.

Solataire seems to have problems.
It resizes poorly upon start, at least.