### PR TITLE
Python 3 scripts should be run by `python3` executable.

### DIFF
--- a/scripts/python3/boot1.py
+++ b/scripts/python3/boot1.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # usage: ./boot1.py target
 #

--- a/scripts/python3/boot1autotools.py
+++ b/scripts/python3/boot1autotools.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import os.path

--- a/scripts/python3/boot1many.py
+++ b/scripts/python3/boot1many.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import os, sys
 argv = sys.argv

--- a/scripts/python3/boot2.py
+++ b/scripts/python3/boot2.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Roughly:
 #!/bin/sh

--- a/scripts/python3/boot2min.py
+++ b/scripts/python3/boot2min.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Roughly:
 #!/bin/sh

--- a/scripts/python3/capture-boot.py
+++ b/scripts/python3/capture-boot.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys, os.path, os, shutil, pylib, uuid
 from os.path import isfile, isdir

--- a/scripts/python3/chext.py
+++ b/scripts/python3/chext.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import glob
 import os

--- a/scripts/python3/do-cm3-all.py
+++ b/scripts/python3/do-cm3-all.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import os.path

--- a/scripts/python3/do-cm3-min.py
+++ b/scripts/python3/do-cm3-min.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import os.path

--- a/scripts/python3/do-cm3-std.py
+++ b/scripts/python3/do-cm3-std.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import os.path

--- a/scripts/python3/do-pkg.py
+++ b/scripts/python3/do-pkg.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import os.path

--- a/scripts/python3/install-cm3-compiler.py
+++ b/scripts/python3/install-cm3-compiler.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 from pylib import *

--- a/scripts/python3/install-config.py
+++ b/scripts/python3/install-config.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import pylib

--- a/scripts/python3/install-front.py
+++ b/scripts/python3/install-front.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import pylib

--- a/scripts/python3/make-deb.py
+++ b/scripts/python3/make-deb.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 from pylib import *

--- a/scripts/python3/make-dist-cfg.py
+++ b/scripts/python3/make-dist-cfg.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from pylib import *
 

--- a/scripts/python3/make-dist.py
+++ b/scripts/python3/make-dist.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import os.path

--- a/scripts/python3/make-msi.py
+++ b/scripts/python3/make-msi.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 from pylib import *

--- a/scripts/python3/pylib.py
+++ b/scripts/python3/pylib.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import os
 from os import getenv

--- a/scripts/python3/upgrade.py
+++ b/scripts/python3/upgrade.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import pylib


### PR DESCRIPTION
On systems with only Python 3 installed, the executable is named `python3`, not `python`.

This PR closed #1234.