### PR TITLE
Fix runtime error inside m3quake QScanner

### DIFF
--- a/m3-sys/m3quake/src/QScanner.m3
+++ b/m3-sys/m3quake/src/QScanner.m3
@@ -46,7 +46,7 @@ PROCEDURE Init (t: T;  f: File.T;  map: Quake.IDMap): T =
      DO 
       size := VAL(stat.size, INTEGER);
       t.buffer := NEW (REF ARRAY OF CHAR, MAX (0, size) + 1);
-      t.buflen := M3File.Read (f, t.buffer^, size);
+      t.buflen := M3File.Read (f, t.buffer^, MAX (0, size));
       IF (t.buflen # size) THEN RETURN NIL; END;
       t.buffer [t.buflen] := EOFChar;
      END;


### PR DESCRIPTION

Fix runtime error inside m3quake QScanner

...
***
*** runtime error:
***    An enumeration or subrange value was out of range.
***    file "../src/QScanner.m3", line 49
***
 
 *** execution of [<function _BuildGlobalFunction at 0x0000000002F2DD68>, <function _ShipFunction at 0x0000000002F2DDD8>] failed ***
...
 
...
      t.buflen := M3File.Read (f, t.buffer^, size);    (* VVM: it is line 49  *)
...
