### PR TITLE
Move Swap from libm3 to m3core.

### DIFF
--- a/m3-comm/events/src/EventStubLib.m3
+++ b/m3-comm/events/src/EventStubLib.m3
@@ -979,19 +979,20 @@ PROCEDURE SwapLongReal(i: LONGREAL) : LONGREAL =
 
 PROCEDURE NativeEndian(rep: DataRep) : BOOLEAN =
   BEGIN
-    RETURN (rep.intFmt >= BigEndianFmt) = (Swap.endian = Swap.Endian.Big);
+    RETURN (rep.intFmt >= BigEndianFmt) = (Swap.GetEndian () = Swap.Endian.Big);
   END NativeEndian;
 
 PROCEDURE ChooseIntFmt(): Byte8 =
+  VAR endian := Swap.GetEndian ();
   BEGIN
     IF BYTESIZE(INTEGER) = 8 THEN
-      IF Swap.endian = Swap.Endian.Little THEN
+      IF endian = Swap.Endian.Little THEN
         RETURN IntFmt64Little;
       ELSE
         RETURN IntFmt64Big;
       END;
     ELSE
-      IF Swap.endian = Swap.Endian.Little THEN
+      IF endian = Swap.Endian.Little THEN
         RETURN IntFmt32Little;
       ELSE
         RETURN IntFmt32Big;

--- a/m3-comm/netobj/src/netobjrt/StubLib.m3
+++ b/m3-comm/netobj/src/netobjrt/StubLib.m3
@@ -1324,20 +1324,22 @@ PROCEDURE SwapLongReal(i: LONGREAL) : LONGREAL =
   END SwapLongReal;
 
 PROCEDURE NativeEndian(rep: DataRep) : BOOLEAN =
+  VAR endian := Swap.GetEndian ();
   BEGIN
-    RETURN (rep.intFmt >= BigEndianFmt) = (Swap.endian = Swap.Endian.Big);
+    RETURN (rep.intFmt >= BigEndianFmt) = (endian = Swap.Endian.Big);
   END NativeEndian;
 
 PROCEDURE ChooseIntFmt(): Byte8 =
+  VAR endian := Swap.GetEndian ();
   BEGIN
     IF BYTESIZE(INTEGER) = 8 THEN
-      IF Swap.endian = Swap.Endian.Little THEN
+      IF endian = Swap.Endian.Little THEN
         RETURN IntFmt64Little;
       ELSE
         RETURN IntFmt64Big;
       END;
     ELSE
-      IF Swap.endian = Swap.Endian.Little THEN
+      IF endian = Swap.Endian.Little THEN
         RETURN IntFmt32Little;
       ELSE
         RETURN IntFmt32Big;

--- a/m3-comm/netobj/src/tcpnetobj/HeaderOps.m3
+++ b/m3-comm/netobj/src/tcpnetobj/HeaderOps.m3
@@ -32,6 +32,7 @@ PROCEDURE Send(t: TCP.T; op: Op; hisEP, myEP: TEXT := NIL)
     RAISES {Wr.Failure, Thread.Alerted} =
   VAR hdr: Header;
       length: CARDINAL;
+      endian := Swap.GetEndian ();
   BEGIN
     hdr.fx.version := CurrentVersion;
     hdr.fx.opCode := ORD(op);
@@ -41,7 +42,7 @@ PROCEDURE Send(t: TCP.T; op: Op; hisEP, myEP: TEXT := NIL)
       StuffText(hdr, myEP);
     END;
     length := hdr.fx.length;
-    IF Swap.endian = Swap.Endian.Big THEN
+    IF endian = Swap.Endian.Big THEN
       hdr.fx.length := Swap.Swap2U(length);
     END;
     t.put(SUBARRAY(LOOPHOLE(ADR(hdr), HeaderAlias)^,
@@ -68,9 +69,10 @@ PROCEDURE Receive(
     END RaiseProtocolError;
     VAR hdr: Header;
       x, pos: INTEGER;
+      endian := Swap.GetEndian ();
   BEGIN
     x := t.get(LOOPHOLE(ADR(hdr.fx), FixedAlias)^, timeout);
-    IF Swap.endian = Swap.Endian.Big THEN
+    IF endian = Swap.Endian.Big THEN
       hdr.fx.length := Swap.Swap2U(hdr.fx.length);
     END;
     IF x # BYTESIZE(hdr.fx) OR

--- a/m3-comm/rdwr/src/SimpleMsgRW.m3
+++ b/m3-comm/rdwr/src/SimpleMsgRW.m3
@@ -192,6 +192,7 @@ PROCEDURE RdSeek(rd: RdT; <*UNUSED*> n: CARDINAL;
   RAISES {Rd.Failure, Thread.Alerted} =
   VAR
     nb: CARDINAL;
+    endian := Swap.GetEndian ();
   BEGIN
     IF dontBlock THEN RETURN RdClass.SeekResult.WouldBlock; END;
     REPEAT
@@ -221,7 +222,7 @@ PROCEDURE RdSeek(rd: RdT; <*UNUSED*> n: CARDINAL;
           (* careful, this is endian dependent *)
           rd.hdr :=
             LOOPHOLE(ADR(rd.buff[rd.st]), UNTRACED REF FragmentHeader)^;
-          IF Swap.endian = Swap.Endian.Big THEN
+          IF endian = Swap.Endian.Big THEN
             rd.hdr.nb := Swap.Swap4(rd.hdr.nb);
           END;
           IF rd.hdr.nb < 0 THEN RAISE Rd.Failure(ProtocolErrorNB); END;
@@ -346,10 +347,11 @@ PROCEDURE WrNextMsg(wr: WrT) RAISES {Wr.Failure, Thread.Alerted} =
   
 PROCEDURE PutFrag(wr: WrT; eom: BOOLEAN) RAISES {Wr.Failure, Thread.Alerted} =
   VAR len := wr.cur - wr.lo;
+      endian := Swap.GetEndian ();
   BEGIN
     WITH hdr = LOOPHOLE(ADR(wr.buff[0]), UNTRACED REF FragmentHeader) DO
       hdr^ := FragmentHeader{eom := ORD(eom), nb := len};
-      IF Swap.endian = Swap.Endian.Big THEN
+      IF endian = Swap.Endian.Big THEN
         hdr.nb := Swap.Swap4(hdr.nb);
       END;
     END;

--- a/m3-comm/tcp/src/common/ConnMsgRW.m3
+++ b/m3-comm/tcp/src/common/ConnMsgRW.m3
@@ -152,6 +152,7 @@ PROCEDURE RdSeek(rd: RdT; <*UNUSED*> n: CARDINAL;
   RAISES {Rd.Failure, Thread.Alerted} =
   VAR
     nb: CARDINAL;
+    endian := Swap.GetEndian ();
   BEGIN
     IF dontBlock THEN RETURN RdClass.SeekResult.WouldBlock; END;
     REPEAT
@@ -179,7 +180,7 @@ PROCEDURE RdSeek(rd: RdT; <*UNUSED*> n: CARDINAL;
           (* careful, this is endian dependent *)
           rd.hdr :=
             LOOPHOLE(ADR(rd.buff[rd.st]), UNTRACED REF FragmentHeader)^;
-          IF Swap.endian = Swap.Endian.Big THEN
+          IF endian = Swap.Endian.Big THEN
             rd.hdr.nb := Swap.Swap4(rd.hdr.nb);
           END;
           IF rd.hdr.nb < 0 THEN RAISE Rd.Failure(ProtocolErrorNB); END;
@@ -289,10 +290,11 @@ PROCEDURE WrNextMsg(wr: WrT) RAISES {Wr.Failure, Thread.Alerted} =
   
 PROCEDURE PutFrag(wr: WrT; eom: BOOLEAN) RAISES {Wr.Failure, Thread.Alerted} =
   VAR len := wr.cur - wr.lo;
+      endian := Swap.GetEndian ();
   BEGIN
     WITH hdr = LOOPHOLE(ADR(wr.buff[0]), UNTRACED REF FragmentHeader) DO
       hdr^ := FragmentHeader{eom := ORD(eom), nb := len};
-      IF Swap.endian = Swap.Endian.Big THEN
+      IF endian = Swap.Endian.Big THEN
         hdr.nb := Swap.Swap4(hdr.nb);
       END;
     END;

--- a/m3-libs/binIO/src/FastBinIO.m3
+++ b/m3-libs/binIO/src/FastBinIO.m3
@@ -36,6 +36,7 @@ EXCEPTION Fatal ;
 
 PROCEDURE UInt32ToInt32(i : UInt32) : Int32 =
   VAR
+    native_endian := Swap.GetEndian ();
     j : Int32 := 0 ;
   BEGIN
     IF BYTESIZE(UInt32) = 4 THEN
@@ -55,6 +56,7 @@ PROCEDURE UInt32ToInt32(i : UInt32) : Int32 =
 
 PROCEDURE Int32ToUInt32(i : Int32) : UInt32 =
   VAR
+    native_endian := Swap.GetEndian ();
     j : UInt32 := 0 ;
   BEGIN
     IF BYTESIZE(UInt32) = 4 THEN
@@ -79,10 +81,8 @@ TYPE
   CharInt16 = ARRAY [0..1] OF CHAR ;  (* 16 bits *)
   CharByte  = CHAR ;  (* essentiall ARRAY [0..0] OF CHAR *) (* 8 bits *)
 
-VAR
-  native_endian := Swap.endian ; (* Endianess of this machine *)
-
 PROCEDURE NeedsSwapping(endian: Endian) : BOOLEAN =
+VAR endian := Swap.GetEndian ();
   BEGIN
     IF endian # Endian.Native THEN
       (* If explicit endian value not equal to native value then swap *)

--- a/m3-libs/libm3/src/hash/SHA256.m3
+++ b/m3-libs/libm3/src/hash/SHA256.m3
@@ -3,9 +3,9 @@
 
 UNSAFE MODULE SHA256;
 
-IMPORT Text, Fmt, Rd, Ctypes;
+IMPORT Text, Fmt, Rd, Ctypes, Swap;
 FROM Word IMPORT Plus, And, Or, Xor, Not, LeftShift, RightShift;
-FROM Swap IMPORT Swap8, Int64On32, Endian, endian;
+FROM Swap IMPORT Swap8, Int64On32, Endian;
 
 <*FATAL ANY*>
 
@@ -67,6 +67,7 @@ PROCEDURE LengthBlock(ctrl : RefCtl) : IntArr =
   VAR
     len64 : Int64On32;
     buf : IntArr;
+    endian := Swap.GetEndian ();
   BEGIN
     len64 := LOOPHOLE(VAL(ctrl.bitLen,LONGINT),Int64On32);
     IF endian = Endian.Little THEN

--- a/m3-libs/libm3/src/uid/Common/Capability.m3
+++ b/m3-libs/libm3/src/uid/Common/Capability.m3
@@ -38,9 +38,10 @@ PROCEDURE Equal(READONLY t1, t2: T): BOOLEAN =
 
 PROCEDURE Hash (READONLY t: T): INTEGER =
   VAR i: Swap.Int64On32;
+      endian := Swap.GetEndian ();
   BEGIN
     LOOPHOLE(i, ARRAY [0 .. 7] OF BITS 8 FOR [0 .. 255]) := t.random;
-    IF Swap.endian = Swap.Endian.Little THEN
+    IF endian = Swap.Endian.Little THEN
       RETURN Swap.Swap4(i.a);
     ELSE
       RETURN i.a;

--- a/m3-libs/libm3/src/uid/Common/TimeStamp.m3
+++ b/m3-libs/libm3/src/uid/Common/TimeStamp.m3
@@ -49,6 +49,7 @@ PROCEDURE Init () =
 
 PROCEDURE New (): T =
   VAR
+    endian     := Swap.GetEndian ();
     fineTime   : INTEGER;
     fineCounter: [0 .. 255];
     time       : [0 .. LAST(Swap.Int32)];
@@ -83,7 +84,7 @@ PROCEDURE New (): T =
         END;
       END;
     END;
-    IF Swap.endian = Swap.Endian.Big
+    IF endian = Swap.Endian.Big
       THEN ts.time := time;
       ELSE ts.time := Swap.Swap4(time);
     END;
@@ -126,11 +127,12 @@ PROCEDURE Min(READONLY t1, t2: T): T =
 
 PROCEDURE Hash (READONLY t: T): INTEGER =
   VAR i: INTEGER;
+      endian := Swap.GetEndian ();
   BEGIN
     WITH a = LOOPHOLE(t, ARRAY [0 .. 3] OF Swap.Int32) DO
       i := Word.Xor(Word.Xor(a[0], a[1]), Word.Xor(a[2], a[3]));
     END;
-    IF Swap.endian = Swap.Endian.Big THEN i := Swap.Swap4 (i) END;
+    IF endian = Swap.Endian.Big THEN i := Swap.Swap4 (i) END;
     RETURN i;
   END Hash;
 
@@ -138,9 +140,10 @@ PROCEDURE ToTime (READONLY t: T): Time.T =
   VAR
     frac := FLOAT(LOOPHOLE(t, TimeStampRep.T).fineTime, LONGREAL) / 256.0D0;
     time := LOOPHOLE(t, TimeStampRep.T).time;
+    endian := Swap.GetEndian ();
   BEGIN
     IF NOT init_done THEN Init () END;
-    IF Swap.endian = Swap.Endian.Little THEN time := Swap.Swap4 (time); END;
+    IF endian = Swap.Endian.Little THEN time := Swap.Swap4 (time); END;
     RETURN FLOAT(time, LONGREAL) + epoch + frac;
   END ToTime;
 

--- a/m3-libs/libm3/src/uid/Common/m3makefile
+++ b/m3-libs/libm3/src/uid/Common/m3makefile
@@ -9,7 +9,6 @@
 
 Module    ("TimeStamp")
 Module    ("Capability")
-Module    ("Swap")
 Module    ("MachineID")
 interface ("MachineIDC")
 interface ("TimeStampRep")

--- a/m3-libs/m3core/src/m3makefile
+++ b/m3-libs/m3core/src/m3makefile
@@ -50,6 +50,7 @@ include_dir ("main")
 include_dir ("weakref")
 include_dir ("word")
 include_dir ("types")
+include_dir ("swap")
 % include_dir ("atomic")  DISABLE UNTIL I CHECK IN THE COMPILER FRONT-END FIXES -- Tony
 
 % m3_option ("-times")

--- a/m3-libs/m3core/src/swap/Swap.i3
+++ b/m3-libs/m3core/src/swap/Swap.i3
@@ -11,10 +11,7 @@ INTERFACE Swap;
 
 TYPE Endian = {Big, Little};
 
-VAR endian: Endian;
-  (* This variable is set at initialization.  If the endian is not
-     one of Big or Little, initialization will generate a checked runtime
-     error. *)
+PROCEDURE GetEndian(): Endian;
 
 CONST
   FirstInt32 = -1 - 16_7FFFFFFF;

--- a/m3-libs/m3core/src/swap/Swap.m3
+++ b/m3-libs/m3core/src/swap/Swap.m3
@@ -29,6 +29,16 @@ CONST
 
 CONST SignExt32 = ARRAY [0..1] OF Word.T {0, Not(16_FFFFFFFF)};
 
+VAR endian: Endian;
+  (* This variable is set at initialization.  If the endian is not
+     one of Big or Little, initialization will generate a checked runtime
+     error. *)
+
+PROCEDURE GetEndian(): Endian =
+BEGIN
+ RETURN endian;
+END GetEndian;
+
 (* Swaps the lower 4 bytes of i *)
 PROCEDURE Swap4 (i: Int32): Int32 =
   BEGIN


### PR DESCRIPTION
So it might be used in float pack/unpack.
Change to function based interface instead of exposing global variable, which is challenging to dynamically link on Windows.