### PR TITLE
m3front: Endian neutrality.

### DIFF
--- a/m3-sys/m3front/src/exprs/TextExpr.m3
+++ b/m3-sys/m3front/src/exprs/TextExpr.m3
@@ -9,7 +9,7 @@
 MODULE TextExpr;
 
 IMPORT M3, CG, Expr, ExprRep, M3String, Textt, Type, M3Buf;
-IMPORT Target, Module, M3RT, M3WString, RunTyme, Procedure;
+IMPORT Target, Module, M3RT, M3WString, RunTyme, Procedure, Word;
 
 TYPE
   P = Expr.T OBJECT
@@ -148,8 +148,15 @@ PROCEDURE SetUID (p: P): INTEGER =
     literals[uid] := x;
 
     (* initialize the variable *)
-    CG.Init_intt (x+Header_offset + M3RT.RH_typecode_offset,
-                  M3RT.RH_typecode_size, M3RT.TEXT_typecode, is_const := TRUE);
+    (*
+     * CG.Init_intt (x+Header_offset + M3RT.RH_typecode_offset,
+     *               M3RT.RH_typecode_size, M3RT.TEXT_typecode, is_const := TRUE);
+     * Write an entire word instead for endian neutrality
+     *)
+    CG.Init_intt (x+Header_offset,
+                  Target.Integer.pack,
+                  Word.Shift (M3RT.TEXT_typecode, M3RT.RH_typecode_offset),
+                  is_const := TRUE);
     CG.Init_var
       (x+Method_offset, globalConstsCGVar, methodListOffset, is_const := TRUE);
     CG.Init_intt (x+Length_offset, Target.Integer.size, cnt, is_const := TRUE);

--- a/m3-sys/m3front/src/misc/CG.m3
+++ b/m3-sys/m3front/src/misc/CG.m3
@@ -3704,7 +3704,7 @@ PROCEDURE Hdr_to_info (offset, size: INTEGER) =
   VAR base: INTEGER;
   BEGIN
     ForceStacked ();
-    IF Target.endian = Target.Endian.Little
+    IF TRUE (* endian neutrality Target.endian = Target.Endian.Little *)
       THEN base := offset;
       ELSE base := Target.Integer.size - offset - size;
     END;


### PR DESCRIPTION
 - TextExpr.SetUID: Write entire word instead of only 20 bits in a ref header.
 - CG.Hdr_to_info: Write "little endian", which is really neutral.

Tested via boot1.py to SPARC64_SOLARIS and then boot2min.py which includes upgrade.py.
As well as usual little endian AMD64_NT upgrade.py.
Big endian was probably broken in the brief time since I removed RT0 bitfields.
Boot1.py little endian and big endian diffs are reduced but not quite gone.

Initialized bitfields (i.e. outside of cm3) should not be impacted, should still work.
More testing is to be done.
Little endian systems are not affected anyway.