### PR TITLE
Fix slash style in case building cm3 for I386_DJGPP target

### DIFF
--- a/m3-sys/cminstall/src/config/I386_DJGPP
+++ b/m3-sys/cminstall/src/config/I386_DJGPP
@@ -36,6 +36,8 @@ M3_BACKEND_MODE = "C"
 include ("cm3cfg.common")
 
 proc compile_c(source, object, options, optimize, debug) is
+  % Something elsewhere is forming the paths incorrectly.
+  options       = escape(subst_chars(options, "\\", "/"))
 % driver has problems, skip it
 % i.e. it does not run a specific version, and many fail, or learn more flags to specify version?
 %


### PR DESCRIPTION

```

 Before:
==
...
gcc version 10.2.0 (GCC)
"d:/cm3/bin/config/I386_DJGPP", line 85: quake runtime error: exit 1: gpp -v -o
m3cggen  _m3main.o Main_m.o d:/cm3/pkg\m3middle\I386_DJGPP/libm3middle.a d:/cm3/
pkg\sysutils\I386_DJGPP/libsysutils.a d:/cm3/pkg\libm3\I386_DJGPP/libm3.a d:/cm3
/pkg\m3core\I386_DJGPP/libm3core.a
...
==



 after:
...

 d:/djgpp/bin/ld.exe -o m3cggen d:/djgpp/bin/../lib/gcc/djgpp/10/../../../crt0.o
 -Ld:/djgpp/bin/../lib/gcc/djgpp/10 -Ld:/djgpp/bin/../lib/gcc -Ld:/djgpp/bin/../
lib/gcc/djgpp/10/../../.. -Ld:/djgpp/lib _m3main.o Main_m.o d:/cm3/pkg/m3middle/
I386_DJGPP/libm3middle.a d:/cm3/pkg/sysutils/I386_DJGPP/libsysutils.a d:/cm3/pkg
/libm3/I386_DJGPP/libm3.a d:/cm3/pkg/m3core/I386_DJGPP/libm3core.a -lstdcxx -lm
-lgcc -lc -lgcc

   . . .

COLLECT_GCC_OPTIONS='-v' '-o' 'm3cggen' '-mtune=pentium' '-march=pentium'
 d:/djgpp/bin/stubify.exe -v m3cggen
stubify for djgpp V2.X executables, Copyright (C) 1995-2003 DJ Delorie
stubify: m3cggen -> m3cggen.exe
...




{{{
gcc version 10.2.0 (GCC)
"d:/cm3/bin/config/I386_DJGPP", line 85: quake runtime error: exit 1: gpp -v -o m3cggen  _m3main.o Main_m.o
 d:/cm3/pkg\m3middle\I386_DJGPP/libm3middle.a
 d:/cm3/pkg\sysutils\I386_DJGPP/libsysutils.a d:/cm3/pkg\libm3\I386_DJGPP/libm3.a
 d:/cm3/pkg\m3core\I386_DJGPP/libm3core.a

--procedure--  -line-  -file---
exec               --  <builtin>
m3_link            85  d:/cm3/bin/config/I386_DJGPP
Program            --  <builtin>
include_dir         7  d:/cm3/src/m3-sys/m3cggen\src\m3makefile
                    8  d:/cm3/src/m3-sys/m3cggen\I386_DJGPP\m3make.args


Fatal Error: procedure "m3_link" defined in "d:/cm3/bin\cm3.cfg" failed.


 *** execution of [<function _BuildGlobalFunction at 0x546a3c>, <function _ShipFunction at 0x546a74>] failed ***

ERROR: ./upgrade.py skipgcc c  c I386_DJGPP

D:\CM3\SRC\SCRIPTS\PYTHON>
}}}




==
.a d:/cm3/pkg/sysutils/I386_DJGPP/libsysutils.a d:/cm3/pkg/libm3/I386_DJGPP/libm
3.a d:/cm3/pkg/m3core/I386_DJGPP/libm3core.a
Using built-in specs.
COLLECT_GCC=d:/djgpp/bin/gpp.exe
Target: djgpp
Configured with: /gcc-10.20/configure djgpp --prefix=/dev/env/DJDIR --disable-we
rror --enable-languages=c,c++,objc,obj-c++,fortran,ada --with-gcc-major-version-
only --enable-libquadmath-support --enable-lto --disable-libstdcxx-pch --enable-
libstdcxx-filesystem-ts
Thread model: single
Supported LTO compression algorithms: zlib
gcc version 10.2.0 (GCC)
COMPILER_PATH=d:/djgpp/bin/
LIBRARY_PATH=d:/djgpp/bin/../lib/gcc/djgpp/10/;d:/djgpp/bin/../lib/gcc/;d:/djgpp
/bin/../lib/gcc/djgpp/10/../../../;d:/djgpp/lib/
COLLECT_GCC_OPTIONS='-v' '-o' 'm3cggen' '-mtune=pentium' '-march=pentium'
 d:/djgpp/bin/ld.exe -o m3cggen d:/djgpp/bin/../lib/gcc/djgpp/10/../../../crt0.o
 -Ld:/djgpp/bin/../lib/gcc/djgpp/10 -Ld:/djgpp/bin/../lib/gcc -Ld:/djgpp/bin/../
lib/gcc/djgpp/10/../../.. -Ld:/djgpp/lib _m3main.o Main_m.o d:/cm3/pkg/m3middle/
I386_DJGPP/libm3middle.a d:/cm3/pkg/sysutils/I386_DJGPP/libsysutils.a d:/cm3/pkg
/libm3/I386_DJGPP/libm3.a d:/cm3/pkg/m3core/I386_DJGPP/libm3core.a -lstdcxx -lm
-lgcc -lc -lgcc
COLLECT_GCC_OPTIONS='-v' '-o' 'm3cggen' '-mtune=pentium' '-march=pentium'
 d:/djgpp/bin/stubify.exe -v m3cggen
stubify for djgpp V2.X executables, Copyright (C) 1995-2003 DJ Delorie
stubify: m3cggen -> m3cggen.exe

D:\CM3\SRC\M3-SYS\M3CGGEN>
==
```