### PR TITLE
FIX 2 errors on PPC_DARWIN

### DIFF
--- a/m3-libs/m3core/src/m3core.h
+++ b/m3-libs/m3core/src/m3core.h
@@ -43,9 +43,12 @@
 #include "winsock2.h"
 #include "ws2tcpip.h"
 #endif
+#ifndef M3_BOOL_H_INCLUDED
+#define M3_BOOL_H_INCLUDED
 typedef int BOOL;
 #define TRUE 1
 #define FALSE 0
+#endif
 
 /* __DARWIN_UNIX03 defaults to 1 on older and newer headers,
  * but older headers still have context "ss" instead of "__ss"
@@ -695,7 +698,10 @@ typedef int/*not socklen_t*/ m3c_socklen_t;
 #endif
 
 #define Usocket__socklen_t Usocket__socklen_t /* inhibit m3c type */
+#ifndef M3_USOCKET__SOCKLEN_T_H_INCLUDED
+#define M3_USOCKET__SOCKLEN_T_H_INCLUDED
 typedef m3_socklen_t Usocket__socklen_t;
+#endif
 
 typedef struct {
 /* verified to exactly match struct linger in UnixC.c, except for Cygwin */
@@ -718,7 +724,10 @@ typedef struct {
 #define Usocket__socklen_t                     Usocket__socklen_t                     /* inhibit m3c type */
 typedef       M3SockAddrUnionAll*              Usocket__struct_sockaddr_in_star;
 typedef const M3SockAddrUnionAll*              Usocket__const_struct_sockaddr_in_star;
+#ifndef M3_USOCKET__SOCKLEN_T_H_INCLUDED
+#define M3_USOCKET__SOCKLEN_T_H_INCLUDED
 typedef m3_socklen_t                           Usocket__socklen_t;
+#endif
 typedef m3_socklen_t*                          Usocket__socklen_t_star;
 
 int __cdecl Usocket__listen(int s, int backlog);

--- a/m3-sys/m3back/src/M3CC.c
+++ b/m3-sys/m3back/src/M3CC.c
@@ -6,9 +6,12 @@
 extern "C" {
 #endif
 
+#ifndef M3_BOOL_H_INCLUDED
+#define M3_BOOL_H_INCLUDED
 typedef int BOOL;
 #define FALSE 0
 #define TRUE 1
+#endif
 
 TEXT
 __cdecl


### PR DESCRIPTION
FIX 2 errors on PPC_DARWIN

 `1)`
FIX error on PPC_DARWIN by adding M3_BOOL_H_INCLUDED
modula3#995 (comment)
= =
M3CC.c:9: error: redefinition of typedef ‘BOOL’
m3core.h:46: error: previous declaration of ‘BOOL’ was here
make: *** [M3CC.o] Error 1
= =

 a-la
m3-sys\m3gdb\gdb\gdb\m3-bool.h
= =

#ifndef M3_BOOL_H_INCLUDED
#define M3_BOOL_H_INCLUDED
typedef int BOOL;
#define TRUE 1
#define FALSE 0
#endif

= =

 `2)`

FIX error on PPC_DARWIN by adding M3_USOCKET__SOCKLEN_T_H_INCLUDED

modula3#995 (comment)
= =
In file included from CerrnoC.c:6:
m3core.h:721: error: redefinition of typedef ‘Usocket__socklen_t’
m3core.h:698: error: previous declaration of ‘Usocket__socklen_t’ was here
make: *** [CerrnoC.o] Error 1
= =

 by preprocessor var M3_USOCKET__SOCKLEN_T_H_INCLUDED :

#ifndef M3_USOCKET__SOCKLEN_T_H_INCLUDED
#define M3_USOCKET__SOCKLEN_T_H_INCLUDED

typedef m3_socklen_t Usocket__socklen_t;

#endif
