### PR TITLE
Cygwin: Skip git info in version.quake.

### DIFF
--- a/m3-sys/cm3/src/version.quake
+++ b/m3-sys/cm3/src/version.quake
@@ -77,7 +77,15 @@ proc version_impl(name) is
 
         % TODO: Out of tree builds.
 
-        if (equal(0, try_exec("@git rev-parse --verify HEAD >", nul))) % or git rev-list -n 1 HEAD
+        % TODO: try_exec uses system and q_exec does not.
+        % On Cygwin we see a significant divergence
+        % and builds fail, because try_exec succeeds and q_exec does not.
+        % The right fix is to either better unify them in quake,
+        % or in sysutils (System.RdExecute) / libm3 (Process.Create),
+        % or at least here in version.quake use a probe that matches the execution.
+
+        if  not equal (TARGET_OS, "CYGWIN") and
+            equal (0, try_exec("@git rev-parse --verify HEAD >", nul)) % or git rev-list -n 1 HEAD
           local revision = compress(q_exec_get("git rev-parse --verify HEAD")[1])
           local branch = compress(q_exec_get("git symbolic-ref -q --short HEAD")[1])
           local remote_name = compress(q_exec_get("git config branch." & branch & ".remote")[1])


### PR DESCRIPTION
There is a perhaps corner case where
exec/try_exec use system
and q_exe uses Process.Create

system probably always uses sh
Process.Create uses sh in a fallback, depending on error.

Cygwin system is finding git
Cygwin Process.Create is not finding git

I am guessing there is rarely a difference?? But I don't know.
In my case, git.exe is the Windows git and I have no Cygwin git.
Installing Cygwin git could help.

The rest of the build create a lot of processes and works.

"For now", maybe forever, in version.quake, skip running git on Cygwin.
Probably nobody will notice.

I looked into changing Process.Create to fallback for another error (NOENT)
to /bin/sh. That should "fix" it. But not clear we should make that change there.
There is Cygwin-specific Process.Create (could be at runtime anyway).

Maybe at the Quake layer we should do something, or in sysutils.

But anyway "for now" this isn't terrible. No other system has needed
a change here in a very long time. Cygwin-specific work isn't very valuable
esp. for this one? thing.