### PR TITLE
m3core: Anonymous structs are not portable.

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -1328,7 +1328,7 @@ typedef union m3core_trace_t
         unsigned readdir : 1;
         unsigned stat : 1;
         unsigned write : 1;
-    };
+    } s;
 } m3core_trace_t;
 
 extern m3core_trace_t m3core_trace;

--- a/m3-libs/m3core/src/unix/Common/UdirC.c
+++ b/m3-libs/m3core/src/unix/Common/UdirC.c
@@ -19,7 +19,7 @@ dirent* Udir__readdir (DIR* d)
     Scheduler__DisableSwitching ();
     result = readdir (d);
 #ifndef _WIN32
-    if (result && m3core_trace.readdir)
+    if (result && m3core_trace.s.readdir)
     {
         char* buf = (char*)alloca (256 + strlen (result->d_name));
         int len = sprintf (buf, "readdir:%s\n", result->d_name);

--- a/m3-libs/m3core/src/unix/Common/UnixC.c
+++ b/m3-libs/m3core/src/unix/Common/UnixC.c
@@ -109,7 +109,7 @@ int __cdecl Unix__open (const char* path, int flags, m3_mode_t mode)
     result = _open (path, flags, (int)mode);
 #else
     result = open (path, flags, (mode_t)mode);
-    if (m3core_trace.open)
+    if (m3core_trace.s.open)
     {
         char* buf = (char*)alloca (256 + strlen (path));
         int len = sprintf (buf, "open (%s):%d\n", path, result);
@@ -134,7 +134,7 @@ int __cdecl Unix__creat (const char* path, m3_mode_t mode)
     result = _creat (path, mode);
 #else
     result = creat (path, mode);
-    if (m3core_trace.creat)
+    if (m3core_trace.s.creat)
     {
         char* buf = (char*)alloca (256 + strlen (path));
         int len = sprintf (buf, "creat (%s):%d\n", path, result);
@@ -156,7 +156,7 @@ int __cdecl Unix__close (int fd)
     result = _close (fd);
 #else
     result = close (fd);
-    if (m3core_trace.close)
+    if (m3core_trace.s.close)
     {
         char* buf = (char*)alloca (256);
         int len = sprintf (buf, "close (%d):%d\n", fd, result);
@@ -177,7 +177,7 @@ int __cdecl Unix__chdir (const char* path)
     result = _chdir (path);
 #else
     result = chdir (path);
-    if (m3core_trace.chdir)
+    if (m3core_trace.s.chdir)
     {
         char* buf = (char*)alloca (256 + strlen (path));
         int len = sprintf (buf, "chdir (%s):%d\n", path, result);

--- a/m3-libs/m3core/src/unix/Common/UstatC.c
+++ b/m3-libs/m3core/src/unix/Common/UstatC.c
@@ -75,7 +75,7 @@ Ustat__stat(const char* path, m3_stat_t* m3st)
     Scheduler__DisableSwitching ();
     result = stat (path, &st);
 #ifndef _WIN32
-    if (m3core_trace.stat)
+    if (m3core_trace.s.stat)
     {
         char* buf = (char*)alloca (256 + strlen (path));
         int len = sprintf (buf, "stat (%s):mode:%X,%d\n", path, (unsigned)st.st_mode, result);
@@ -105,7 +105,7 @@ Ustat__fstat(int fd, m3_stat_t* m3st)
     Scheduler__DisableSwitching ();
     result = fstat (fd, &st);
 #ifndef _WIN32
-    if (m3core_trace.fstat)
+    if (m3core_trace.s.fstat)
     {
         char* buf = (char*)alloca (256);
         int len = sprintf (buf, "fstat (%d):mode:%X,%d\n", fd, (unsigned)st.st_mode, result);

--- a/m3-libs/m3core/src/unix/Common/Uuio.c
+++ b/m3-libs/m3core/src/unix/Common/Uuio.c
@@ -21,7 +21,7 @@ Uuio__write (int fd, const void* buf, size_t n)
     result = _write (fd, buf, n);
 #else
     result = write (fd, buf, n);
-    if (m3core_trace.write)
+    if (m3core_trace.s.write)
     {
         char* buf = (char*)alloca (256);
         int len = sprintf (buf, "write (fd:%d, buf:%p, n:%ld):%ld\n", fd, buf, (long)n, (long)result);


### PR DESCRIPTION
Anonymous structs are not portable. Call it s for struct.
Seen building on Solaris w/ Sun CC.