### PR TITLE
m3front: Endian neutrality.

### DIFF
--- a/m3-sys/m3front/src/misc/M3.i3
+++ b/m3-sys/m3front/src/misc/M3.i3
@@ -14,7 +14,8 @@ INTERFACE M3;
 IMPORT M3Buf, Jmpbufs, M3ID;
 
 TYPE
-  Flag = BITS 1 FOR BOOLEAN;
+  (* Flag = BITS 1 FOR BOOLEAN; endian neutrality *)
+  Flag = BOOLEAN;
 
   (* an optionally module qualified name (qualified identifier) *)
   QID = RECORD

--- a/m3-sys/m3front/src/values/ValueRep.i3
+++ b/m3-sys/m3front/src/values/ValueRep.i3
@@ -16,8 +16,12 @@ REVEAL
     extName    : M3ID.T;
     scope      : M3.Scope;
     vnext      : M3.Value; (* linked list of all values in the same module *)
+    (* endian neutrality
     checkDepth : BITS 12 FOR [-2048..2047];
     class      : BITS 4 FOR Value.Class;
+    *)
+    checkDepth : [-2048..2047];
+    class      : Value.Class;
     checked    : M3.Flag;
     readonly   : M3.Flag;
     traced     : M3.Flag; (* assigned a traced value *)


### PR DESCRIPTION
Remove bitfields from m3front itself.
  M3.Flag = BITS 1 for BOOLEAN => BOOLEAN
  class : BITS 4 FOR  Value.Class; => Value.Class
  BITS 12 FOR [-2048..2047] => [-2048..2047]

Yes this will definitely use more memory, running the compiler, but I do not think anyone will really notice or mind.
Compiler output is unaffected.

Alternatively we could assume little endian layout, but then Modula3/C interop of bitmaps outside of cm3 will suffer.