### PR TITLE
Add glue code to fix missing Modula-3 implementations of cabs, frexp,

### DIFF
--- a/m3-libs/libm3/src/arith/POSIX/COPYRIGHT-INTEL
+++ b/m3-libs/libm3/src/arith/POSIX/COPYRIGHT-INTEL
@@ -1,0 +1,28 @@
+Copyright (C) 2024 Intel Corporation
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ 
+SPDX-License-Identifier: BSD-3-Clause

--- a/m3-libs/libm3/src/arith/POSIX/Math.i3
+++ b/m3-libs/libm3/src/arith/POSIX/Math.i3
@@ -130,21 +130,21 @@ CONST
 <*EXTERNAL*> PROCEDURE hypot (x, y: LONGREAL): LONGREAL;
 (* returns sqrt (x*x + y*y). *)
 
-<*EXTERNAL*> PROCEDURE cabs (z: Complex): LONGREAL;
+PROCEDURE cabs (z: Complex): LONGREAL;
 TYPE Complex = RECORD x, y: LONGREAL END;
 (* returns sqrt (z.x*z.x + z.y*z.y) *)
 
 
 (*---- Floating point representations ----*)
 
-<*EXTERNAL*> PROCEDURE frexp (x: LONGREAL;  VAR exp: int): LONGREAL;
+PROCEDURE frexp (x: LONGREAL;  VAR exp: int): LONGREAL;
 (* returns a value y and sets exp such that x = y * 2^exp,
     where ABS(y) is in the interval [0.5, 1). *)
 
 <*EXTERNAL*> PROCEDURE ldexp (x: LONGREAL; exp: int): LONGREAL;
 (* returns x * 2^exp. *)
 
-<*EXTERNAL*> PROCEDURE modf (x: LONGREAL; VAR(*OUT*) i: LONGREAL): LONGREAL;
+PROCEDURE modf (x: LONGREAL; VAR(*OUT*) i: LONGREAL): LONGREAL;
 (* splits the argument "x" into an integer part "i" and a fractional part "f"
    such that "f + i = x" and such that "f" and "i" both have the same sign as
    "x", and returns "f". Although "i" is a LONGREAL, it is set to an integral

--- a/m3-libs/libm3/src/arith/POSIX/MathPosix.m3
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosix.m3
@@ -31,7 +31,7 @@ PROCEDURE modf (x: LONGREAL; VAR i: LONGREAL): LONGREAL =
 
 PROCEDURE cabs (z: Complex): LONGREAL =
   BEGIN
-    RETURN MathPosixC.cabs_glue(z.x, z.y)
+    RETURN hypot(z.x, z.y)
   END cabs;
 
 BEGIN END MathPosix.

--- a/m3-libs/libm3/src/arith/POSIX/MathPosix.m3
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosix.m3
@@ -1,0 +1,37 @@
+MODULE MathPosix EXPORTS Math;
+
+(*
+  Glue to fix broken prototypes in CM3-d5.11.9
+
+  Author : Mika Nystrom <mika.nystroem@intel.com>
+  June, 2024
+
+  Copyright (c) Intel Corporation, 2024.  All rights reserved.
+
+  See COPYRIGHT-INTEL for terms.  
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+ *)
+
+IMPORT MathPosixC;
+FROM Ctypes IMPORT int;
+
+PROCEDURE frexp (x: LONGREAL;  VAR exp: int): LONGREAL =
+  BEGIN
+    exp := MathPosixC.frexp_exp_glue(x);
+    RETURN MathPosixC.frexp_result_glue(x)
+  END frexp;
+
+PROCEDURE modf (x: LONGREAL; VAR i: LONGREAL): LONGREAL =
+  BEGIN
+    i := MathPosixC.modf_intpart_glue(x);
+    RETURN MathPosixC.modf_result_glue(x);
+  END modf;
+
+PROCEDURE cabs (z: Complex): LONGREAL =
+  BEGIN
+    RETURN MathPosixC.cabs_glue(z.x, z.y)
+  END cabs;
+
+BEGIN END MathPosix.

--- a/m3-libs/libm3/src/arith/POSIX/MathPosixC.c
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosixC.c
@@ -1,0 +1,63 @@
+/*
+  Glue to fix broken prototypes in CM3-d5.11.9
+
+  Author : Mika Nystrom <mika.nystroem@intel.com>
+  June, 2024
+
+  Copyright (c) Intel Corporation, 2024.  All rights reserved.
+
+  See COPYRIGHT-INTEL for terms.  
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+ */
+
+#include <math.h>
+#include <complex.h>
+
+double
+MathPosixC__frexp_result_glue(double x)
+{
+  int dummy;
+  
+  return frexp(x, &dummy);
+}
+
+int
+MathPosixC__frexp_exp_glue(double x)
+{
+  int exp;
+
+  (void)frexp(x, &exp);
+
+  return exp;
+}
+
+double
+MathPosixC__cabs_glue(double x, double y)
+{
+  double complex z = x + I * y;
+
+  return cabs(z);
+}
+
+double
+MathPosixC__modf_result_glue(double x)
+{
+  double dummy;
+  
+  return modf(x, &dummy);
+}
+
+double
+MathPosixC__modf_intpart_glue(double x)
+{
+  double intpart;
+
+  (void)modf(x, &intpart);
+
+  return intpart;
+}
+
+
+

--- a/m3-libs/libm3/src/arith/POSIX/MathPosixC.c
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosixC.c
@@ -13,7 +13,6 @@
  */
 
 #include <math.h>
-#include <complex.h>
 
 double
 MathPosixC__frexp_result_glue(double x)
@@ -31,14 +30,6 @@ MathPosixC__frexp_exp_glue(double x)
   (void)frexp(x, &exp);
 
   return exp;
-}
-
-double
-MathPosixC__cabs_glue(double x, double y)
-{
-  double complex z = x + I * y;
-
-  return cabs(z);
 }
 
 double

--- a/m3-libs/libm3/src/arith/POSIX/MathPosixC.i3
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosixC.i3
@@ -1,0 +1,20 @@
+INTERFACE MathPosixC;
+FROM Ctypes IMPORT int;
+
+<*EXTERNAL "MathPosixC__frexp_result_glue"*>
+PROCEDURE frexp_result_glue(x : LONGREAL) : LONGREAL;
+
+<*EXTERNAL "MathPosixC__frexp_exp_glue"*>
+PROCEDURE frexp_exp_glue(x : LONGREAL) : int;
+
+<*EXTERNAL "MathPosixC__cabs_glue"*>
+PROCEDURE cabs_glue(x, y : LONGREAL) : LONGREAL;  
+
+<*EXTERNAL "MathPosixC__modf_result_glue"*>
+PROCEDURE modf_result_glue(x : LONGREAL) : LONGREAL;
+
+<*EXTERNAL "MathPosixC__modf_intpart_glue"*>
+PROCEDURE modf_intpart_glue(x : LONGREAL) : LONGREAL;
+
+END MathPosixC.
+

--- a/m3-libs/libm3/src/arith/POSIX/m3makefile
+++ b/m3-libs/libm3/src/arith/POSIX/m3makefile
@@ -7,3 +7,6 @@
 %      modified on Tue Feb 11 16:29:34 PST 1992 by muller
 
 Interface ("Math")
+implementation ("MathPosix")
+c_source ("MathPosixC")
+interface ("MathPosixC")


### PR DESCRIPTION
See cm3 issue 1178.

This PR creates glue procedures for the Math routines cabs, frexp, and modf.  

signgam is left alone---I am not sure it needs any work.

What we do here is use standard call-by-value and standard C types to communicate in the simplest way into a new glue C module, with its own EXTERNAL symbols.

The suspect procedures are unmarked as EXTERNAL in Math.i3 and instead implemented in MathPosix.m3, which calls the new C code with appropriate arguments.

The code has been tested to link with all symbols, but not for functionality.  (Prior work does not link, at least not with the C backend.)