### PR TITLE
Revert endian

### DIFF
--- a/m3-libs/libm3/src/arith/POSIX/COPYRIGHT-INTEL
+++ b/m3-libs/libm3/src/arith/POSIX/COPYRIGHT-INTEL
@@ -1,0 +1,28 @@
+Copyright (C) 2024 Intel Corporation
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ 
+SPDX-License-Identifier: BSD-3-Clause

--- a/m3-libs/libm3/src/arith/POSIX/Math.i3
+++ b/m3-libs/libm3/src/arith/POSIX/Math.i3
@@ -130,21 +130,21 @@ CONST
 <*EXTERNAL*> PROCEDURE hypot (x, y: LONGREAL): LONGREAL;
 (* returns sqrt (x*x + y*y). *)
 
-<*EXTERNAL*> PROCEDURE cabs (z: Complex): LONGREAL;
+PROCEDURE cabs (z: Complex): LONGREAL;
 TYPE Complex = RECORD x, y: LONGREAL END;
 (* returns sqrt (z.x*z.x + z.y*z.y) *)
 
 
 (*---- Floating point representations ----*)
 
-<*EXTERNAL*> PROCEDURE frexp (x: LONGREAL;  VAR exp: int): LONGREAL;
+PROCEDURE frexp (x: LONGREAL;  VAR exp: int): LONGREAL;
 (* returns a value y and sets exp such that x = y * 2^exp,
     where ABS(y) is in the interval [0.5, 1). *)
 
 <*EXTERNAL*> PROCEDURE ldexp (x: LONGREAL; exp: int): LONGREAL;
 (* returns x * 2^exp. *)
 
-<*EXTERNAL*> PROCEDURE modf (x: LONGREAL; VAR(*OUT*) i: LONGREAL): LONGREAL;
+PROCEDURE modf (x: LONGREAL; VAR(*OUT*) i: LONGREAL): LONGREAL;
 (* splits the argument "x" into an integer part "i" and a fractional part "f"
    such that "f + i = x" and such that "f" and "i" both have the same sign as
    "x", and returns "f". Although "i" is a LONGREAL, it is set to an integral

--- a/m3-libs/libm3/src/arith/POSIX/MathPosix.m3
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosix.m3
@@ -1,0 +1,37 @@
+MODULE MathPosix EXPORTS Math;
+
+(*
+  Glue to fix broken prototypes in CM3-d5.11.9
+
+  Author : Mika Nystrom <mika.nystroem@intel.com>
+  June, 2024
+
+  Copyright (c) Intel Corporation, 2024.  All rights reserved.
+
+  See COPYRIGHT-INTEL for terms.  
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+ *)
+
+IMPORT MathPosixC;
+FROM Ctypes IMPORT int;
+
+PROCEDURE frexp (x: LONGREAL;  VAR exp: int): LONGREAL =
+  BEGIN
+    exp := MathPosixC.frexp_exp_glue(x);
+    RETURN MathPosixC.frexp_result_glue(x)
+  END frexp;
+
+PROCEDURE modf (x: LONGREAL; VAR i: LONGREAL): LONGREAL =
+  BEGIN
+    i := MathPosixC.modf_intpart_glue(x);
+    RETURN MathPosixC.modf_result_glue(x);
+  END modf;
+
+PROCEDURE cabs (z: Complex): LONGREAL =
+  BEGIN
+    RETURN MathPosixC.cabs_glue(z.x, z.y)
+  END cabs;
+
+BEGIN END MathPosix.

--- a/m3-libs/libm3/src/arith/POSIX/MathPosixC.c
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosixC.c
@@ -1,0 +1,63 @@
+/*
+  Glue to fix broken prototypes in CM3-d5.11.9
+
+  Author : Mika Nystrom <mika.nystroem@intel.com>
+  June, 2024
+
+  Copyright (c) Intel Corporation, 2024.  All rights reserved.
+
+  See COPYRIGHT-INTEL for terms.  
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+ */
+
+#include <math.h>
+#include <complex.h>
+
+double
+MathPosixC__frexp_result_glue(double x)
+{
+  int dummy;
+  
+  return frexp(x, &dummy);
+}
+
+int
+MathPosixC__frexp_exp_glue(double x)
+{
+  int exp;
+
+  (void)frexp(x, &exp);
+
+  return exp;
+}
+
+double
+MathPosixC__cabs_glue(double x, double y)
+{
+  double complex z = x + I * y;
+
+  return cabs(z);
+}
+
+double
+MathPosixC__modf_result_glue(double x)
+{
+  double dummy;
+  
+  return modf(x, &dummy);
+}
+
+double
+MathPosixC__modf_intpart_glue(double x)
+{
+  double intpart;
+
+  (void)modf(x, &intpart);
+
+  return intpart;
+}
+
+
+

--- a/m3-libs/libm3/src/arith/POSIX/MathPosixC.i3
+++ b/m3-libs/libm3/src/arith/POSIX/MathPosixC.i3
@@ -1,0 +1,20 @@
+INTERFACE MathPosixC;
+FROM Ctypes IMPORT int;
+
+<*EXTERNAL "MathPosixC__frexp_result_glue"*>
+PROCEDURE frexp_result_glue(x : LONGREAL) : LONGREAL;
+
+<*EXTERNAL "MathPosixC__frexp_exp_glue"*>
+PROCEDURE frexp_exp_glue(x : LONGREAL) : int;
+
+<*EXTERNAL "MathPosixC__cabs_glue"*>
+PROCEDURE cabs_glue(x, y : LONGREAL) : LONGREAL;  
+
+<*EXTERNAL "MathPosixC__modf_result_glue"*>
+PROCEDURE modf_result_glue(x : LONGREAL) : LONGREAL;
+
+<*EXTERNAL "MathPosixC__modf_intpart_glue"*>
+PROCEDURE modf_intpart_glue(x : LONGREAL) : LONGREAL;
+
+END MathPosixC.
+

--- a/m3-libs/libm3/src/arith/POSIX/m3makefile
+++ b/m3-libs/libm3/src/arith/POSIX/m3makefile
@@ -7,3 +7,6 @@
 %      modified on Tue Feb 11 16:29:34 PST 1992 by muller
 
 Interface ("Math")
+implementation ("MathPosix")
+c_source ("MathPosixC")
+interface ("MathPosixC")

--- a/m3-libs/m3core/src/swap/Swap.i3
+++ b/m3-libs/m3core/src/swap/Swap.i3
@@ -13,6 +13,15 @@ TYPE Endian = {Big, Little};
 
 PROCEDURE GetEndian(): Endian;
 
+<*OBSOLETE*>VAR endian: Endian;
+  (* This variable is set at initialization.  If the endian is not
+     one of Big or Little, initialization will generate a checked runtime
+     error. 
+
+     New code should not use this declaration.  They should use GetEndian() 
+     above instead.
+  *)
+    
 CONST
   FirstInt32 = -1 - 16_7FFFFFFF;
     (* This value is computed in such a way that it will have the same value

--- a/m3-libs/m3core/src/swap/Swap.m3
+++ b/m3-libs/m3core/src/swap/Swap.m3
@@ -29,11 +29,6 @@ CONST
 
 CONST SignExt32 = ARRAY [0..1] OF Word.T {0, Not(16_FFFFFFFF)};
 
-VAR endian: Endian;
-  (* This variable is set at initialization.  If the endian is not
-     one of Big or Little, initialization will generate a checked runtime
-     error. *)
-
 PROCEDURE GetEndian(): Endian =
 BEGIN
  RETURN endian;


### PR DESCRIPTION
Bring back "endian" global into the Swap.i3 interface, so that code can be written that uses Swap across compiler releases.  (Status before this commit is that code has to either use endian or GetEndian() depending on the release, so it cannot be written so it works in both cases.)