### PR TITLE
y.tab.c - Use strchr() because index() is a deprecated POSIX function

### DIFF
--- a/m3-tools/pp/src/flex-bison/y.tab.c
+++ b/m3-tools/pp/src/flex-bison/y.tab.c
@@ -5946,7 +5946,7 @@ HandleComments(firstTime, initNPS, doBreak)
 		    /* Emit the word. */
 		    while (!IsWhite(*s) && *s != 0)
 			P(*s++);
-		    sentenceBreak = index(".!?", s[-1]) != 0;
+		    sentenceBreak = strchr(".!?", s[-1]) != 0;
 		}
 	    }
 	    Formatter__SetFont(formatter, fonts->body);


### PR DESCRIPTION

Since index() is deprecated in POSIX and not part of the C standard library, we should use strchr()

...
strchr() is part of the C standard library. index() is a now deprecated POSIX function. The POSIX specification recommends implementing index() as a macro that expands to a call to strchr().

Since index() is deprecated in POSIX and not part of the C standard library, you should use strchr().
...



...
char  *index(const char *, int); /* LEGACY, see strchr */
...




https://stackoverflow.com/questions/4291149/difference-between-string-h-and-strings-h
= = =
 . . .

strings.h comes from the BSD branch in the unix evolution. Its content has been standardized by POSIX, but most of it is marked as legacy and can be easily replaced with other functions:

   . . .

char  *index(const char *, int); /* LEGACY, see strchr */

 . . .
= = =





https://stackoverflow.com/questions/4091864/c-differences-between-strchr-and-index
= = =
 . . . 

strchr() is part of the C standard library. index() is a now deprecated POSIX function. The POSIX specification recommends implementing index() as a macro that expands to a call to strchr().

Since index() is deprecated in POSIX and not part of the C standard library, you should use strchr().

 . . .
= = =
