### PR TITLE
Fix linking of llvm13

### DIFF
--- a/m3-sys/llvm/llvm13/src/m3makefile
+++ b/m3-sys/llvm/llvm13/src/m3makefile
@@ -1,6 +1,10 @@
 import("libm3")
 import("m3middle")
 import("m3quake")
+if equal (OS_TYPE, "POSIX")
+  LIB_DIR = ""
+  import_lib("LLVM-13",LIB_DIR) 
+end
 import("llvm13bindings")
 
 include("version.quake")

--- a/m3-sys/llvm/llvm13bindings/src/m3makefile
+++ b/m3-sys/llvm/llvm13bindings/src/m3makefile
@@ -19,7 +19,7 @@ Module    ("M3DebugInfo")
 
 if equal (OS_TYPE, "POSIX")
 % set the location of posix libraries llvm depends on
-  LIB_DIR = "/usr/local/lib"
+  LIB_DIR = ""
 % set the location of the llvm libraries
   LLVM_LIB_DIR = LIB_DIR
 
@@ -77,6 +77,7 @@ proc llvmlibs() is
         lib = lib_tab{key}
         if equal (OS_TYPE, "POSIX")
           lib = sub(lib,3,len(lib)) %remove lib prefix
+          lib = subst(lib,".so","",1) %remove lib suffix
 	end
         if equal(OS, "Windows_NT")	
           lib = subst(lib,".lib","",1) %remove suffix


### PR DESCRIPTION
Fix linking of llvm13

Fix errors of linking like this:
= =
 -> archiving libllvm13bindings.a
/usr/bin/ld.gold: error: cannot find -lLLVM-13.so
collect2: error: ld returned 1 exit status
  make_lib => 256
= =
