### PR TITLE
m3core: Remove bitfields from RT0.

### DIFF
--- a/m3-libs/m3core/src/runtime/common/RT0.i3
+++ b/m3-libs/m3core/src/runtime/common/RT0.i3
@@ -197,8 +197,10 @@ CONST (* Type UIDs for the builtin types *)
 CONST
   SB = BITSIZE (ADDRESS) - 26;  (* # spare bits in a ref header *)
 
+(* This is the conceptual definition. *)
+
 TYPE
-  RefHeader = RECORD
+  RefHeaderBits = RECORD
     forwarded : BITS  1 FOR BOOLEAN    := FALSE; (* used during collection *)
     typecode  : BITS 20 FOR Typecode   := 0;     (* the typecode *)
     dirty     : BITS  1 FOR BOOLEAN    := FALSE; (* used during collection *)
@@ -208,6 +210,31 @@ TYPE
     markb     : BITS  1 FOR BOOLEAN    := FALSE; (* used during collection *)
     spare     : BITS SB FOR [0 .. 63]  := 0;     (* for future expansion *)
   END;
+
+(* This is used so that C++ bootstraps are endian neutral. *)
+
+  RefHeader = RECORD
+    word := 0;
+  END;
+
+PROCEDURE Forwarded (header: UNTRACED REF RefHeader): BOOLEAN;
+PROCEDURE GetTypecode (header: UNTRACED REF RefHeader): Typecode;
+PROCEDURE Dirty (header: UNTRACED REF RefHeader): BOOLEAN;
+PROCEDURE Gray (header: UNTRACED REF RefHeader): BOOLEAN;
+PROCEDURE Weak (header: UNTRACED REF RefHeader): BOOLEAN;
+PROCEDURE MarkA (header: UNTRACED REF RefHeader): BOOLEAN;
+PROCEDURE MarkB (header: UNTRACED REF RefHeader): BOOLEAN;
+PROCEDURE Spare (header: UNTRACED REF RefHeader): [0..63];
+
+PROCEDURE SetForwarded (header: UNTRACED REF RefHeader; value : BOOLEAN);
+PROCEDURE SetDirty (header: UNTRACED REF RefHeader; value: BOOLEAN);
+PROCEDURE SetGray (header: UNTRACED REF RefHeader; value: BOOLEAN);
+PROCEDURE SetWeak (header: UNTRACED REF RefHeader; value: BOOLEAN);
+PROCEDURE SetMarkA (header: UNTRACED REF RefHeader; value: BOOLEAN);
+PROCEDURE SetMarkB (header: UNTRACED REF RefHeader; value: BOOLEAN);
+PROCEDURE SetSpare (header: UNTRACED REF RefHeader; value: [0..63]);
+
+PROCEDURE Pack (typecode: Typecode; dirty: BOOLEAN := FALSE): RefHeader;
 
 (*--------------------------------- compiler generated procedure closures ---*)
 

--- a/m3-libs/m3core/src/runtime/common/RT0.m3
+++ b/m3-libs/m3core/src/runtime/common/RT0.m3
@@ -4,9 +4,109 @@
 
 (* Last modified on Thu Jan 30 09:45:28 PST 1992 by kalsow     *)
 
-(* THIS MODULE MUST NOT IMPORT ANY OTHERS! *)
+UNSAFE MODULE RT0;
 
-MODULE RT0;
+IMPORT Word;(* THIS MODULE ALMOST MUST NOT IMPORT ANY OTHERS! *)
+
+(* See RefHeaderBitFields
+ * Actual bitfields are avoided so that C++ bootstrap
+ * is endian neutral
+ *)
+
+(* Most fields are boolean so helpers for that. *)
+PROCEDURE Set (header: UNTRACED REF RefHeader; value: BOOLEAN; offset: [0..63]) =
+BEGIN
+  header.word := Word.Insert (header.word, ORD (value), offset, 1);
+END Set;
+
+PROCEDURE Get (header: UNTRACED REF RefHeader; offset: [0..63]): BOOLEAN =
+BEGIN
+  RETURN Word.Extract (header.word, offset, 1) # 0;
+END Get;
+
+PROCEDURE Forwarded (header: UNTRACED REF RefHeader): BOOLEAN =
+BEGIN
+  RETURN Get (header, 0);
+END Forwarded;
+
+PROCEDURE GetTypecode (header: UNTRACED REF RefHeader): Typecode =
+BEGIN
+  RETURN Word.Extract (header.word, 1, 20);
+END GetTypecode;
+
+PROCEDURE Dirty (header: UNTRACED REF RefHeader): BOOLEAN =
+BEGIN
+  RETURN Get (header, 21);
+END Dirty;
+
+PROCEDURE Gray (header: UNTRACED REF RefHeader): BOOLEAN =
+BEGIN
+  RETURN Get (header, 22);
+END Gray;
+
+PROCEDURE Weak (header: UNTRACED REF RefHeader): BOOLEAN =
+BEGIN
+  RETURN Get (header, 23);
+END Weak;
+
+PROCEDURE MarkA (header: UNTRACED REF RefHeader): BOOLEAN =
+BEGIN
+  RETURN Get (header, 24);
+END MarkA;
+
+PROCEDURE MarkB (header: UNTRACED REF RefHeader): BOOLEAN =
+BEGIN
+  RETURN Get (header, 25);
+END MarkB;
+
+PROCEDURE Spare (header: UNTRACED REF RefHeader): [0..63] =
+BEGIN
+  RETURN Word.Extract (header.word, 26, 6);
+END Spare;
+
+PROCEDURE SetForwarded (header: UNTRACED REF RefHeader; value := TRUE) =
+BEGIN
+  Set (header, value, 0);
+END SetForwarded;
+
+PROCEDURE SetDirty (header: UNTRACED REF RefHeader; value: BOOLEAN) =
+BEGIN
+  Set (header, value, 21);
+END SetDirty;
+
+PROCEDURE SetGray (header: UNTRACED REF RefHeader; value: BOOLEAN) =
+BEGIN
+  Set (header, value, 22);
+END SetGray;
+
+PROCEDURE SetWeak (header: UNTRACED REF RefHeader; value: BOOLEAN) =
+BEGIN
+  Set (header, value, 23);
+END SetWeak;
+
+PROCEDURE SetMarkA (header: UNTRACED REF RefHeader; value: BOOLEAN) =
+BEGIN
+  Set (header, value, 24);
+END SetMarkA;
+
+PROCEDURE SetMarkB (header: UNTRACED REF RefHeader; value: BOOLEAN) =
+BEGIN
+  Set (header, value, 25);
+END SetMarkB;
+
+PROCEDURE SetSpare (header: UNTRACED REF RefHeader; value: [0..63]) =
+BEGIN
+  header.word := Word.Insert (header.word, value, 26, 6);
+END SetSpare;
+
+PROCEDURE Pack (typecode: Typecode; dirty: BOOLEAN := FALSE): RefHeader =
+VAR header := RefHeader {0};
+BEGIN
+  header.word := Word.Insert (0, ORD(typecode), 1, 20);
+  SetDirty (ADR (header), dirty);
+  RETURN header;
+END Pack;
+
 BEGIN
 END RT0.
 

--- a/m3-libs/m3core/src/runtime/common/RTAllocStats.m3
+++ b/m3-libs/m3core/src/runtime/common/RTAllocStats.m3
@@ -114,7 +114,7 @@ PROCEDURE InsertSiteNum (ref: REFANY;  sitetag: INTEGER) =
     addr := LOOPHOLE (ref, ADDRESS);
     hdr  := LOOPHOLE (addr - BYTESIZE(RT0.RefHeader), RTHeapRep.RefHeader);
   BEGIN
-    hdr^.spare := sitetag;
+    RT0.SetSpare (hdr, sitetag);
   END InsertSiteNum;
 
 PROCEDURE GetSite (VAR(*OUT*) site: Site;  skip: CARDINAL) =

--- a/m3-libs/m3core/src/runtime/common/RTHeapMap.m3
+++ b/m3-libs/m3core/src/runtime/common/RTHeapMap.m3
@@ -28,7 +28,7 @@ REVEAL
 
 PROCEDURE WalkRef (h: ObjectPtr;  v: Visitor) =
   VAR
-    tc: RT0.Typecode := h.typecode;
+    tc: RT0.Typecode := RT0.GetTypecode (h);
     t: RT0.TypeDefn;
   BEGIN
     IF (tc # RTHeapRep.Fill_1_type) AND (tc # RTHeapRep.Fill_N_type) THEN

--- a/m3-libs/m3core/src/runtime/common/RTHeapRep.i3
+++ b/m3-libs/m3core/src/runtime/common/RTHeapRep.i3
@@ -155,13 +155,15 @@ TYPE
 CONST
   (* 1 word filler *)
   Fill_1_type: Typecode = 0; (* = NilTypecode, for zero-filled pages *)
-  FillHeader1 = Header{typecode := Fill_1_type, dirty := FALSE};
+VAR
+  FillHeader1: Header;
 
 CONST
   (* multi-word filler, the second word is the total size of the object,
      in bytes *)
   Fill_N_type: Typecode = LAST(Typecode);
-  FillHeaderN = Header{typecode := Fill_N_type, dirty := FALSE};
+VAR
+  FillHeaderN: Header;
 
 PROCEDURE InsertFiller(start: RefHeader; n: INTEGER);
 

--- a/m3-libs/m3core/src/runtime/common/RTHeapRep.m3
+++ b/m3-libs/m3core/src/runtime/common/RTHeapRep.m3
@@ -107,4 +107,6 @@ PROCEDURE Noop (<*UNUSED*> cl: MonitorClosure) =
   END Noop;
 
 BEGIN
+  FillHeader1 := RT0.Pack (typecode := Fill_1_type, dirty := FALSE);
+  FillHeaderN := RT0.Pack (typecode := Fill_N_type, dirty := FALSE);
 END RTHeapRep.

--- a/m3-libs/m3core/src/runtime/common/RTHeapStats.m3
+++ b/m3-libs/m3core/src/runtime/common/RTHeapStats.m3
@@ -201,7 +201,7 @@ PROCEDURE InnerVisit (<*UNUSED*> self: RTHeapMap.Visitor;  loc: ADDRESS) =
     header := ref - ADRSIZE (RT0.RefHeader);
     IF (heap_min <= ref) AND (ref < heap_max)
       AND (Word.And (LOOPHOLE(ref, INTEGER), Mask) = 0) THEN
-      typecode := header.typecode;
+      typecode := RT0.GetTypecode (header);
       IF (0 < typecode) AND (typecode < n_types) THEN
         cell := (ref - heap_min) DIV MapGrain;
         word := cell DIV BITSIZE (Word.T);
@@ -232,7 +232,7 @@ PROCEDURE TypeName (ref: ADDRESS): TEXT =
     header := ref - ADRSIZE (RT0.RefHeader);
     IF (Word.And (LOOPHOLE (header, INTEGER), Mask) = 0) (* => aligned *)
       AND (heap_min <= ref) AND (ref < heap_max) THEN
-      typecode := header.typecode;
+      typecode := RT0.GetTypecode (header);
       IF (0 < typecode) AND (typecode <= n_types) THEN
         RETURN RTTypeSRC.TypecodeName (typecode);
       END;

--- a/m3-libs/m3core/src/runtime/common/RTutils.m3
+++ b/m3-libs/m3core/src/runtime/common/RTutils.m3
@@ -311,7 +311,7 @@ PROCEDURE Walk (v    : Visitor;
         IF (zz.sites = NIL) THEN zz.sites := NEW (StatList, n_sites+1); END;
         addr := LOOPHOLE (ref, ADDRESS);
         hdr  := LOOPHOLE (addr - BYTESIZE(RT0.RefHeader), RTHeapRep.RefHeader);
-        site := hdr.spare;
+        site := RT0.Spare (hdr);
         INC (zz.sites[site].count);
         INC (zz.sites[site].size, size);
       END;


### PR DESCRIPTION
The goal of this PR is to remove endian-specific code from cm3
and its constituent libraries.

The reason for that, is so that the output of the C++ backend
needed to produce cm3, is portable between little endian and big endian systems.

The goal eventually is to have one thing to download for any system, Unix, Windows,
32bit, 64bit, little endian, big endian, just like most "source".

This is tedious and arguably slightly reduces readabilty and performance
but it should not be significant either way.