### PR TITLE
Config: DJGPP convert backward slashes to forward.

### DIFF
--- a/m3-sys/cminstall/src/config/I386_DJGPP
+++ b/m3-sys/cminstall/src/config/I386_DJGPP
@@ -83,6 +83,9 @@ proc compile_c(source, object, options, optimize, debug) is
 end
 
 proc m3_link(prog, options, objects, imported_libs, shared) is
+  % Something elsewhere is forming the paths incorrectly.
+  imported_libs = subst_chars(imported_libs, "\\", "/")
+  objects       = subst_chars(objects, "\\", "/")
   exec ("gpp", "-v -o", prog, options, arglist("@", [objects, imported_libs]))
   return 0
 end


### PR DESCRIPTION
Config: On DJGPP something is inserting incorrect backward slashes in paths.
Workaround in config by changing them to forward slashes.
This should not be needed really.
Reported and based on proposed fix from Victor.