### PR TITLE
m3core: Endian neutrality.

### DIFF
--- a/m3-libs/m3core/src/float/Common/IEEESpecial.m3
+++ b/m3-libs/m3core/src/float/Common/IEEESpecial.m3
@@ -4,21 +4,30 @@
 (*                                                                           *)
 (* Last modified on Fri Feb 25 13:49:00 PST 1994 by kalsow                   *)
 (*      modified on Wed Dec  8 16:57:44 PST 1993 by heydon                   *)
+(* Jay Krell jay.krell@cornell.edu                                           *)
 
 UNSAFE MODULE IEEESpecial;
 
-IMPORT RealRep, LongRealRep;
+IMPORT IEEE;
+
+CONST Pack32 = IEEE.Pack32;
+CONST Pack64 = IEEE.Pack64TwoPartSignificand;
+TYPE Float32 = IEEE.Float32;
+TYPE Float64 = IEEE.Float64TwoPartSignificand;
 
 BEGIN
-  LOOPHOLE (RealNegInf, RealRep.T) := RealRep.NegInf;
-  LOOPHOLE (RealPosInf, RealRep.T) := RealRep.PosInf;
-  LOOPHOLE (RealNan,    RealRep.T) := RealRep.Nan;
+  (* See RealRep, LongRealRep in ieee-le, ieee-be directories.
+   * The information is duplicated to produce endian neutral C++ bootstraps.
+   *)
+  RealNegInf := Pack32 (Float32 { sign := 1, exponent := 16_FF });
+  RealPosInf := Pack32 (Float32 { sign := 0, exponent := 16_FF });
+  RealNan    := Pack32 (Float32 { sign := 0, exponent := 16_FF, significand := 1 });
 
-  LOOPHOLE (LongNegInf, LongRealRep.T) := LongRealRep.NegInf;
-  LOOPHOLE (LongPosInf, LongRealRep.T) := LongRealRep.PosInf;
-  LOOPHOLE (LongNan,    LongRealRep.T) := LongRealRep.Nan;
+  LongNegInf := Pack64 (Float64 { sign := 1, exponent := 16_7FF });
+  LongPosInf := Pack64 (Float64 { sign := 0, exponent := 16_7FF });
+  LongNan    := Pack64 (Float64 { sign := 0, exponent := 16_7FF, significand0 := 1 });
 
-  LOOPHOLE (ExtdNegInf, LongRealRep.T) := LongRealRep.NegInf;
-  LOOPHOLE (ExtdPosInf, LongRealRep.T) := LongRealRep.PosInf;
-  LOOPHOLE (ExtdNan,    LongRealRep.T) := LongRealRep.Nan;
+  ExtdNegInf := LOOPHOLE (LongNegInf, EXTENDED);
+  ExtdPosInf := LOOPHOLE (LongPosInf, EXTENDED);
+  ExtdNan    := LOOPHOLE (LongNan, EXTENDED);
 END IEEESpecial.

--- a/m3-libs/m3core/src/float/Common/grisu/IEEE.i3
+++ b/m3-libs/m3core/src/float/Common/grisu/IEEE.i3
@@ -1,4 +1,5 @@
 (* Copyright (C) 2016 Peter McKinna. All rights reserved. *)
+(* and Jay Krell jay.krell@cornell.edu                    *)
 (* See file COPYRIGHT-BSD for details. *)
 
 INTERFACE IEEE;
@@ -47,5 +48,81 @@ TYPE
     normalizedBoundaries(VAR outMminus,outMplus : GFP);
     lowerBoundaryIsCloser() : BOOLEAN;
   END;
-  
+
+(* These can be considered as INTEGER.
+ * Arguably making them all LONGINT but that is inconvenient in places.
+ *)
+TYPE Sign32 = [0 .. 1]; (* 1 bit *)
+TYPE Exponent32 = [0 .. 16_FF]; (* 8 bits *)
+TYPE Significand32 = [0 .. 16_7FFFFF]; (* 23 bits *)
+
+TYPE Int32 = Uint32;
+
+(* For unfortunate historical reasons a float64 can be considered
+ * as having its significand split into two pieces.
+ * This is presumably so the parts fit in 32bit INTEGER.
+ * These can be considered as INTEGER except Significand64 = LONGINT.
+ * Arguably making them all LONGINT but that is inconvenient in places.
+ *)
+TYPE Sign64 = [0 .. 1]; (* 1 bit *)
+TYPE Exponent64 = [0 .. 16_7FF]; (* 11 bits *)
+TYPE Significand64_0 = [0 .. 16_FFFFF];
+TYPE Significand64_1 = [-16_7fffffff - 1 .. 16_7fffffff];
+TYPE Significand64 = [0L .. 16_FFFFFFFFFFFFFL]; (* 52 bits *)
+
+(* These unpacked forms are endian-neutral,
+ * to aid endian neutrality of C++ backend output,
+ * to have endian neutral bootstrap distributions.
+ *
+ * That is, there are no bitfields here.
+ *)
+TYPE Float64TwoPartSignificand = RECORD
+    significand1 : Significand64_1 := 0; (* 32 bits *)
+    significand0 : Significand64_0 := 0; (* 20 bits *)
+    exponent     : Exponent64      := 0; (* 11 bits *)
+    sign         : Sign64          := 0;
+END;
+
+TYPE Float64OnePartSignificand = RECORD
+    significand  : Significand64   := 0L; (* 52 bits *)
+    exponent     : Exponent64      := 0;  (* 11 bits *)
+    sign         : Sign64          := 0;
+END;
+
+TYPE Float32 = RECORD
+    significand : Significand32 := 0; (* 23 bits *)
+    exponent    : Exponent32    := 0; (* 8 bits *)
+    sign        : Sign32        := 0;
+END;
+
+PROCEDURE Unpack32 (r:REAL): Float32;
+PROCEDURE Unpack64OnePartSignificand (r:LONGREAL): Float64OnePartSignificand;
+PROCEDURE Unpack64TwoPartSignificand (r:LONGREAL): Float64TwoPartSignificand;
+
+PROCEDURE Pack32 (READONLY r:Float32): REAL;
+PROCEDURE Pack64TwoPartSignificand (READONLY r:Float64TwoPartSignificand): LONGREAL;
+PROCEDURE Pack64OnePartSignificand (READONLY r:Float64OnePartSignificand): LONGREAL;
+
+(* These can be provided if/as needed.
+ * PROCEDURE SetSign32 (VAR a: REAL; sign: Sign32);
+ * PROCEDURE SetExponent32 (VAR a: REAL; exponent: Exponent32);
+ * PROCEDURE SetSignificand32 (VAR a: REAL; significand: Significand32);
+ *
+ * PROCEDURE GetSign32 (a: REAL): Sign32;
+ * PROCEDURE GetExponent32 (a: REAL): Exponent32;
+ * PROCEDURE GetSignificand32 (a: REAL): Significand32;
+ *
+ * PROCEDURE SetSign64 (VAR a: LONGREAL; sign: Sign64);
+ * PROCEDURE SetExponent64 (VAR a: LONGREAL; exponent: Exponent64);
+ * PROCEDURE SetSignificand64_0 (VAR a: LONGREAL; significand0: Significand64_0);
+ * PROCEDURE SetSignificand64_1 (VAR a: LONGREAL; significand1: Significand64_1);
+ * PROCEDURE SetSignificand64 (VAR a: LONGREAL; significand: Significand64);
+ *
+ * PROCEDURE GetSign64 (a: LONGREAL): Sign64;
+ * PROCEDURE GetExponent64 (a: LONGREAL): Exponent64;
+ * PROCEDURE GetSignificand64 (a: LONGREAL): Significand64;
+ * PROCEDURE GetSignificand64_0 (a: LONGREAL): Significand64_0;
+ * PROCEDURE GetSignificand64_1 (a: LONGREAL): Significand64_1;
+ *)
+
 END IEEE.

--- a/m3-libs/m3core/src/float/Common/grisu/IEEE.m3
+++ b/m3-libs/m3core/src/float/Common/grisu/IEEE.m3
@@ -1,10 +1,12 @@
 (* Copyright (C) 2016 Peter McKinna. All rights reserved. *)
+(* jay.krell@cornell.edu                                  *)
 (* See file COPYRIGHT-BSD for details. *)
 
 UNSAFE MODULE IEEE;
 
-IMPORT Word,Long;
+IMPORT Word, Long;
 FROM SimFP IMPORT GFP,Uint64,Uint32,SignificandSize;
+FROM Cstdint IMPORT uint32_t, uint64_t;
 
 CONST
   (* Double constants *)
@@ -486,6 +488,61 @@ PROCEDURE LowerBoundaryIsCloser_S(self : Single) : BOOLEAN =
     physSignificandIsZero := Word.And(self.asUint32(), fSignificandMask) = 0;
     RETURN physSignificandIsZero AND (self.exponent() # fDenormalExponent);
   END LowerBoundaryIsCloser_S;
-  
+
+PROCEDURE Unpack32 (r:REAL): Float32 =
+VAR i := LOOPHOLE (r, uint32_t);
+BEGIN
+  RETURN Float32 {sign        := Word.Extract (i, 31, 1),
+                  exponent    := Word.Extract (i, 23, 8),
+                  significand := Word.Extract (i, 0, 23)};
+END Unpack32;
+
+PROCEDURE Unpack64OnePartSignificand (r:LONGREAL): Float64OnePartSignificand =
+VAR i := LOOPHOLE (r, uint64_t);
+BEGIN
+  RETURN Float64OnePartSignificand {
+    sign        := VAL (Long.Extract (i, 63,  1), INTEGER),
+    exponent    := VAL (Long.Extract (i, 52, 11), INTEGER),
+    significand :=      Long.Extract (i,  0, 52)};
+END Unpack64OnePartSignificand;
+
+PROCEDURE Unpack64TwoPartSignificand (r:LONGREAL): Float64TwoPartSignificand =
+VAR i := LOOPHOLE (r, uint64_t);
+BEGIN
+  RETURN Float64TwoPartSignificand {
+    sign         := VAL (Long.Extract (i, 63,  1), INTEGER),
+    exponent     := VAL (Long.Extract (i, 52, 11), INTEGER),
+    significand0 := VAL (Long.Extract (i, 32, 20), INTEGER),
+    significand1 := VAL (Long.Extract (i,  0, 32), INTEGER)};
+END Unpack64TwoPartSignificand;
+
+PROCEDURE Pack32 (READONLY r:Float32): REAL =
+VAR result: uint32_t := 0;
+BEGIN
+  result := Word.Insert (result, r.sign,        31,  1);
+  result := Word.Insert (result, r.exponent,    23,  8);
+  result := Word.Insert (result, r.significand,  0, 23);
+  RETURN LOOPHOLE (result, REAL);
+END Pack32;
+
+PROCEDURE Pack64TwoPartSignificand (READONLY r:Float64TwoPartSignificand): LONGREAL =
+VAR result: uint64_t := 0L;
+BEGIN
+  result := Long.Insert (result, VAL (r.sign, uint64_t),         63, 1);
+  result := Long.Insert (result, VAL (r.exponent, uint64_t),     52, 11);
+  result := Long.Insert (result, VAL (r.significand0, uint64_t), 32, 20);
+  result := Long.Insert (result, VAL (r.significand1, uint64_t),  0, 32);
+  RETURN LOOPHOLE (result, LONGREAL);
+END Pack64TwoPartSignificand;
+
+PROCEDURE Pack64OnePartSignificand (READONLY r:Float64OnePartSignificand): LONGREAL =
+VAR result: uint64_t := 0L;
+BEGIN
+  result := Long.Insert (result, VAL (r.sign, uint64_t),     63,  1);
+  result := Long.Insert (result, VAL (r.exponent, uint64_t), 52, 11);
+  result := Long.Insert (result,      r.significand,         0, 52);
+  RETURN LOOPHOLE (result, LONGREAL);
+END Pack64OnePartSignificand;
+
 BEGIN
 END IEEE.

--- a/m3-libs/m3core/src/float/Common/grisu/m3makefile
+++ b/m3-libs/m3core/src/float/Common/grisu/m3makefile
@@ -1,4 +1,9 @@
-module ("Grisu")
-module ("CachedPowers")
+% temporarily disable Grisu for C backend until problems investigated
+% C fails at runtime
+if not equal (M3_BACKEND_MODE, "C")
+  module ("Grisu")
+  module ("CachedPowers")
+end
+
 module ("SimFP")
 module ("IEEE")

--- a/m3-libs/m3core/src/float/Common/m3makefile
+++ b/m3-libs/m3core/src/float/Common/m3makefile
@@ -8,11 +8,12 @@
 
 % temporarily disable Grisu for C backend until problems investigated
 % C fails at runtime
+
 if equal (M3_BACKEND_MODE, "C")
   include_dir("no_grisu")
-else
-  include_dir("grisu")
 end
+
+include_dir("grisu")
 
 Interface ("FPU")
 
@@ -29,8 +30,11 @@ implementation ("Extended")
 
 module ("DragonInt")
 module ("DragonT")
-module ("FloatUtils")
-module ("TextToFloat")
+
+if not defined ("M3_BOOTSTRAP") % endian neutrality: avoid bitfields
+  module ("FloatUtils")
+  module ("TextToFloat")
+end
 
 % FloatMode.i3.template is not compilable.  Its purpose is to appear
 % in the "Some Useful Modula-3 Interfaces" manual.  It should be

--- a/m3-libs/m3core/src/float/IEEE/LongFloatBoot.m3
+++ b/m3-libs/m3core/src/float/IEEE/LongFloatBoot.m3
@@ -1,0 +1,254 @@
+(* Slower form of LongFloat for endian neutral bootstrap. *)
+
+UNSAFE MODULE LongFloatBoot EXPORTS LongFloat;
+
+(* This module implements the operations on IEEE double precision reals
+   that do not depend on the operating system. *)
+
+IMPORT IEEE;
+IMPORT DragonT, FPU, Word, Ctypes, Convert, Grisu, Cstdlib;
+
+TYPE Float64 = IEEE.Float64TwoPartSignificand;
+CONST Pack = IEEE.Pack64TwoPartSignificand;
+CONST Unpack = IEEE.Unpack64TwoPartSignificand;
+
+PROCEDURE Scalb (x: T; n: INTEGER): T =
+  BEGIN
+    RETURN FLOAT (FPU.scalb (FLOAT (x, LONGREAL), n), T);
+  END Scalb;
+
+VAR Log_of_zero := Pack (Float64 {sign := 1, exponent := 16_7ff,
+                                    significand0 := 0, significand1 := 0});
+PROCEDURE Logb (x: T): T =
+  VAR xx := Unpack (x);
+  BEGIN
+    CASE Class (x) OF
+    | IEEEClass.SignalingNaN,
+      IEEEClass.QuietNaN =>
+        RETURN x;
+    | IEEEClass.Infinity =>
+        RETURN ABS (x);
+    | IEEEClass.Zero =>
+        RETURN Log_of_zero;
+    | IEEEClass.Normal =>
+        xx.exponent := xx.exponent - 1023;
+        RETURN Pack (xx);
+    | IEEEClass.Denormal =>
+        RETURN -1022.0d0;
+    END;
+  END Logb;
+
+PROCEDURE ILogb (x: T): INTEGER =
+  VAR xx := Unpack (x);  v, w: Word.T;  n: INTEGER;
+  BEGIN
+    CASE Class (x) OF
+    | IEEEClass.SignalingNaN,
+      IEEEClass.QuietNaN =>
+        (* RETURN 0; *)
+        <* ASSERT FALSE*>
+    | IEEEClass.Infinity =>
+        RETURN (LAST (INTEGER));
+    | IEEEClass.Zero =>
+        RETURN (FIRST (INTEGER));
+    | IEEEClass.Normal =>
+        RETURN xx.exponent - 1023;
+    | IEEEClass.Denormal =>
+        IF xx.significand0 = 0
+          THEN v := 16_80000000;  n := - 1043;  w := xx.significand1;
+          ELSE v := 16_00080000;  n := - 1023;  w := xx.significand0;
+        END;
+        WHILE Word.And (v, w) = 0 DO
+          v := Word.RightShift (v, 1);
+          DEC (n);
+        END;
+        RETURN n;
+    END; (*CASE*)
+  END ILogb;
+
+PROCEDURE NextAfter (x, y: T): T =
+  CONST Ones0 = 16_fffff; (* BITSIZE (significand0) 1's *)
+        Ones1 = -1; (* all 1's *)
+  VAR xx := Unpack (x);
+      yy := Unpack (y);
+      zz := Float64 {};
+  BEGIN
+    IF x = y                       THEN RETURN x; END;
+    IF IsNaN (x) OR NOT Finite (x) THEN RETURN x; END;
+    IF IsNaN (y)                   THEN RETURN y; END;
+
+    IF x = 0.0d0   THEN
+      zz.sign         := yy.sign;
+      zz.exponent     := 0;
+      zz.significand0 := 0;
+      zz.significand1 := 1;
+      RETURN Pack (zz);
+    END;
+
+    IF (x > 0.0d0 AND x > y) OR (x < 0.0d0 AND x < y) THEN
+      IF xx.significand0 = 0 AND xx.significand1 = 0 THEN
+        xx.significand0 := Ones0;
+        xx.significand1 := Ones1;
+        DEC (xx.exponent);
+        IF xx.exponent = 0 THEN
+          RETURN (2.0d0 * x) / 2.0d0; (* generate underflow *) END;
+      ELSIF xx.significand1 = 0 THEN
+        xx.significand1 := Ones1;
+        DEC (xx.significand0);
+      ELSE
+        DEC (xx.significand1); END;
+    ELSE
+      IF xx.significand0 = Ones0 AND xx.significand1 = Ones1 THEN
+        xx.significand0 := 0;
+        xx.significand1 := 0;
+        INC (xx.exponent);
+        IF xx.exponent = 16_7ff THEN
+          RETURN (x + x); (* generate overflow *) END;
+      ELSIF xx.significand1 = Ones1 THEN
+        xx.significand1 := 0;
+        INC (xx.significand0);
+      ELSE
+        INC (xx.significand1); END; END;
+
+    RETURN Pack (xx);
+  END NextAfter;
+
+PROCEDURE CopySign (x, y: T): T =
+  VAR res := Unpack (x);
+  BEGIN
+    res.sign := Unpack (y).sign;
+    RETURN Pack (res);
+  END CopySign;
+
+PROCEDURE Finite (x: T): BOOLEAN =
+  VAR xx := Unpack (x);
+  BEGIN
+    RETURN xx.exponent # 16_7ff;
+  END Finite;
+
+PROCEDURE IsNaN (x: T): BOOLEAN =
+  VAR xx := Unpack (x);
+  BEGIN
+    RETURN xx.exponent = 16_7ff
+       AND (xx.significand0 # 0 OR xx.significand1 # 0);
+  END IsNaN;
+
+PROCEDURE Sign (x: T): [0..1] =
+  VAR xx := Unpack (x);
+  BEGIN
+    RETURN xx.sign;
+  END Sign;
+
+PROCEDURE Differs (x, y: T): BOOLEAN =
+  BEGIN
+    RETURN (x < y) OR (y < x);
+  END Differs;
+
+PROCEDURE Unordered (x, y: T): BOOLEAN =
+  BEGIN
+    RETURN NOT (x <= y OR y <= x);
+  END Unordered;
+
+PROCEDURE Class (x: T): IEEEClass =
+  VAR xx := Unpack (x);
+  BEGIN
+    IF xx.exponent = 0 THEN
+      IF xx.significand0 = 0 AND xx.significand1 = 0
+        THEN RETURN IEEEClass.Zero;
+        ELSE RETURN IEEEClass.Denormal;
+      END;
+    ELSIF xx.exponent # 16_7FF THEN
+      RETURN IEEEClass.Normal;
+    ELSIF xx.significand0 = 0 AND xx.significand1 = 0 THEN
+      RETURN IEEEClass.Infinity;
+    ELSIF Word.And (16_00080000, xx.significand0) # 0 THEN
+      RETURN IEEEClass.QuietNaN;
+    ELSE
+      RETURN IEEEClass.SignalingNaN;
+    END;
+  END Class;
+
+PROCEDURE Sqrt (x: T): T =
+  BEGIN
+    RETURN FLOAT (FPU.sqrt (FLOAT (x, LONGREAL)), T);
+  END Sqrt;
+
+PROCEDURE FromDecimal (sign   : [0..1];
+              READONLY digits : ARRAY OF [0..9];
+                       exp    : INTEGER): T =
+  <*FATAL Convert.Failed*>
+  TYPE CharBuf = UNTRACED REF ARRAY OF Ctypes.char;
+  CONST Sign = ARRAY [0..1] OF Ctypes.char { ORD ('+'), ORD ('-') };
+  VAR
+    ebuf: ARRAY [0..Word.Size] OF CHAR;
+    buf: CharBuf;
+    expLen, len: CARDINAL;
+    res: T;
+  BEGIN
+    (* strategy:  build a C-style null terminated string and
+       call the C runtime library to convert it to binary value. *)
+
+    (* Allocate the buffer to hold the digits, the exponent value, and the
+       four characters: 1) the leading sign, 2) the decimal point, 3) the 'e'
+       character, and 4) the terminating 0 character. *)
+    IF exp # 0 THEN expLen := Convert.FromInt(ebuf, exp) END;
+    buf := NEW(CharBuf, NUMBER(digits) + expLen + 4);
+    buf[0] := Sign [sign];              len := 1;
+    buf[len] := ORD('0') + digits[0];   INC(len);
+    buf[len] := ORD('.');               INC(len);
+    FOR i := FIRST(digits) + 1 TO LAST(digits) DO
+      buf[len] := ORD ('0') + digits [i];  INC (len);
+    END;
+    IF exp # 0 THEN
+      buf[len] := ORD ('e');  INC (len);
+      FOR i := 0 TO expLen - 1 DO
+	buf[len] := ORD (ebuf[i]);  INC (len);
+      END
+    END;
+    buf[len] := 0;
+
+    res := FLOAT (Cstdlib.strtod (ADR(buf[0]), NIL), T);
+    DISPOSE(buf);
+    RETURN res
+  END FromDecimal;
+
+PROCEDURE ToDecimal(x: T): DecimalApprox =
+  VAR xx := Unpack (x);
+    res: DecimalApprox;
+    exp, sig0, sig1: INTEGER;
+    count: CARDINAL;
+    grisuMode := Grisu.FastDtoaMode.FAST_DTOA_SHORTEST;
+  BEGIN
+    res.class := Class (x);
+    res.sign := Sign (x);
+
+    IF (res.class # IEEEClass.Denormal) AND (res.class # IEEEClass.Normal) THEN
+      RETURN res;
+    END;
+
+    IF NOT Grisu.FastDtoa(ABS(x), grisuMode, 0, res.digits, count, res.exp) THEN
+      (* fallback on Dragon *)
+
+      (* we have the lower 32 bits in significand1, the upper 20 bits in
+         significand0 and may be a bit to set at the top (if bits = 53) *)
+
+      sig1 := Word.And (xx.significand1, 16_ffffffff);
+      sig0 := Word.And (xx.significand0, 16_fffff);
+
+      IF xx.exponent = 0 THEN
+        exp := -1021;
+      ELSE
+        exp  := xx.exponent - 1022;
+        sig0 := Word.Or (sig0, 16_100000);  (* add the implied 53rd bit *)
+      END;
+
+      DragonT.F (exp, 0, 0, sig0, sig1, 53, DragonT.CutoffMode.normal, 0,
+                res.digits, count, res.exp);
+    END;
+    res.len := count;
+    res.errorSign := 0;
+    RETURN res;
+  END ToDecimal;
+
+BEGIN
+END LongFloatBoot.
+

--- a/m3-libs/m3core/src/float/IEEE/RealFloatBoot.m3
+++ b/m3-libs/m3core/src/float/IEEE/RealFloatBoot.m3
@@ -1,0 +1,233 @@
+(* Slower form of RealFloat for endian neutral bootstrap. *)
+
+UNSAFE MODULE RealFloatBoot EXPORTS RealFloat;
+
+(* This module implements the operations on IEEE single precision reals
+   that do not depend on the operating system. *)
+
+IMPORT IEEE;
+IMPORT DragonT, FPU, Word, Ctypes, Convert, Grisu, Cstdlib;
+
+TYPE Float32 = IEEE.Float32;
+CONST Pack = IEEE.Pack32;
+CONST Unpack = IEEE.Unpack32;
+
+PROCEDURE Scalb (x: T; n: INTEGER): T =
+  BEGIN
+    RETURN FLOAT (FPU.scalb (FLOAT (x, LONGREAL), n), T);
+  END Scalb;
+
+VAR Log_of_zero := Pack (Float32 {sign := 1, exponent := 16_ff, significand := 0});
+
+PROCEDURE Logb (x: T): T =
+  VAR xx := Unpack (x);
+  BEGIN
+    CASE Class (x) OF
+    | IEEEClass.SignalingNaN,
+      IEEEClass.QuietNaN =>
+        RETURN x;
+    | IEEEClass.Infinity =>
+        RETURN ABS (x);
+    | IEEEClass.Zero =>
+        RETURN Log_of_zero;
+    | IEEEClass.Normal =>
+        xx.exponent := xx.exponent - 127;
+        RETURN Pack (xx);
+    | IEEEClass.Denormal =>
+        RETURN -126.0; END;
+  END Logb;
+
+PROCEDURE ILogb (x: T): INTEGER =
+  VAR xx := Unpack (x);  v, w: Word.T;  n: INTEGER;
+  BEGIN
+    CASE Class (x) OF
+    | IEEEClass.SignalingNaN,
+      IEEEClass.QuietNaN =>
+        (* RETURN 0; *)
+        <* ASSERT FALSE*>
+    | IEEEClass.Infinity =>
+        RETURN (LAST (INTEGER));
+    | IEEEClass.Zero =>
+        RETURN (FIRST (INTEGER));
+    | IEEEClass.Normal =>
+        RETURN xx.exponent - 127;
+    | IEEEClass.Denormal =>
+        v := 16_400000;  n := - 127;  w := xx.significand;
+        WHILE Word.And (v, w) = 0 DO
+          v := Word.RightShift (v, 1);
+          DEC (n);
+        END;
+        RETURN n;
+    END; (*CASE*)
+  END ILogb;
+
+PROCEDURE NextAfter (x, y: T): T =
+  VAR xx := Unpack (x);
+      yy := Unpack (y);
+      zz := Float32 {};
+  BEGIN
+    IF x = y                       THEN RETURN x; END;
+    IF IsNaN (x) OR NOT Finite (x) THEN RETURN x; END;
+    IF IsNaN (y)                   THEN RETURN y; END;
+
+    IF x = 0.0   THEN
+      zz.sign        := yy.sign;
+      zz.exponent    := 0;
+      zz.significand := 1;
+      RETURN Pack (zz);
+    END;
+
+    IF (x > 0.0 AND x > y) OR (x < 0.0 AND x < y) THEN
+      IF xx.significand = 0 THEN
+        xx.significand := 16_7fffff;
+        DEC (xx.exponent);
+        IF xx.exponent = 0 THEN
+          RETURN (2.0 * x) / 2.0; (* generate underflow *) END;
+      ELSE
+        DEC (xx.significand); END;
+    ELSE
+      IF xx.significand = 16_7FFFFF THEN
+        xx.significand := 0;
+        INC (xx.exponent);
+        IF xx.exponent = 16_FF THEN
+          RETURN (x + x);  (* generate overflow *) END;
+      ELSE
+        INC (xx.significand); END; END;
+
+    RETURN Pack (xx);
+  END NextAfter;
+
+PROCEDURE CopySign (x, y: T): T =
+  VAR res := Unpack (x);
+  BEGIN
+    res.sign := Unpack (y).sign;
+    RETURN Pack (res);
+  END CopySign;
+
+PROCEDURE Finite (x: T): BOOLEAN =
+  VAR xx := Unpack (x);
+  BEGIN
+    RETURN xx.exponent # 16_FF;
+  END Finite;
+
+PROCEDURE IsNaN (x: T): BOOLEAN =
+  VAR xx := Unpack (x);
+  BEGIN
+    RETURN xx.exponent = 16_ff AND xx.significand # 0;
+  END IsNaN;
+
+PROCEDURE Sign (x: T): [0..1] =
+  VAR xx := Unpack (x);
+  BEGIN
+    RETURN xx.sign;
+  END Sign;
+
+PROCEDURE Differs (x, y: T): BOOLEAN =
+  BEGIN
+    RETURN (x < y) OR (y < x);
+  END Differs;
+
+PROCEDURE Unordered (x, y: T): BOOLEAN =
+  BEGIN
+    RETURN NOT (x <= y OR y <= x);
+  END Unordered;
+
+PROCEDURE Sqrt (x: T): T =
+  BEGIN
+    RETURN FLOAT (FPU.sqrt (FLOAT (x, LONGREAL)), T);
+  END Sqrt;
+
+PROCEDURE Class (x: T): IEEEClass =
+  VAR xx := Unpack (x);
+  BEGIN
+    IF xx.exponent = 0 THEN
+      IF xx.significand = 0
+        THEN RETURN IEEEClass.Zero;
+        ELSE RETURN IEEEClass.Denormal;
+      END;
+    ELSIF xx.exponent # 16_FF THEN
+      RETURN IEEEClass.Normal;
+    ELSIF xx.significand = 0 THEN
+      RETURN IEEEClass.Infinity;
+    ELSIF Word.And (16_00400000, xx.significand) # 0 THEN
+      RETURN IEEEClass.QuietNaN;
+    ELSE
+      RETURN IEEEClass.SignalingNaN;
+    END;
+  END Class;
+
+PROCEDURE FromDecimal (sign   : [0..1];
+              READONLY digits : ARRAY OF [0..9];
+                       exp    : INTEGER): T =
+  <*FATAL Convert.Failed*>
+  TYPE CharBuf = UNTRACED REF ARRAY OF Ctypes.char;
+  CONST Sign = ARRAY [0..1] OF Ctypes.char { ORD ('+'), ORD ('-') };
+  VAR
+    ebuf: ARRAY [0..Word.Size] OF CHAR;
+    buf: CharBuf;
+    expLen, len: CARDINAL;
+    res: T;
+  BEGIN
+    (* strategy:  build a C-style null terminated string and
+       call the C runtime library to convert it to binary value. *)
+
+    (* Allocate the buffer to hold the digits, the exponent value, and the
+       four characters: 1) the leading sign, 2) the decimal point, 3) the 'e'
+       character, and 4) the terminating 0 character. *)
+    IF exp # 0 THEN expLen := Convert.FromInt(ebuf, exp) END;
+    buf := NEW(CharBuf, NUMBER(digits) + expLen + 4);
+    buf[0] := Sign [sign];              len := 1;
+    buf[len] := ORD('0') + digits[0];   INC(len);
+    buf[len] := ORD('.');               INC(len);
+    FOR i := FIRST(digits) + 1 TO LAST(digits) DO
+      buf[len] := ORD ('0') + digits [i];  INC (len);
+    END;
+    IF exp # 0 THEN
+      buf[len] := ORD ('e');  INC (len);
+      FOR i := 0 TO expLen - 1 DO
+	buf[len] := ORD (ebuf[i]);  INC (len);
+      END
+    END;
+    buf[len] := 0;
+
+    res := FLOAT (Cstdlib.strtod (ADR(buf[0]), NIL), T);
+    DISPOSE(buf);
+    RETURN res
+  END FromDecimal;
+
+PROCEDURE ToDecimal(x: T): DecimalApprox =
+  VAR xx := Unpack (x);
+    res: DecimalApprox;
+    exp, sig: INTEGER;
+    count: CARDINAL;
+    grisuMode := Grisu.FastDtoaMode.FAST_DTOA_SHORTEST_SINGLE;
+  BEGIN
+    res.class := Class (x);
+    res.sign := Sign (x);
+
+    IF (res.class # IEEEClass.Denormal) AND (res.class # IEEEClass.Normal) THEN
+      RETURN res;
+    END;
+
+    IF NOT Grisu.FastDtoa(FLOAT(ABS(x),LONGREAL), grisuMode, 0, res.digits, count, res.exp) THEN
+      (* fallback on Dragon *)
+
+      sig := xx.significand;
+
+      IF xx.exponent = 0 THEN
+        exp := -125;
+      ELSE
+        exp := xx.exponent - 126;
+        sig := Word.Or (sig, 16_800000); (* add the implied 24th bit *)
+      END;
+
+      DragonT.F (exp, 0, 0, 0, sig, 24, DragonT.CutoffMode.normal, 0,
+                 res.digits, count, res.exp);
+    END;
+    res.len := count;
+    res.errorSign := 0;
+    RETURN res;
+  END ToDecimal;
+
+BEGIN
+END RealFloatBoot.

--- a/m3-libs/m3core/src/float/IEEE/m3makefile
+++ b/m3-libs/m3core/src/float/IEEE/m3makefile
@@ -9,6 +9,16 @@ Interface ("Real")
 Interface ("LongReal")
 Interface ("Extended")
 
+if defined ("M3_BOOTSTRAP") % endian neutrality: avoid bitfields
+
+implementation ("RealFloatBoot")
+implementation ("LongFloatBoot")
+
+else
+
 implementation ("RealFloat")
 implementation ("LongFloat")
+
+end
+
 implementation ("ExtendedFloat")

--- a/m3-libs/m3core/src/float/m3makefile
+++ b/m3-libs/m3core/src/float/m3makefile
@@ -51,9 +51,13 @@ else
         _FloatPieces{TARGET} = ["IEEE-default"]
         _FloatPieces{"IEEE-default"} = 1 % indicator to m3-sys/m3tests
     end
-    _FloatPieces{TARGET} =
+    if defined ("M3_BOOTSTRAP") % endian neutrality: avoid bitfields
+      _FloatPieces{TARGET} = [ _FloatPieces{TARGET}, "IEEE" ]
+    else
+      _FloatPieces{TARGET} =
         { "LITTLE"  : [ _FloatPieces{TARGET}, "IEEE", "IEEE-le" ],
           "BIG"     : [ _FloatPieces{TARGET}, "IEEE", "IEEE-be" ] }{TARGET_ENDIAN}
+   end
 end
 
 if not defined ("M3TESTS")


### PR DESCRIPTION
Introduce new ways to construct/deconstruct REAL / LONGREAL
that produce endian neutral C++, so that C++ bootstraps can be endian neutral.

There are two basic acceptable ideas:
 - traffice in an unpacked record with sign, exponent, significand,
   that will be larger than real/longreal.
 - pass integer/longint around, or loopholed real/longreal and use
   Word/Long.Insert/Extract in place of read/writing loopholed record fields,
   and wrap Word/Long in things like GetExponent(r:REAL):INTEGEr, SetExponent(VAR r:REAL; exp: INTEGER).

The new functionality is adding to the existing IEEE module which was added for Grisu work.
Grisu parts are now sometimes compiled to C++ (the original reason to omit Grisu is likely
obsolete now and will be revisited later).

In some places rather than slow down normal paths, a new Boot implementation is added.

Ultimately the goal is that the existing RealRep / LongRealRep interfaces will remain,
unmodified, in m3core, for almost anyone to use, but they will not be used by cm3.

IEEESpecial is "rewritten" here, for example, leading to Lex/Scan/IO that I figured
I could not omit from cm3 bootstrap.

We should really consider if converting an INTEGER to a LONGINT requires VAL.
The other way around, understood, reluctantly.

We should also consider making INTEGER 64bits on all systems, even if pointers are smaller.
The amount we now do to cater to obsolete 32bits systems is onerous.