### PR TITLE
Endian neutrality: Widen Variable.mem_type and stk_type from 4 to 8 bits.

### DIFF
--- a/m3-sys/m3front/src/values/Variable.m3
+++ b/m3-sys/m3front/src/values/Variable.m3
@@ -50,8 +50,9 @@ REVEAL
         size        : INTEGER   := 0;
         align       : AlignVal  := 0;
         cg_align    : AlignVal  := 0;
-        mem_type    : BITS 4 FOR CG.Type := FIRST (CG.Type);
-        stk_type    : BITS 4 FOR CG.Type := FIRST (CG.Type);
+        (* 4 bits suffices, 8 bits provides endian neutral output of C++ backend *)
+        mem_type    : BITS (*4*)8 FOR CG.Type := FIRST (CG.Type);
+        stk_type    : BITS (*4*)8 FOR CG.Type := FIRST (CG.Type);
         indirect    : M3.Flag   := FALSE;
         open_ok     : M3.Flag   := FALSE;
         need_addr   : M3.Flag   := FALSE;


### PR DESCRIPTION
Likely we could eliminate one of them?