### PR TITLE
Endian neutrality: Trim libm3 for boot.

### DIFF
--- a/m3-libs/libm3/src/m3makefile
+++ b/m3-libs/libm3/src/m3makefile
@@ -15,8 +15,11 @@ import ("m3core")
 %----------------------------------------------- machine dependent packages ---
 
 include_dir ("os")
-include_dir ("random")
-include_dir ("uid")
+
+if not defined ("M3_BOOTSTRAP") % endian neutrality: avoid bitfields
+  include_dir ("random")
+  include_dir ("uid")
+end
 
 %--------------------------------------------- machine independent packages ---
 
@@ -33,7 +36,9 @@ include_dir ("params")
 include_dir ("property")
 include_dir ("table")
 include_dir ("atom")
-include_dir ("sortedtable")
+if not defined ("M3_BOOTSTRAP") % endian neutrality: avoid bitfields
+  include_dir ("sortedtable")
+end
 include_dir ("sort")
 include_dir ("sequence")
 include_dir ("etimer")
@@ -42,9 +47,17 @@ include_dir ("perftool")
 include_dir ("pqueue")
 include_dir ("sqrt")
 %include_dir ("config") % see m3quake/MxConfig instead
-include_dir ("pickle")
+
+if not defined ("M3_BOOTSTRAP") % endian neutrality: avoid bitfields
+  include_dir ("pickle")
+end
+
 include_dir ("text")
-include_dir ("hash")
+
+if not defined ("M3_BOOTSTRAP") % endian neutrality: avoid bitfields
+  include_dir ("hash")
+end
+
 include_dir ("resource")
 
 % m3_option ("-times")

--- a/m3-sys/m3back/src/M3C.m3
+++ b/m3-sys/m3back/src/M3C.m3
@@ -1,6 +1,6 @@
 MODULE M3C;
 
-IMPORT RefSeq, TextSeq, Wr, Text, IntRefTbl, SortedIntRefTbl, TIntN, IntIntTbl;
+IMPORT RefSeq, TextSeq, Wr, Text, IntRefTbl, TIntN, IntIntTbl;
 IMPORT M3CG, M3CG_Ops, Target, TFloat, TargetMap, IntArraySort, Process;
 IMPORT M3ID, TInt, TWord, ASCII, Thread, Stdio, Word, TextUtils;
 FROM TargetMap IMPORT CG_Bytes, CG_Size;
@@ -2857,7 +2857,7 @@ BEGIN
     (* The CHAR typename exists to satisfy DeclareTypes dependency walk, but should not be
      * actually typedefed. It conflicts with windows.h. UCHAR replaces it right after this. *)
     self.const_INTEGER := M3ID.Add("const_INTEGER"); (* special case *)
-    self.typeidToType := NEW(SortedIntRefTbl.Default).init(); (* FUTURE? *)
+    self.typeidToType := NEW(IntRefTbl.Default).init(); (* FUTURE? *)
     self.multipass := NEW(Multipass_t).Init();
     self.multipass.reuse_refs := TRUE; (* TODO: change them all to integers *)
     self.multipass.self := self;


### PR DESCRIPTION
When building boot, remove from libm3: random ui sortedtable pickle hash.
These use bitfields and are not needed in cm3.

In m3c replace sortedtable with table to avoid use of bitfields.

Normal libm3 is not affected by this.
Only when building with cm3 -boot.

We should probably split into multiple libs but probably will not.